### PR TITLE
Add system primitive with lifecycle hooks

### DIFF
--- a/agent_memory/code_structure.txt
+++ b/agent_memory/code_structure.txt
@@ -1,3 +1,3 @@
-Source code now resides under the `src/` directory. The ECS primitives are split into
-`src/ecs/entity/` and `src/ecs/components/`. Tests live under the top-level `tests/`
-directory.
+Source code resides under the `src/` directory. The ECS primitives are split into
+`src/ecs/entity/`, `src/ecs/components/`, and `src/ecs/system/`. Tests live under the
+top-level `tests/` directory.

--- a/src/ecs/system/System.js
+++ b/src/ecs/system/System.js
@@ -1,0 +1,13 @@
+/** System primitive with lifecycle hooks */
+
+class System {
+  init(_entityManager, _componentManager) {}
+
+  update(_entityManager, _componentManager) {
+    throw new Error(`${this.constructor.name}.update must be implemented`);
+  }
+
+  destroy(_entityManager, _componentManager) {}
+}
+
+module.exports = { System };

--- a/tests/system.test.js
+++ b/tests/system.test.js
@@ -1,0 +1,42 @@
+const test = require('node:test');
+const assert = require('assert');
+const { EntityManager } = require('../src/ecs/entity/EntityManager.js');
+const { ComponentManager } = require('../src/ecs/components/ComponentManager.js');
+const { ComponentType } = require('../src/ecs/components/ComponentType.js');
+const { System } = require('../src/ecs/system/System.js');
+
+test('System requires update implementation', () => {
+  const sys = new System();
+  assert.throws(() => sys.update(), /System\.update must be implemented/);
+});
+
+test('System update error references subclass name', () => {
+  class NoUpdateSystem extends System {}
+  const sys = new NoUpdateSystem();
+  assert.throws(
+    () => sys.update(),
+    /NoUpdateSystem\.update must be implemented/
+  );
+});
+
+test('System init and update mutate components', () => {
+  const cm = new ComponentManager();
+  const em = new EntityManager(cm);
+  const ValueType = new ComponentType('value', { count: 'number' });
+
+  class IncrementSystem extends System {
+    init(em, cm) {
+      this.entity = em.createEntity();
+      cm.addComponent(this.entity, ValueType, { count: 0 });
+    }
+    update(em, cm) {
+      const comp = cm.getComponent(this.entity, ValueType);
+      comp.count++;
+    }
+  }
+
+  const sys = new IncrementSystem();
+  sys.init(em, cm);
+  sys.update(em, cm);
+  assert.strictEqual(cm.getComponent(sys.entity, ValueType).count, 1);
+});


### PR DESCRIPTION
## Summary
- define base System primitive with init, update, and destroy hooks
- reference subclass name in missing update errors
- test system lifecycle and environment mutation

## Testing
- `node --test tests/primitives.test.js tests/system.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b652823164832a8c6b1cc5b6710dfa