### PR TITLE
Implement basic time component and system

### DIFF
--- a/workspaces/Describing_Simulation_0/src/ecs/components/implementations/BasicTimeComponent.ts
+++ b/workspaces/Describing_Simulation_0/src/ecs/components/implementations/BasicTimeComponent.ts
@@ -1,0 +1,39 @@
+import { TimeComponent, TimeComponentState } from "./TimeComponent";
+
+export interface BasicTimeComponentState extends TimeComponentState {
+  readonly delta: number;
+}
+
+export const BASIC_TIME_COMPONENT_TYPE = "core/time/basic";
+
+/**
+ * Concrete time component storing the current tick and frame delta values.
+ */
+export class BasicTimeComponent extends TimeComponent {
+  public constructor() {
+    super(BASIC_TIME_COMPONENT_TYPE);
+  }
+
+  public create(initialState: Partial<BasicTimeComponentState> = {}): BasicTimeComponentState {
+    return {
+      tick: initialState.tick ?? 0,
+      delta: initialState.delta ?? 0,
+    };
+  }
+
+  public clone(state: BasicTimeComponentState): BasicTimeComponentState {
+    return {
+      tick: state.tick,
+      delta: state.delta,
+    };
+  }
+
+  public advance(state: TimeComponentState, elapsed: number): BasicTimeComponentState {
+    const currentState = state as BasicTimeComponentState;
+
+    return {
+      tick: currentState.tick + 1,
+      delta: elapsed,
+    };
+  }
+}

--- a/workspaces/Describing_Simulation_0/src/ecs/systems/implementations/BasicTimeSystem.ts
+++ b/workspaces/Describing_Simulation_0/src/ecs/systems/implementations/BasicTimeSystem.ts
@@ -1,0 +1,70 @@
+import { BasicTimeComponent, BasicTimeComponentState } from "../../components/implementations/BasicTimeComponent";
+import { TimeComponentState } from "../../components/implementations/TimeComponent";
+import { TimeSystem } from "./TimeSystem";
+
+export interface BasicTimeSystemOptions {
+  readonly component?: BasicTimeComponent;
+  readonly systemId?: string;
+  readonly initialState?: Partial<BasicTimeComponentState>;
+}
+
+export const BASIC_TIME_SYSTEM_ID = "core/time/basic";
+
+/**
+ * Concrete implementation of the time system that advances a time component on
+ * each update cycle.
+ */
+export class BasicTimeSystem extends TimeSystem {
+  public readonly id: string;
+
+  private readonly component: BasicTimeComponent;
+  private readonly initialState: Partial<BasicTimeComponentState>;
+  private currentState: BasicTimeComponentState;
+
+  public constructor(options: BasicTimeSystemOptions = {}) {
+    super();
+    this.component = options.component ?? new BasicTimeComponent();
+    this.id = options.systemId ?? BASIC_TIME_SYSTEM_ID;
+    this.initialState = { ...options.initialState };
+    this.currentState = this.component.create(this.initialState);
+  }
+
+  public initialize(): void {
+    this.currentState = this.component.create(this.initialState);
+  }
+
+  public update(deltaTime: number): void {
+    this.step(deltaTime);
+  }
+
+  public shutdown(): void {
+    this.currentState = this.component.create(this.initialState);
+  }
+
+  public getState(): TimeComponentState {
+    return this.component.clone(this.currentState);
+  }
+
+  public step(elapsed: number): void {
+    this.currentState = this.component.advance(this.currentState, elapsed);
+  }
+}
+
+let activeTimeSystem: BasicTimeSystem | undefined;
+
+/**
+ * Creates a new instance of the basic time system and stores a reference for
+ * shared queries.
+ */
+export function createBasicTimeSystem(options: BasicTimeSystemOptions = {}): BasicTimeSystem {
+  const system = new BasicTimeSystem(options);
+  activeTimeSystem = system;
+  return system;
+}
+
+/**
+ * Returns the most recent state of the globally tracked basic time system.
+ */
+export function getCurrentTimeState(): TimeComponentState | undefined {
+  return activeTimeSystem?.getState();
+}


### PR DESCRIPTION
## Summary
- add a concrete time component that stores tick and delta information
- implement a basic time system that advances the component each update and exposes helper factories

## Testing
- not run (no automated tests configured)


------
https://chatgpt.com/codex/tasks/task_e_68c887e02ab0832abfca03b8b648485a