### PR TITLE
Implement in-memory bus and inbound handler registry

### DIFF
--- a/workspaces/Describing_Simulation_0/.gitignore
+++ b/workspaces/Describing_Simulation_0/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/workspaces/Describing_Simulation_0/package.json
+++ b/workspaces/Describing_Simulation_0/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "describing-simulation",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "npm run build --silent && node --test dist/tests"
+  }
+}

--- a/workspaces/Describing_Simulation_0/src/ecs/messaging/Bus.ts
+++ b/workspaces/Describing_Simulation_0/src/ecs/messaging/Bus.ts
@@ -10,3 +10,25 @@ export abstract class Bus<TMessage> {
 
   public abstract publish(message: TMessage): void;
 }
+
+/**
+ * In-memory implementation of the {@link Bus} abstraction. Subscribers are
+ * invoked synchronously in the order they were registered.
+ */
+export class InMemoryBus<TMessage> extends Bus<TMessage> {
+  private readonly subscribers = new Set<BusSubscriber<TMessage>>();
+
+  public subscribe(handler: BusSubscriber<TMessage>): void {
+    this.subscribers.add(handler);
+  }
+
+  public unsubscribe(handler: BusSubscriber<TMessage>): void {
+    this.subscribers.delete(handler);
+  }
+
+  public publish(message: TMessage): void {
+    for (const subscriber of Array.from(this.subscribers)) {
+      subscriber(message);
+    }
+  }
+}

--- a/workspaces/Describing_Simulation_0/src/ecs/messaging/handlers/inbound/implementations/DefaultInboundHandlerRegistry.ts
+++ b/workspaces/Describing_Simulation_0/src/ecs/messaging/handlers/inbound/implementations/DefaultInboundHandlerRegistry.ts
@@ -1,0 +1,31 @@
+import { Message, MessageHandler } from "../../../MessageHandler";
+import { InboundHandlerRegistry } from "../InboundHandlerRegistry";
+
+/**
+ * Default registry implementation backed by an in-memory map keyed by the
+ * handler's declared message type.
+ */
+export class DefaultInboundHandlerRegistry<
+  TMessage extends Message = Message,
+> extends InboundHandlerRegistry<TMessage> {
+  private readonly handlers = new Map<
+    TMessage["type"],
+    MessageHandler<TMessage>
+  >();
+
+  public register(handler: MessageHandler<TMessage>): void {
+    this.handlers.set(handler.messageType, handler);
+  }
+
+  public unregister(type: TMessage["type"]): void {
+    this.handlers.delete(type);
+  }
+
+  public resolve(type: TMessage["type"]): MessageHandler<TMessage> | undefined {
+    return this.handlers.get(type);
+  }
+
+  public list(): Iterable<MessageHandler<TMessage>> {
+    return this.handlers.values();
+  }
+}

