### PR TITLE
Add instruction documents index

### DIFF
--- a/instruction_documents/index.md
+++ b/instruction_documents/index.md
@@ -1,0 +1,6 @@
+# Instruction Documents
+
+- [Describing_Simulation_0_theory.md](Describing_Simulation_0_theory.md) — Summarizes the conceptual framework for translating natural language hypotheticals into simulation-ready specifications, outlining assumptions about temporality, boundaries, environments, and conditions.
+- [Describing_Simulation_0_bootstraps.md](Describing_Simulation_0_bootstraps.md) — Covers repository setup expectations, directory structure, and supporting resources such as tools, workspaces, and memory records that enable consistent bootstrapping.
+- [Describing_Simulation_0_codifying_simulations.md](Describing_Simulation_0_codifying_simulations.md) — Provides coding guidance for implementing the simulation engine, emphasizing an entity-component-system architecture, scaffolding, and plugin extension points.
+- [Describing_Simulation_0_master_prompt.md](Describing_Simulation_0_master_prompt.md) — Defines the phased workflow prompt agents should follow, from bootstrapping through artifact creation, to plan and execute tasks responsibly.


### PR DESCRIPTION
## Summary
- add an index for instruction documents with brief descriptions of each guide

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c87c8148b4832a8da6a1c0863cb74b