### PR TITLE
Remove specs directory and update agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,9 @@
 # Agent Instructions
 
-This repository follows a spec-as-code development pattern.
-
-- All development work should be driven by specifications stored in this repository.
-- When adding or modifying features, update or add the relevant specification files.
 - Commit messages should be in the present tense and summarize the change briefly.
 - Run available tests or linters for the affected areas before committing.
 - Leave the working tree in a clean state after each task.
-- Maintain approach-level notes in the `agent_memory/` directory. Use text files
-  to document styles, patterns, or other reusable insights. Update this
-  directory passively whenever user prompts include approach-level information.
+- Maintain approach-level notes in the `agent_memory/` directory. Use text files to document styles, patterns, or other reusable insights. Update this directory passively whenever user prompts include approach-level information.
 
 These instructions should be reused by any agent contributing to this repository.
+

--- a/specs/human_input_directory.md
+++ b/specs/human_input_directory.md
@@ -1,5 +1,0 @@
-# Human Input Directory Specification
-
-- Human contributions are stored under `human_input/`.
-- Only human-authored files should reside in this directory.
-- Agents should not modify files within `human_input/` unless instructed.


### PR DESCRIPTION
## Summary
- remove outdated spec-as-code references from AGENTS.md
- delete unused specs directory

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b632d50b24832aa28b14efbcdc2232