### PR TITLE
Add time component and system

### DIFF
--- a/agent_memory/describing_simulation/time_notes.md
+++ b/agent_memory/describing_simulation/time_notes.md
@@ -1,0 +1,5 @@
+# Time Notes
+
+- Implemented TimeComponent and TimeSystem per checkpoint III.
+- Followed TDD: wrote tests before implementing logic.
+- Could not find explicit instructions for explanation in Describing_Simulation_8-1-2025 during first review.

--- a/src/ecs/time/TimeComponent.ts
+++ b/src/ecs/time/TimeComponent.ts
@@ -1,0 +1,4 @@
+/** ComponentType representing elapsed time */
+import { ComponentType } from '../components/ComponentType.js';
+
+export const TimeComponent = new ComponentType('time', { value: 'number' });

--- a/src/ecs/time/TimeSystem.ts
+++ b/src/ecs/time/TimeSystem.ts
@@ -1,0 +1,22 @@
+/** TimeSystem increments global time each update */
+import { System } from '../system/System.js';
+import { EntityManager } from '../entity/EntityManager.js';
+import { ComponentManager } from '../components/ComponentManager.js';
+import { TimeComponent } from './TimeComponent.js';
+
+export class TimeSystem extends System {
+  private timeEntity!: number;
+
+  init(em: EntityManager, cm: ComponentManager): void {
+    this.timeEntity = em.createEntity();
+    cm.addComponent(this.timeEntity, TimeComponent, { value: 0 });
+  }
+
+  update(_em: EntityManager, cm: ComponentManager): void {
+    const comp = cm.getComponent(this.timeEntity, TimeComponent);
+    if (!comp) {
+      throw new Error('Time component not found');
+    }
+    comp.value++;
+  }
+}

--- a/tests/time.test.ts
+++ b/tests/time.test.ts
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { EntityManager } from '../src/ecs/entity/EntityManager.js';
+import { ComponentManager } from '../src/ecs/components/ComponentManager.js';
+import { TimeComponent } from '../src/ecs/time/TimeComponent.js';
+import { TimeSystem } from '../src/ecs/time/TimeSystem.js';
+
+// TimeSystem creates a time entity with an initial time of 0 on init
+// TimeSystem increments the time component on each update
+
+test('TimeSystem initializes time to 0 and increments each update', () => {
+  const cm = new ComponentManager();
+  const em = new EntityManager(cm);
+  const timeSystem = new TimeSystem();
+  timeSystem.init(em, cm);
+  const entities = cm.getEntitiesWithComponent(TimeComponent);
+  assert.strictEqual(entities.size, 1);
+  const e = Array.from(entities)[0];
+  const comp = cm.getComponent(e, TimeComponent)!;
+  assert.strictEqual(comp.value, 0);
+  timeSystem.update(em, cm);
+  assert.strictEqual(cm.getComponent(e, TimeComponent)?.value, 1);
+  timeSystem.update(em, cm);
+  assert.strictEqual(cm.getComponent(e, TimeComponent)?.value, 2);
+});


### PR DESCRIPTION
## Summary
- add `TimeComponent` to track elapsed time
- implement `TimeSystem` to increment time each update
- record TDD notes and inability to find explanation instructions in memory

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b656b71254832aa76dd0d454d91bf4