### PR TITLE
Add workspace initialization script

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,25 @@
+# Tools
+
+## init_workspace.py
+
+Create new workspace directories under `workspaces/`.
+
+### Usage
+
+```bash
+python tools/init_workspace.py <workspace_name> [--seed] [--templates TEMPLATE_DIR]
+```
+
+- `workspace_name`: Name of the workspace to create.
+- `--seed`: Copy template files into the workspace. Templates are read from
+  `tools/templates` by default.
+- `--templates`: Optional path to an alternate templates directory.
+
+Example:
+
+```bash
+python tools/init_workspace.py demo --seed
+```
+
+This creates `workspaces/demo` and populates it with any files found in
+`tools/templates`.

--- a/tools/init_workspace.py
+++ b/tools/init_workspace.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Utility to create and optionally seed workspace directories."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+
+def copy_templates(templates_dir: Path, destination: Path) -> None:
+    """Copy files from ``templates_dir`` into ``destination``.
+
+    Copies files recursively while preserving relative structure.
+    Existing files are overwritten.
+    """
+    for item in templates_dir.rglob('*'):
+        if item.is_file():
+            target = destination / item.relative_to(templates_dir)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(item, target)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Initialize a workspace directory")
+    parser.add_argument("workspace_name", help="Name of the workspace to create")
+    parser.add_argument(
+        "--seed",
+        action="store_true",
+        help="Seed workspace with template files (from tools/templates by default)",
+    )
+    parser.add_argument(
+        "--templates",
+        type=Path,
+        default=None,
+        help="Path to template files (defaults to tools/templates)",
+    )
+
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parent.parent
+    workspaces_dir = repo_root / "workspaces"
+    workspaces_dir.mkdir(exist_ok=True)
+
+    workspace_dir = workspaces_dir / args.workspace_name
+    if workspace_dir.exists():
+        print(f"Workspace '{args.workspace_name}' already exists: {workspace_dir}")
+    else:
+        workspace_dir.mkdir(parents=True)
+        print(f"Created workspace directory: {workspace_dir}")
+
+    if args.seed:
+        templates_dir = args.templates or Path(__file__).resolve().parent / "templates"
+        if templates_dir.exists():
+            copy_templates(templates_dir, workspace_dir)
+            print(f"Seeded workspace using templates from {templates_dir}")
+        else:
+            print(f"Template directory '{templates_dir}' not found; skipping seeding")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/templates/README.md
+++ b/tools/templates/README.md
@@ -1,0 +1,3 @@
+# Workspace Template
+
+Describe your workspace here.


### PR DESCRIPTION
## Summary
- add `init_workspace.py` to create workspace directories and optionally seed from template files
- document usage in `tools/README.md`
- include sample template README for seeding

## Testing
- `python tools/init_workspace.py --help`
- `python tools/init_workspace.py demo_ws --seed`


------
https://chatgpt.com/codex/tasks/task_e_68c4f10584c0832aa1132a62c7f1fc49