### PR TITLE
Implement default component manager with state isolation tests

### DIFF
--- a/workspaces/Describing_Simulation_0/package.json
+++ b/workspaces/Describing_Simulation_0/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "describing_simulation_0",
+  "version": "1.0.0",
+  "description": "This workspace now houses the initial scaffolding for an entity-component-system (ECS) simulation engine. The intent is to provide strongly typed extension points that future agents can implement without redefining the overall structure.",
+  "main": "index.js",
+  "directories": {
+    "test": "tests"
+  },
+  "scripts": {
+    "test": "ts-node tests/components.test.ts"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.2"
+  }
+}

--- a/workspaces/Describing_Simulation_0/src/ecs/components/implementations/DefaultComponentManager.ts
+++ b/workspaces/Describing_Simulation_0/src/ecs/components/implementations/DefaultComponentManager.ts
@@ -1,0 +1,98 @@
+import { ComponentManager } from "../ComponentManager";
+import { ComponentType, ComponentTypeId } from "../ComponentType";
+import { EntityId } from "../../entity/Entity";
+
+/**
+ * Stores component instances per entity using nested maps.
+ */
+export class DefaultComponentManager extends ComponentManager {
+  private readonly registry = new Map<ComponentTypeId, ComponentType>();
+
+  private readonly components = new Map<EntityId, Map<ComponentTypeId, unknown>>();
+
+  public register(componentType: ComponentType): void {
+    if (this.registry.has(componentType.type)) {
+      throw new Error(`Component type '${componentType.type}' is already registered.`);
+    }
+
+    this.registry.set(componentType.type, componentType);
+  }
+
+  public unregister(componentTypeId: ComponentTypeId): void {
+    this.registry.delete(componentTypeId);
+
+    for (const [entityId, componentMap] of this.components) {
+      componentMap.delete(componentTypeId);
+
+      if (componentMap.size === 0) {
+        this.components.delete(entityId);
+      }
+    }
+  }
+
+  public has(componentTypeId: ComponentTypeId): boolean {
+    return this.registry.has(componentTypeId);
+  }
+
+  public attach(entityId: EntityId, componentTypeId: ComponentTypeId, state: unknown): void {
+    const componentType = this.registry.get(componentTypeId);
+
+    if (!componentType) {
+      throw new Error(`Component type '${componentTypeId}' is not registered.`);
+    }
+
+    const cloneArg = state as Parameters<typeof componentType.clone>[0];
+    const componentState =
+      state === undefined ? componentType.create() : componentType.clone(cloneArg);
+
+    let componentsForEntity = this.components.get(entityId);
+
+    if (!componentsForEntity) {
+      componentsForEntity = new Map<ComponentTypeId, unknown>();
+      this.components.set(entityId, componentsForEntity);
+    }
+
+    componentsForEntity.set(componentTypeId, componentState);
+  }
+
+  public detach(entityId: EntityId, componentTypeId: ComponentTypeId): void {
+    if (!this.registry.has(componentTypeId)) {
+      throw new Error(`Component type '${componentTypeId}' is not registered.`);
+    }
+
+    const componentsForEntity = this.components.get(entityId);
+
+    if (!componentsForEntity) {
+      return;
+    }
+
+    componentsForEntity.delete(componentTypeId);
+
+    if (componentsForEntity.size === 0) {
+      this.components.delete(entityId);
+    }
+  }
+
+  public read(entityId: EntityId, componentTypeId: ComponentTypeId): unknown {
+    const componentType = this.registry.get(componentTypeId);
+
+    if (!componentType) {
+      throw new Error(`Component type '${componentTypeId}' is not registered.`);
+    }
+
+    const componentsForEntity = this.components.get(entityId);
+
+    if (!componentsForEntity) {
+      return undefined;
+    }
+
+    const state = componentsForEntity.get(componentTypeId);
+
+    if (state === undefined) {
+      return undefined;
+    }
+
+    const cloneArg = state as Parameters<typeof componentType.clone>[0];
+    return componentType.clone(cloneArg);
+  }
+}

