### PR TITLE
Add simulation scaffolding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "simtest0",
+  "version": "1.0.0",
+  "main": "dist/main.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/main.js",
+    "test": "tsc --noEmit"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.11.17",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.0"
+  }
+}

--- a/src/ecs/ECS.ts
+++ b/src/ecs/ECS.ts
@@ -1,0 +1,43 @@
+import { EntityManager } from './entity/EntityManager';
+import { ComponentManager } from './components/ComponentManager';
+
+export interface System {
+  update(delta: number): void;
+}
+
+export class ECS {
+  readonly entities = new EntityManager();
+  readonly components = new ComponentManager();
+  private systems: System[] = [];
+  private running = false;
+
+  addSystem(system: System): void {
+    this.systems.push(system);
+  }
+
+  removeSystem(system: System): void {
+    this.systems = this.systems.filter(s => s !== system);
+  }
+
+  update(delta: number): void {
+    for (const system of this.systems) {
+      system.update(delta);
+    }
+  }
+
+  run(tick = 16): void {
+    this.running = true;
+    const step = () => {
+      if (!this.running) return;
+      this.update(tick);
+      setTimeout(step, tick);
+    };
+    step();
+  }
+
+  stop(): void {
+    this.running = false;
+  }
+}
+
+export default ECS;

--- a/src/ecs/components/ComponentManager.ts
+++ b/src/ecs/components/ComponentManager.ts
@@ -1,0 +1,27 @@
+export class ComponentManager {
+  private components = new Map<number, Map<string, unknown>>();
+
+  addComponent<T>(entity: number, name: string, component: T): void {
+    let entityComponents = this.components.get(entity);
+    if (!entityComponents) {
+      entityComponents = new Map<string, unknown>();
+      this.components.set(entity, entityComponents);
+    }
+    entityComponents.set(name, component);
+  }
+
+  removeComponent(entity: number, name: string): void {
+    const entityComponents = this.components.get(entity);
+    entityComponents?.delete(name);
+  }
+
+  getComponent<T>(entity: number, name: string): T | undefined {
+    return this.components.get(entity)?.get(name) as T | undefined;
+  }
+
+  forEachEntity(callback: (entity: number, components: Map<string, unknown>) => void): void {
+    this.components.forEach((components, entity) => callback(entity, components));
+  }
+}
+
+export default ComponentManager;

--- a/src/ecs/entity/EntityManager.ts
+++ b/src/ecs/entity/EntityManager.ts
@@ -1,0 +1,20 @@
+export class EntityManager {
+  private nextId = 0;
+  private entities = new Set<number>();
+
+  createEntity(): number {
+    const id = this.nextId++;
+    this.entities.add(id);
+    return id;
+  }
+
+  removeEntity(id: number): void {
+    this.entities.delete(id);
+  }
+
+  getAll(): Iterable<number> {
+    return this.entities;
+  }
+}
+
+export default EntityManager;

--- a/src/ecs/systems/ConditionSystem.ts
+++ b/src/ecs/systems/ConditionSystem.ts
@@ -1,0 +1,15 @@
+import { System } from '../ECS';
+
+export type ConditionFn = () => boolean;
+
+export class ConditionSystem implements System {
+  constructor(private condition: ConditionFn) {}
+
+  update(): void {
+    if (this.condition()) {
+      throw new Error('Simulation end condition met');
+    }
+  }
+}
+
+export default ConditionSystem;