--- a/workspaces/Describing_Simulation_0/tests/messaging.test.ts
+++ b/workspaces/Describing_Simulation_0/tests/messaging.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { InMemoryBus } from "../src/ecs/messaging/Bus";
+import { Message, MessageHandler } from "../src/ecs/messaging/MessageHandler";
+import { DefaultInboundHandlerRegistry } from "../src/ecs/messaging/handlers/inbound/implementations/DefaultInboundHandlerRegistry";
+
+class RecordingHandler extends MessageHandler<Message> {
+  public readonly messageType = "record" as const;
+  public readonly handled: Message[] = [];
+
+  public handle(message: Message): void {
+    if (message.type !== this.messageType) {
+      throw new Error(`Unexpected message type: ${message.type}`);
+    }
+
+    this.handled.push(message);
+  }
+}
+
+describe("DefaultInboundHandlerRegistry", () => {
+  it("registers handlers and resolves them by message type", () => {
+    const registry = new DefaultInboundHandlerRegistry<Message>();
+    const handler = new RecordingHandler();
+
+    registry.register(handler);
+
+    assert.strictEqual(registry.resolve(handler.messageType), handler);
+    assert.deepStrictEqual(Array.from(registry.list()), [handler]);
+  });
+
+  it("unregisters handlers and returns undefined for unknown types", () => {
+    const registry = new DefaultInboundHandlerRegistry<Message>();
+    const handler = new RecordingHandler();
+
+    registry.register(handler);
+    registry.unregister(handler.messageType);
+
+    assert.strictEqual(registry.resolve(handler.messageType), undefined);
+    assert.deepStrictEqual(Array.from(registry.list()), []);
+  });
+});
+
+describe("InMemoryBus", () => {
+  it("dispatches messages synchronously to all subscribers", () => {
+    const bus = new InMemoryBus<string>();
+    const received: string[] = [];
+
+    bus.subscribe((message) => received.push(`first:${message}`));
+    bus.subscribe((message) => received.push(`second:${message}`));
+
+    bus.publish("payload");
+
+    assert.deepStrictEqual(received, ["first:payload", "second:payload"]);
+  });
+
+  it("dispatches inbound messages using registered handlers", () => {
+    const bus = new InMemoryBus<Message>();
+    const registry = new DefaultInboundHandlerRegistry<Message>();
+    const handler = new RecordingHandler();
+
+    registry.register(handler);
+
+    bus.subscribe((message) => {
+      const resolved = registry.resolve(message.type);
+      resolved?.handle(message);
+    });
+
+    const message: Message = {
+      type: handler.messageType,
+      payload: { value: 42 },
+    };
+
+    bus.publish(message);
+
+    assert.deepStrictEqual(handler.handled, [message]);
+  });
+});

--- a/workspaces/Describing_Simulation_0/tsconfig.json
+++ b/workspaces/Describing_Simulation_0/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "typeRoots": ["./types"],
+    "resolveJsonModule": true,
+    "lib": ["ES2020"],
+    "rootDir": ".",
+    "outDir": "dist",
+    "allowJs": false
+  },
+  "include": ["src", "tests"]
+}

--- a/workspaces/Describing_Simulation_0/types/node-assert-strict/index.d.ts
+++ b/workspaces/Describing_Simulation_0/types/node-assert-strict/index.d.ts
@@ -1,0 +1,13 @@
+declare module "node:assert/strict" {
+  function strictEqual(actual: unknown, expected: unknown, message?: string | Error): void;
+  function deepStrictEqual(actual: unknown, expected: unknown, message?: string | Error): void;
+
+  interface StrictAssert {
+    strictEqual: typeof strictEqual;
+    deepStrictEqual: typeof deepStrictEqual;
+  }
+
+  const assert: StrictAssert;
+  export { strictEqual, deepStrictEqual };
+  export default assert;
+}

--- a/workspaces/Describing_Simulation_0/types/node-test/index.d.ts
+++ b/workspaces/Describing_Simulation_0/types/node-test/index.d.ts
@@ -1,0 +1,26 @@
+declare module "node:test" {
+  interface TestContext {
+    readonly name?: string;
+    skip(message?: string): void;
+    todo(message?: string): void;
+  }
+
+  interface TestOptions {
+    readonly only?: boolean;
+    readonly skip?: boolean;
+    readonly todo?: boolean;
+    readonly timeout?: number;
+  }
+
+  type TestFn = (t: TestContext) => void | Promise<void>;
+
+  export function test(fn: TestFn): void;
+  export function test(name: string, fn: TestFn): void;
+  export function test(name: string, options: TestOptions, fn: TestFn): void;
+
+  export const it: typeof test;
+
+  export function describe(fn: TestFn): void;
+  export function describe(name: string, fn: TestFn): void;
+  export function describe(name: string, options: TestOptions, fn: TestFn): void;
+}


### PR DESCRIPTION
## Summary
- implement an in-memory bus that manages subscribers and publishes messages synchronously
- add a default inbound handler registry backed by a map of message types to handlers
- configure TypeScript/Node testing scaffolding and add unit tests covering registry usage and dispatch

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68c887dc0b58832a816e8257893963b8