### PR TITLE
Add root AGENTS guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Repository Contribution Guidance
+
+- Always review `instruction_documents/index.md` for the latest repository instructions before making any changes or submitting contributions.
+
+## Key Directories
+
+All directories listed below are located at the root of this repository:
+
+- **Workspaces**: `workspaces/` — active implementation efforts for the current revision belong here.
+- **Tools**: `tools/` — scripts and automation utilities live here for reuse.
+- **Memory**: `memory/` — contains long-term guidance in `memory/ways/` and short-term records in `memory/records/`.
+- **Verifications**: `verifications/` — outputs from validation and test runs should be stored here.
+
+Keep this document visible to ensure every contributor follows the same entry point into the instruction set and repository layout.


### PR DESCRIPTION
## Summary
- add a root AGENTS.md so contributors see the repository entry point
- document the locations of workspace, tools, memory, and verification directories and point to instruction_documents/index.md

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c8b894aa38832a82f79aa309767337