### PR TITLE
Reinforce doc-sourced structure and TDD workflow in agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,8 @@
 - Leave the working tree in a clean state after each task.
 - Maintain approach-level notes in the `agent_memory/` directory. Use text files to document styles, patterns, or other reusable insights. Update this directory passively whenever user prompts include approach-level information.
 - If it takes searching to find a meta level decision from the document, it should be in memory.
-- Follow the directory layout in `Describing_Simulation_8-1-2025.md`: component and system implementations belong under
-  `implementations/` with extensibility in `plugins/`.
+- Before coding, review `agent_memory/` and the latest `human_input/Describing_Simulation_8-1-2025.md` to understand the directory structure and required TDD flow.
+- Follow the directory layout described in `human_input/Describing_Simulation_8-1-2025.md` (or its latest version): component and system implementations belong under `implementations/` with extensibility in `plugins/`.
+- Use the TDD workflow from `Describing_Simulation_8-1-2025.md`: create skeletons, write comment-only tests, convert them into executable tests, implement logic, then run tests until they pass.
 
 These instructions should be reused by any agent contributing to this repository.
-

--- a/agent_memory/code_structure.txt
+++ b/agent_memory/code_structure.txt
@@ -1,3 +1,4 @@
+The repository's layout follows `human_input/Describing_Simulation_8-1-2025.md` (or its latest version). Consult that document before adjusting directories.
 Source code resides under the `src/` directory. The ECS primitives are split into
 `src/ecs/entity/`, `src/ecs/components/`, and `src/ecs/systems/`. Built-in component
 and system implementations live under their respective `implementations/` directories,

--- a/agent_memory/describing_simulation/tdd_strategy.md
+++ b/agent_memory/describing_simulation/tdd_strategy.md
@@ -1,5 +1,7 @@
 # TDD Strategy
 
+This workflow comes from `human_input/Describing_Simulation_8-1-2025.md` (or its latest version) and should be reviewed before coding.
+
 - Generate skeleton files without implementation from descriptions.
 - Write comment-only tests expressing intended behavior.
 - Convert comments into executable tests that import the skeletons.


### PR DESCRIPTION
## Summary
- Require agents to review repository memory and the Describing_Simulation document before coding
- Clarify that directory structure and TDD workflow come from Describing_Simulation_8-1-2025.md
- Update memory notes to reference the document for structure and TDD guidance

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6855d4608832aad9bc676d0495edf