### PR TITLE
Set up TypeScript tooling for Describing Simulation workspace

### DIFF
--- a/workspaces/Describing_Simulation_0/jest.config.js
+++ b/workspaces/Describing_Simulation_0/jest.config.js
@@ -1,0 +1,8 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/tests'],
+  testMatch: ['**/*.test.ts'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'json', 'node']
+};

--- a/workspaces/Describing_Simulation_0/package.json
+++ b/workspaces/Describing_Simulation_0/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "describing_simulation_0",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "test": "jest"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.11",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.0"
+  }
+}

--- a/workspaces/Describing_Simulation_0/tsconfig.json
+++ b/workspaces/Describing_Simulation_0/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "rootDir": "./",
+    "outDir": "dist"
+  },
+  "include": ["src", "tests"]
+}


### PR DESCRIPTION
## Summary
- add a workspace-specific `package.json` with build/test scripts and TypeScript/Jest tooling
- configure a strict ES2020 `tsconfig.json`
- add a `ts-jest` configuration so Jest can execute the existing TypeScript tests

## Testing
- npm install *(fails: registry returned 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c887afdba4832a891587f677d4c7b8