### PR TITLE
Add concrete entity and manager implementations

### DIFF
--- a/workspaces/Describing_Simulation_0/src/ecs/entity/ConcreteEntity.ts
+++ b/workspaces/Describing_Simulation_0/src/ecs/entity/ConcreteEntity.ts
@@ -1,0 +1,35 @@
+import { Entity, EntityId } from "./Entity";
+
+/**
+ * Default entity implementation that stores component data in-memory using a
+ * simple map keyed by component type.
+ */
+export class ConcreteEntity extends Entity {
+  private readonly components = new Map<string, unknown>();
+
+  public constructor(id: EntityId, initialComponents?: Map<string, unknown>) {
+    super(id);
+
+    if (initialComponents !== undefined) {
+      for (const [componentType, componentData] of initialComponents.entries()) {
+        this.components.set(componentType, componentData);
+      }
+    }
+  }
+
+  public addComponent(componentType: string, componentData: unknown): void {
+    this.components.set(componentType, componentData);
+  }
+
+  public removeComponent(componentType: string): void {
+    this.components.delete(componentType);
+  }
+
+  public getComponent<T = unknown>(componentType: string): T | undefined {
+    return this.components.get(componentType) as T | undefined;
+  }
+
+  public listComponents(): string[] {
+    return Array.from(this.components.keys());
+  }
+}

--- a/workspaces/Describing_Simulation_0/src/ecs/entity/ConcreteEntityManager.ts
+++ b/workspaces/Describing_Simulation_0/src/ecs/entity/ConcreteEntityManager.ts
@@ -1,0 +1,46 @@
+import { Entity, EntityId } from "./Entity";
+import { EntityManager } from "./EntityManager";
+import { ConcreteEntity } from "./ConcreteEntity";
+
+const UUID_TEMPLATE = "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx";
+
+const generateUuid = (): string =>
+  UUID_TEMPLATE.replace(/[xy]/g, (character) => {
+    const random = Math.floor(Math.random() * 16);
+    const value = character === "x" ? random : (random & 0x3) | 0x8;
+    return value.toString(16);
+  });
+
+/**
+ * Default entity manager backed by an in-memory map of entity identifiers to
+ * their corresponding entity instances.
+ */
+export class ConcreteEntityManager extends EntityManager {
+  private readonly entities = new Map<EntityId, ConcreteEntity>();
+
+  public createEntity(initialComponents?: Map<string, unknown>): Entity;
+  public createEntity(initialComponents: Map<string, unknown> | undefined, requestedId?: EntityId): Entity;
+  public createEntity(initialComponents?: Map<string, unknown>, requestedId?: EntityId): Entity {
+    const entityId = requestedId ?? generateUuid();
+
+    if (this.entities.has(entityId)) {
+      throw new Error(`Entity with id "${entityId}" already exists.`);
+    }
+
+    const entity = new ConcreteEntity(entityId, initialComponents);
+    this.entities.set(entityId, entity);
+    return entity;
+  }
+
+  public destroyEntity(entityId: EntityId): void {
+    this.entities.delete(entityId);
+  }
+
+  public getEntity(entityId: EntityId): Entity | undefined {
+    return this.entities.get(entityId);
+  }
+
+  public getAllEntities(): Iterable<Entity> {
+    return this.entities.values();
+  }
+}

--- a/workspaces/Describing_Simulation_0/src/ecs/entity/index.ts
+++ b/workspaces/Describing_Simulation_0/src/ecs/entity/index.ts
@@ -1,0 +1,4 @@
+export { Entity, EntityId } from "./Entity";
+export { EntityManager } from "./EntityManager";
+export { ConcreteEntity } from "./ConcreteEntity";
+export { ConcreteEntityManager } from "./ConcreteEntityManager";


### PR DESCRIPTION
## Summary
- implement a concrete entity that manages components in-memory
- add an entity manager that stores entities in a map and generates UUIDs when needed
- re-export the concrete implementations for external consumers

## Testing
- not run (tests not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c887c1948c832a90a4d05cc7078bc7