### PR TITLE
Document TDD strategy from Describing Simulation

### DIFF
--- a/agent_memory/describing_simulation/tdd_strategy.md
+++ b/agent_memory/describing_simulation/tdd_strategy.md
@@ -1,0 +1,7 @@
+# TDD Strategy
+
+- Generate skeleton files without implementation from descriptions.
+- Write comment-only tests expressing intended behavior.
+- Convert comments into executable tests that import the skeletons.
+- Implement business logic to satisfy the tests.
+- Run tests and iterate until all pass.


### PR DESCRIPTION
## Summary
- remove repository TDD strategy document, retaining note only in agent memory

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b63eab9b8c832a9129ca0371eda327