### PR TITLE
Implement outbound messaging with bus and system

### DIFF
--- a/agent_memory/describing_simulation/outbound_messaging_notes.md
+++ b/agent_memory/describing_simulation/outbound_messaging_notes.md
@@ -1,0 +1,5 @@
+# Outbound Messaging Notes
+
+- `OutboundMessageBus` supports a single listener and relays pushed messages directly.
+- `OutboundMessageSystem` sends messages for entities with `OutboundMessageComponent` and removes those entities.
+- `OutboundMessageType` currently defines `data` and `exit` message categories.

--- a/src/ecs/components/implementations/OutboundMessageComponent.ts
+++ b/src/ecs/components/implementations/OutboundMessageComponent.ts
@@ -1,0 +1,10 @@
+/** ComponentType for outbound messages */
+import { ComponentType } from '../ComponentType.js';
+import { OutboundMessageType } from '../../messaging/OutboundMessageType.js';
+
+export interface OutboundMessageData {
+  type: OutboundMessageType;
+  payload: any;
+}
+
+export const OutboundMessageComponent = new ComponentType('outboundMessage', { type: 'string', payload: 'object' });

--- a/src/ecs/messaging/OutboundMessageBus.ts
+++ b/src/ecs/messaging/OutboundMessageBus.ts
@@ -1,0 +1,24 @@
+/** OutboundMessageBus with single listener */
+import { OutboundMessageType } from './OutboundMessageType.js';
+
+export interface OutboundMessage {
+  type: OutboundMessageType;
+  payload: any;
+}
+
+export class OutboundMessageBus {
+  private listener?: (msg: OutboundMessage) => void;
+
+  subscribe(listener: (msg: OutboundMessage) => void): void {
+    if (this.listener) {
+      throw new Error('Listener already registered');
+    }
+    this.listener = listener;
+  }
+
+  push(message: OutboundMessage): void {
+    if (this.listener) {
+      this.listener(message);
+    }
+  }
+}

--- a/src/ecs/messaging/OutboundMessageType.ts
+++ b/src/ecs/messaging/OutboundMessageType.ts
@@ -1,0 +1,5 @@
+/** Outbound message types */
+export enum OutboundMessageType {
+  Data = 'data',
+  Exit = 'exit',
+}

--- a/src/ecs/systems/implementations/OutboundMessageSystem.ts
+++ b/src/ecs/systems/implementations/OutboundMessageSystem.ts
@@ -1,0 +1,26 @@
+/** System sending outbound messages */
+import { System } from '../System.js';
+import { OutboundMessageBus } from '../../messaging/OutboundMessageBus.js';
+import { EntityManager } from '../../entity/EntityManager.js';
+import { ComponentManager } from '../../components/ComponentManager.js';
+import { OutboundMessageComponent, OutboundMessageData } from '../../components/implementations/OutboundMessageComponent.js';
+
+export class OutboundMessageSystem extends System {
+  private bus: OutboundMessageBus;
+
+  constructor(bus: OutboundMessageBus) {
+    super();
+    this.bus = bus;
+  }
+
+  update(em: EntityManager, cm: ComponentManager): void {
+    const entities = cm.getEntitiesWithComponent(OutboundMessageComponent);
+    for (const e of entities) {
+      const comp = cm.getComponent(e, OutboundMessageComponent) as OutboundMessageData | undefined;
+      if (comp) {
+        this.bus.push({ type: comp.type, payload: comp.payload });
+      }
+      em.removeEntity(e);
+    }
+  }
+}

--- a/tests/outbound.test.ts
+++ b/tests/outbound.test.ts
@@ -1,0 +1,47 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { OutboundMessageBus, OutboundMessage } from '../src/ecs/messaging/OutboundMessageBus.js';
+import { OutboundMessageType } from '../src/ecs/messaging/OutboundMessageType.js';
+import { OutboundMessageComponent } from '../src/ecs/components/implementations/OutboundMessageComponent.js';
+import { OutboundMessageSystem } from '../src/ecs/systems/implementations/OutboundMessageSystem.js';
+import { ComponentManager } from '../src/ecs/components/ComponentManager.js';
+import { EntityManager } from '../src/ecs/entity/EntityManager.js';
+
+test('OutboundMessageBus delivers messages to listener', () => {
+  const bus = new OutboundMessageBus();
+  const received: OutboundMessage[] = [];
+  bus.subscribe((msg) => received.push(msg));
+  bus.push({ type: OutboundMessageType.Data, payload: { value: 1 } });
+  assert.deepStrictEqual(received, [
+    { type: OutboundMessageType.Data, payload: { value: 1 } },
+  ]);
+});
+
+test('OutboundMessageBus allows only one listener', () => {
+  const bus = new OutboundMessageBus();
+  bus.subscribe(() => {});
+  assert.throws(() => bus.subscribe(() => {}));
+});
+
+test('OutboundMessageSystem emits messages and clears entities', () => {
+  const bus = new OutboundMessageBus();
+  const cm = new ComponentManager();
+  const em = new EntityManager(cm);
+  const received: OutboundMessage[] = [];
+  bus.subscribe((msg) => received.push(msg));
+  const e = em.createEntity();
+  cm.addComponent(e, OutboundMessageComponent, {
+    type: OutboundMessageType.Data,
+    payload: { foo: 'bar' },
+  });
+  const sys = new OutboundMessageSystem(bus);
+  sys.update(em, cm);
+  assert.deepStrictEqual(received, [
+    { type: OutboundMessageType.Data, payload: { foo: 'bar' } },
+  ]);
+  assert.strictEqual(em.hasEntity(e), false);
+  assert.strictEqual(
+    cm.getComponent(e, OutboundMessageComponent),
+    undefined,
+  );
+});


### PR DESCRIPTION
## Summary
- add outbound message types and bus supporting a single listener
- create outbound message component and system to emit and flush messages
- document outbound messaging approach

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b686daad18832a98f8de38ee5a33b0