### PR TITLE
Add agent memory directory and instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,5 +7,8 @@ This repository follows a spec-as-code development pattern.
 - Commit messages should be in the present tense and summarize the change briefly.
 - Run available tests or linters for the affected areas before committing.
 - Leave the working tree in a clean state after each task.
+- Maintain approach-level notes in the `agent_memory/` directory. Use text files
+  to document styles, patterns, or other reusable insights. Update this
+  directory passively whenever user prompts include approach-level information.
 
 These instructions should be reused by any agent contributing to this repository.

--- a/agent_memory/README.md
+++ b/agent_memory/README.md
@@ -1,0 +1,8 @@
+# Agent Memory
+
+This directory stores approach-level notes for this repository.
+Add or update text files here to document styles, patterns, and other
+reusable insights about how work is done.
+
+Future agents should passively update this directory when user requests
+include information about development approaches or patterns.


### PR DESCRIPTION
## Summary
- create `agent_memory` directory for approach-level notes
- document passive responsibility in `AGENTS.md`

## Testing
- `pytest` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_68b62e66abd0832a8ea2644d140cdddd