### PR TITLE
Add repository guideposts and contributor conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# Repository Conventions
+
+These guidelines summarize working agreements for maintaining the Describing Simulation materials. They complement the framing
+in `Describing_Simulation_0.md` and its linked instruction documents.
+
+## File Naming
+- Use descriptive, lower-case names with underscores for Markdown files that explain simulation processes or repository guides.
+- Mirror section titles from the instruction documents when creating companion files so readers can navigate between summaries
+  and the source material.
+
+## Commit Scope
+- Group related documentation edits into a single commit to preserve traceable updates to specific concepts.
+- Avoid bundling unrelated refactors with instruction changes; open a dedicated commit if the instruction documents require a
+  structural reorganization.
+
+## Testing Expectations
+- This repository is documentation-focused; automated tests are not required.
+- Before committing, review Markdown for readability and ensure cross-links resolve to existing files in the repository.

--- a/Describing_Simulation_0.md
+++ b/Describing_Simulation_0.md
@@ -2,6 +2,11 @@
 
 The detailed instructions that previously lived in this document have been partitioned for easier reference. Each major section is now available in the `instruction_documents/` directory.
 
+## Repository Guideposts
+
+- Start with the high-level [index](index.md) for a summary of the repository's purpose and layout.
+- Review the contributor [conventions](AGENTS.md) before editing or extending any documentation.
+
 ## Instruction Documents
 
 - [Theory](instruction_documents/Describing_Simulation_0_theory.md)

--- a/index.md
+++ b/index.md
@@ -1,0 +1,13 @@
+# Repository Overview
+
+## Purpose
+This repository curates the "Describing Simulation" materials that outline a methodology for translating natural language hypotheticals into executable simulations. The documents capture theoretical framing, codification practices, and supporting prompts for agents tasked with simulation design.
+
+## Directory Layout
+- `Describing_Simulation_0.md`: Entry point that introduces the Describing Simulation manuscript and links to the detailed instruction documents.
+- `index.md`: High-level orientation document (this file).
+- `AGENTS.md`: Working conventions for contributors updating these materials.
+- `instruction_documents/`: Location referenced by the main manuscript for sectioned instruction files (consult upstream sources if the directory is omitted in a given checkout).
+
+## Next Steps
+For a full dive into the framework, continue with [`Describing_Simulation_0.md`](Describing_Simulation_0.md).


### PR DESCRIPTION
## Summary
- add a repository index that introduces the documentation and explains the layout
- document contributor conventions in AGENTS.md to clarify naming, commit scope, and testing expectations
- link to the new index and conventions from the main Describing Simulation manuscript for discoverability

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68c8b03e6f04832aab8dbca6588fd113