--- a/src/ecs/systems/SnapshotSystem.ts
+++ b/src/ecs/systems/SnapshotSystem.ts
@@ -1,0 +1,25 @@
+import { System } from '../ECS';
+import { ComponentManager } from '../components/ComponentManager';
+
+export class SnapshotSystem implements System {
+  private history: Array<Record<number, Record<string, unknown>>> = [];
+
+  constructor(private components: ComponentManager) {}
+
+  update(): void {
+    const snapshot: Record<number, Record<string, unknown>> = {};
+    this.components.forEachEntity((entity, comps) => {
+      snapshot[entity] = {};
+      comps.forEach((value, key) => {
+        snapshot[entity][key] = value;
+      });
+    });
+    this.history.push(snapshot);
+  }
+
+  getSnapshots(): Array<Record<number, Record<string, unknown>>> {
+    return this.history;
+  }
+}
+
+export default SnapshotSystem;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,21 @@
+import createServer from './server';
+import { ECS } from './ecs/ECS';
+import { SnapshotSystem } from './ecs/systems/SnapshotSystem';
+import { ConditionSystem } from './ecs/systems/ConditionSystem';
+import { EventBus } from './messaging/EventBus';
+import { MessageType } from './messaging/MessageTypes';
+
+const bus = new EventBus();
+const ecs = new ECS();
+const snapshotSystem = new SnapshotSystem(ecs.components);
+
+ecs.addSystem(snapshotSystem);
+ecs.addSystem(new ConditionSystem(() => false));
+
+bus.subscribe(MessageType.START, () => ecs.run());
+bus.subscribe(MessageType.PAUSE, () => ecs.stop());
+bus.subscribe(MessageType.STOP, () => ecs.stop());
+
+const app = createServer(bus, snapshotSystem);
+const PORT = process.env.PORT ? Number(process.env.PORT) : 3000;
+app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/src/messaging/EventBus.ts
+++ b/src/messaging/EventBus.ts
@@ -1,0 +1,24 @@
+export type Handler<T> = (payload: T) => void;
+
+export class EventBus {
+  private handlers = new Map<string, Set<Handler<any>>>();
+
+  subscribe<T>(type: string, handler: Handler<T>): void {
+    let set = this.handlers.get(type);
+    if (!set) {
+      set = new Set();
+      this.handlers.set(type, set);
+    }
+    set.add(handler as Handler<any>);
+  }
+
+  unsubscribe<T>(type: string, handler: Handler<T>): void {
+    this.handlers.get(type)?.delete(handler as Handler<any>);
+  }
+
+  publish<T>(type: string, payload: T): void {
+    this.handlers.get(type)?.forEach(h => h(payload));
+  }
+}
+
+export default EventBus;

--- a/src/messaging/MessageTypes.ts
+++ b/src/messaging/MessageTypes.ts
@@ -1,0 +1,6 @@
+export enum MessageType {
+  START = 'START',
+  PAUSE = 'PAUSE',
+  STOP = 'STOP',
+  METRICS = 'METRICS'
+}

--- a/src/routes/apiRoutes.ts
+++ b/src/routes/apiRoutes.ts
@@ -1,0 +1,14 @@
+import { Router } from 'express';
+import { EventBus } from '../messaging/EventBus';
+import { SnapshotSystem } from '../ecs/systems/SnapshotSystem';
+import controls from './controls';
+import metrics from './metrics';
+import pluginRoutes from './plugins';
+
+export default function apiRoutes(bus: EventBus, snapshot: SnapshotSystem): Router {
+  const router = Router();
+  router.use('/controls', controls(bus));
+  router.use('/metrics', metrics(snapshot));
+  router.use('/plugins', pluginRoutes);
+  return router;
+}

--- a/src/routes/controls.ts
+++ b/src/routes/controls.ts
@@ -1,0 +1,24 @@
+import { Router, Request, Response } from 'express';
+import { EventBus } from '../messaging/EventBus';
+import { MessageType } from '../messaging/MessageTypes';
+
+export default function controls(bus: EventBus): Router {
+  const router = Router();
+
+  router.post('/start', (_req: Request, res: Response) => {
+    bus.publish(MessageType.START, undefined);
+    res.sendStatus(200);
+  });
+
+  router.post('/pause', (_req: Request, res: Response) => {
+    bus.publish(MessageType.PAUSE, undefined);
+    res.sendStatus(200);
+  });
+
+  router.post('/stop', (_req: Request, res: Response) => {
+    bus.publish(MessageType.STOP, undefined);
+    res.sendStatus(200);
+  });
+
+  return router;
+}

--- a/src/routes/metrics.ts
+++ b/src/routes/metrics.ts
@@ -1,0 +1,12 @@
+import { Router, Request, Response } from 'express';
+import { SnapshotSystem } from '../ecs/systems/SnapshotSystem';
+
+export default function metrics(snapshot: SnapshotSystem): Router {
+  const router = Router();
+
+  router.get('/snapshots', (_req: Request, res: Response) => {
+    res.json(snapshot.getSnapshots());
+  });
+
+  return router;
+}

--- a/src/routes/plugins/index.ts
+++ b/src/routes/plugins/index.ts
@@ -1,0 +1,7 @@
+import { Router } from 'express';
+
+const router = Router();
+
+// Agent-defined routes can be mounted here.
+
+export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,11 @@
+import express from 'express';
+import apiRoutes from './routes/apiRoutes';
+import { EventBus } from './messaging/EventBus';
+import { SnapshotSystem } from './ecs/systems/SnapshotSystem';
+
+export default function createServer(bus: EventBus, snapshot: SnapshotSystem) {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', apiRoutes(bus, snapshot));
+  return app;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- set up TypeScript project structure for ECS-based simulation
- add entity, component, and system managers with snapshot and condition systems
- include event bus, API routes for controls and metrics, and Express server entrypoint

## Testing
- `npm test` *(fails: Cannot find module 'express' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68aea9157a70832aba29f51dfadaa15c