### PR TITLE
Implement ECS primitives with tests

### DIFF
--- a/agent_memory/describing_simulation/primitives_notes.md
+++ b/agent_memory/describing_simulation/primitives_notes.md
@@ -1,0 +1,6 @@
+# Primitives Notes
+
+- Entities are represented by numeric identifiers.
+- EntityManager issues unique ids and coordinates removal with the component manager.
+- ComponentType instances require unique names.
+- ComponentManager tracks components per entity and supports queries and removal.

--- a/ecs/component_manager.js
+++ b/ecs/component_manager.js
@@ -1,0 +1,51 @@
+/** ComponentManager primitive */
+
+class ComponentManager {
+  constructor() {
+    this.components = new Map(); // Map<entity, Map<compType, component>>
+  }
+
+  addComponent(entity, compType, component) {
+    if (!this.components.has(entity)) {
+      this.components.set(entity, new Map());
+    }
+    const entityMap = this.components.get(entity);
+    entityMap.set(compType, component);
+  }
+
+  getComponent(entity, compType) {
+    const entityMap = this.components.get(entity);
+    return entityMap ? entityMap.get(compType) : undefined;
+  }
+
+  getComponents(entity) {
+    const entityMap = this.components.get(entity);
+    return entityMap ? new Map(entityMap) : new Map();
+  }
+
+  getEntitiesWithComponent(compType) {
+    const result = new Set();
+    for (const [entity, comps] of this.components.entries()) {
+      if (comps.has(compType)) {
+        result.add(entity);
+      }
+    }
+    return result;
+  }
+
+  removeComponent(entity, compType) {
+    const entityMap = this.components.get(entity);
+    if (entityMap) {
+      entityMap.delete(compType);
+      if (entityMap.size === 0) {
+        this.components.delete(entity);
+      }
+    }
+  }
+
+  removeEntity(entity) {
+    this.components.delete(entity);
+  }
+}
+
+module.exports = { ComponentManager };

--- a/ecs/component_type.js
+++ b/ecs/component_type.js
@@ -1,0 +1,16 @@
+/** ComponentType primitive */
+
+class ComponentType {
+  constructor(name, schema) {
+    if (ComponentType.registry.has(name)) {
+      throw new Error('ComponentType name must be unique');
+    }
+    this.name = name;
+    this.schema = schema;
+    ComponentType.registry.add(name);
+  }
+}
+
+ComponentType.registry = new Set();
+
+module.exports = { ComponentType };

--- a/ecs/entity.js
+++ b/ecs/entity.js
@@ -1,0 +1,5 @@
+/**
+ * Entity primitive represented by a number id.
+ * @typedef {number} Entity
+ */
+module.exports = {};

--- a/ecs/entity_manager.js
+++ b/ecs/entity_manager.js
@@ -1,0 +1,31 @@
+/** EntityManager primitive */
+
+class EntityManager {
+  constructor(componentManager) {
+    this.componentManager = componentManager;
+    this.entities = new Set();
+    this.nextId = 1;
+  }
+
+  createEntity() {
+    const id = this.nextId++;
+    this.entities.add(id);
+    return id;
+  }
+
+  removeEntity(entity) {
+    if (this.entities.delete(entity) && this.componentManager) {
+      this.componentManager.removeEntity(entity);
+    }
+  }
+
+  hasEntity(entity) {
+    return this.entities.has(entity);
+  }
+
+  allEntities() {
+    return new Set(this.entities);
+  }
+}
+
+module.exports = { EntityManager };

--- a/tests/primitives.test.js
+++ b/tests/primitives.test.js
@@ -1,0 +1,65 @@
+const test = require('node:test');
+const assert = require('assert');
+const { EntityManager } = require('../ecs/entity_manager');
+const { ComponentManager } = require('../ecs/component_manager');
+const { ComponentType } = require('../ecs/component_type');
+
+// EntityManager - createEntity returns unique Entity
+// EntityManager - removeEntity deletes entity and its components
+// EntityManager - hasEntity checks presence
+// EntityManager - allEntities returns all current entities
+
+test('EntityManager creates unique entities', () => {
+  const cm = new ComponentManager();
+  const em = new EntityManager(cm);
+  const e1 = em.createEntity();
+  const e2 = em.createEntity();
+  assert.notStrictEqual(e1, e2);
+  assert.ok(em.hasEntity(e1));
+  assert.ok(em.hasEntity(e2));
+});
+
+test('EntityManager removes entities and clears components', () => {
+  const cm = new ComponentManager();
+  const em = new EntityManager(cm);
+  const type = new ComponentType('test', {});
+  const e = em.createEntity();
+  cm.addComponent(e, type, {});
+  em.removeEntity(e);
+  assert.ok(!em.hasEntity(e));
+  assert.strictEqual(cm.getComponents(e).size, 0);
+  assert.strictEqual(em.allEntities().size, 0);
+});
+
+// ComponentManager - addComponent associates component data with entity and type
+// ComponentManager - getComponent retrieves component for entity and type
+// ComponentManager - getComponents returns all components for an entity
+// ComponentManager - getEntitiesWithComponent returns entities having a component type
+// ComponentManager - removeComponent removes component for entity and type
+// ComponentManager - removeEntity removes all components of entity
+
+test('ComponentManager adds and retrieves components', () => {
+  const cm = new ComponentManager();
+  const type = new ComponentType('position', {});
+  cm.addComponent(1, type, { x: 0, y: 0 });
+  const comp = cm.getComponent(1, type);
+  assert.deepStrictEqual(comp, { x: 0, y: 0 });
+});
+
+test('ComponentManager queries and removes components', () => {
+  const cm = new ComponentManager();
+  const typeA = new ComponentType('a', {});
+  const typeB = new ComponentType('b', {});
+  cm.addComponent(1, typeA, { value: 1 });
+  cm.addComponent(1, typeB, { value: 2 });
+  cm.addComponent(2, typeA, { value: 3 });
+
+  assert.strictEqual(cm.getComponents(1).size, 2);
+  assert.deepStrictEqual(cm.getEntitiesWithComponent(typeA), new Set([1, 2]));
+
+  cm.removeComponent(1, typeA);
+  assert.strictEqual(cm.getComponent(1, typeA), undefined);
+
+  cm.removeEntity(2);
+  assert.strictEqual(cm.getComponents(2).size, 0);
+});


### PR DESCRIPTION
## Summary
- build EntityManager handling numeric entity ids and coordinated removal
- add ComponentManager for storing and querying entity components
- enforce unique ComponentType names and record notes on primitives

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68b640130a24832a95615849fb6c3399