### PR TITLE
Add workspace setup helper script

### DIFF
--- a/tools/index.md
+++ b/tools/index.md
@@ -4,7 +4,11 @@ This directory collects helper scripts and utilities that support working with t
 
 ## Current Contents
 
-- _None yet._ The directory is ready to receive shared tooling as it becomes available.
+- `setup_workspace.sh`: Initializes a workspace with standard `src` and `tests` directories so new projects start with a consistent layout.
+
+  ```bash
+  ./tools/setup_workspace.sh workspaces/Describing_Simulation_0
+  ```
 
 ## Planned Additions
 

--- a/tools/setup_workspace.sh
+++ b/tools/setup_workspace.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+show_usage() {
+  cat <<'USAGE'
+Usage: setup_workspace.sh <workspace_path>
+
+Initializes the core directory structure for a workspace, creating source and test directories when they are missing.
+USAGE
+}
+
+if [[ $# -eq 0 ]]; then
+  show_usage >&2
+  exit 1
+fi
+
+if [[ $# -gt 1 ]]; then
+  show_usage >&2
+  exit 1
+fi
+
+case "$1" in
+  -h|--help)
+    show_usage
+    exit 0
+    ;;
+  *)
+    workspace_dir=$1
+    ;;
+esac
+
+if [[ -z "${workspace_dir:-}" ]]; then
+  show_usage >&2
+  exit 1
+fi
+
+mkdir -p "$workspace_dir"
+
+declare -a required_dirs=(
+  "src"
+  "tests"
+  "tests/unit"
+  "tests/integration"
+)
+
+for subdir in "${required_dirs[@]}"; do
+  dir_path="$workspace_dir/$subdir"
+  if [[ -d "$dir_path" ]]; then
+    printf 'Skipping existing directory: %s\n' "$dir_path"
+  else
+    mkdir -p "$dir_path"
+    printf 'Created directory: %s\n' "$dir_path"
+  fi
+done
+
+printf 'Workspace initialization complete for: %s\n' "$workspace_dir"
+


### PR DESCRIPTION
## Summary
- add a setup_workspace.sh tool that provisions src and test directories for a workspace
- update the tools index with usage documentation and an invocation example for the new script

## Testing
- tmpdir=$(mktemp -d); ./tools/setup_workspace.sh "$tmpdir"
- ./tools/setup_workspace.sh "$tmpdir" # idempotence check


------
https://chatgpt.com/codex/tasks/task_e_68c87eae2c5c832aa45d8714f9a83910