--- a/workspaces/Describing_Simulation_0/tests/components.test.ts
+++ b/workspaces/Describing_Simulation_0/tests/components.test.ts
@@ -1,4 +1,122 @@
-// Component manager should register component types for lookup.
-// Component manager should attach component state to entities.
-// Component manager should detach component state and reclaim resources.
-// Component manager should retrieve component state snapshots without mutation.
+import { strict as assert } from "node:assert";
+
+import { ComponentState, ComponentType } from "../src/ecs/components/ComponentType";
+import { DefaultComponentManager } from "../src/ecs/components/implementations/DefaultComponentManager";
+
+interface TestComponentState extends ComponentState {
+  value: number;
+  nested: {
+    flag: boolean;
+  };
+}
+
+class TestComponent extends ComponentType<TestComponentState> {
+  public constructor() {
+    super("test");
+  }
+
+  public create(initialState: Partial<TestComponentState> = {}): TestComponentState {
+    return {
+      value: initialState.value ?? 0,
+      nested: {
+        flag: initialState.nested?.flag ?? false,
+      },
+    };
+  }
+
+  public clone(state: TestComponentState): TestComponentState {
+    return {
+      value: state.value,
+      nested: { flag: state.nested.flag },
+    };
+  }
+}
+
+type TestCase = {
+  readonly name: string;
+  readonly fn: () => void;
+};
+
+const cases: TestCase[] = [];
+
+const test = (name: string, fn: () => void) => {
+  cases.push({ name, fn });
+};
+
+test("register stores component types and enforces uniqueness", () => {
+  const manager = new DefaultComponentManager();
+  const component = new TestComponent();
+
+  assert.equal(manager.has(component.type), false);
+
+  manager.register(component);
+
+  assert.equal(manager.has(component.type), true);
+  assert.throws(() => manager.register(component));
+});
+
+test("attach requires prior registration", () => {
+  const manager = new DefaultComponentManager();
+  const component = new TestComponent();
+  const state = component.create({ value: 5, nested: { flag: true } });
+
+  assert.throws(() => manager.attach("entity-1", component.type, state));
+});
+
+test("reads and writes clone component state to prevent mutation leakage", () => {
+  const manager = new DefaultComponentManager();
+  const component = new TestComponent();
+  manager.register(component);
+
+  const originalState = component.create({ value: 7, nested: { flag: true } });
+  manager.attach("entity-1", component.type, originalState);
+
+  originalState.value = 42;
+  originalState.nested.flag = false;
+
+  const firstSnapshot = manager.read("entity-1", component.type) as TestComponentState;
+  assert.equal(firstSnapshot.value, 7);
+  assert.equal(firstSnapshot.nested.flag, true);
+
+  firstSnapshot.value = 11;
+  firstSnapshot.nested.flag = false;
+
+  const secondSnapshot = manager.read("entity-1", component.type) as TestComponentState;
+  assert.equal(secondSnapshot.value, 7);
+  assert.equal(secondSnapshot.nested.flag, true);
+});
+
+test("detach removes component state and subsequent reads are undefined", () => {
+  const manager = new DefaultComponentManager();
+  const component = new TestComponent();
+  manager.register(component);
+
+  manager.attach("entity-1", component.type, component.create({ value: 3 }));
+  manager.detach("entity-1", component.type);
+
+  assert.equal(manager.read("entity-1", component.type), undefined);
+});
+
+test("read and detach throw when the component type is unknown", () => {
+  const manager = new DefaultComponentManager();
+
+  assert.throws(() => manager.read("entity-1", "missing"));
+  assert.throws(() => manager.detach("entity-1", "missing"));
+});
+
+let failed = 0;
+
+for (const { name, fn } of cases) {
+  try {
+    fn();
+    console.log(`✓ ${name}`);
+  } catch (error) {
+    failed += 1;
+    console.error(`✗ ${name}`);
+    console.error(error);
+  }
+}
+
+if (failed > 0) {
+  process.exitCode = 1;
+}

--- a/workspaces/Describing_Simulation_0/tsconfig.json
+++ b/workspaces/Describing_Simulation_0/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "types": ["node"],
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"],
+  "exclude": ["dist"]
+}


### PR DESCRIPTION
## Summary
- implement a DefaultComponentManager that stores component instances per entity and clones state on attach/read to avoid mutation
- extend the component tests with a lightweight harness covering registration requirements, state isolation, and detach behavior

## Testing
- npx ts-node tests/components.test.ts *(fails: registry returned 403 when downloading ts-node in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c887e386c4832a8b4319ee2fb0e9a5