### PR TITLE
Implement ECS system lifecycle and time tracking

### DIFF
--- a/project/src/ecs/components/implementations/TimeComponent.ts
+++ b/project/src/ecs/components/implementations/TimeComponent.ts
@@ -1,0 +1,3 @@
+export class TimeComponent {
+  constructor(public ticks: number = 0) {}
+}

--- a/project/src/ecs/systems/System.ts
+++ b/project/src/ecs/systems/System.ts
@@ -1,0 +1,16 @@
+export interface System {
+  /**
+   * Set up any state, entities, or components required by the system.
+   */
+  init(): void;
+
+  /**
+   * Execute one update tick of the system.
+   */
+  update(): void;
+
+  /**
+   * Clean up any resources owned by the system.
+   */
+  destroy(): void;
+}

--- a/project/src/ecs/systems/SystemManager.ts
+++ b/project/src/ecs/systems/SystemManager.ts
@@ -1,0 +1,60 @@
+import { System } from './System';
+
+type RegisteredSystem = {
+  system: System;
+  order: number;
+  initialized: boolean;
+};
+
+export class SystemManager {
+  private systems: RegisteredSystem[] = [];
+
+  register(system: System, order = 0): void {
+    if (this.systems.some((entry) => entry.system === system)) {
+      throw new Error('System is already registered.');
+    }
+
+    this.systems.push({ system, order, initialized: false });
+    this.systems.sort((a, b) => a.order - b.order);
+  }
+
+  initAll(): void {
+    for (const entry of this.systems) {
+      if (!entry.initialized) {
+        entry.system.init();
+        entry.initialized = true;
+      }
+    }
+  }
+
+  updateAll(): void {
+    for (const entry of this.systems) {
+      if (!entry.initialized) {
+        entry.system.init();
+        entry.initialized = true;
+      }
+
+      entry.system.update();
+    }
+  }
+
+  destroyAll(): void {
+    for (let index = this.systems.length - 1; index >= 0; index -= 1) {
+      const entry = this.systems[index];
+
+      if (entry.initialized) {
+        entry.system.destroy();
+        entry.initialized = false;
+      }
+    }
+  }
+
+  clear(): void {
+    this.destroyAll();
+    this.systems = [];
+  }
+
+  getRegisteredSystems(): ReadonlyArray<System> {
+    return this.systems.map((entry) => entry.system);
+  }
+}

--- a/project/src/ecs/systems/implementations/TimeSystem.ts
+++ b/project/src/ecs/systems/implementations/TimeSystem.ts
@@ -1,0 +1,62 @@
+import { TimeComponent } from '../../components/implementations/TimeComponent';
+import { System } from '../System';
+
+export class TimeSystem implements System {
+  private nextEntityId = 0;
+  private timeEntityId: number | null = null;
+  private readonly timeComponents = new Map<number, TimeComponent>();
+
+  init(): void {
+    if (this.timeEntityId !== null) {
+      return;
+    }
+
+    const entityId = this.allocateEntity();
+    this.timeComponents.set(entityId, new TimeComponent());
+    this.timeEntityId = entityId;
+  }
+
+  update(): void {
+    if (this.timeEntityId === null) {
+      this.init();
+    }
+
+    const component =
+      this.timeEntityId !== null
+        ? this.timeComponents.get(this.timeEntityId)
+        : undefined;
+
+    if (!component) {
+      throw new Error('Time entity has not been initialized.');
+    }
+
+    component.ticks += 1;
+  }
+
+  destroy(): void {
+    if (this.timeEntityId === null) {
+      return;
+    }
+
+    this.timeComponents.delete(this.timeEntityId);
+    this.timeEntityId = null;
+  }
+
+  getTimeEntityId(): number | null {
+    return this.timeEntityId;
+  }
+
+  getTimeComponent(): TimeComponent | undefined {
+    if (this.timeEntityId === null) {
+      return undefined;
+    }
+
+    return this.timeComponents.get(this.timeEntityId);
+  }
+
+  private allocateEntity(): number {
+    const id = this.nextEntityId;
+    this.nextEntityId += 1;
+    return id;
+  }
+}

--- a/project/tests/ecs/systems/TimeSystem.test.ts
+++ b/project/tests/ecs/systems/TimeSystem.test.ts
@@ -1,0 +1,19 @@
+// describe('TimeSystem', () => {
+//   it('creates a dedicated time entity with an initial tick count of zero during initialization', () => {
+//     // Arrange: instantiate a TimeSystem.
+//     // Act: call init.
+//     // Assert: an entity id is assigned and the related TimeComponent reports zero ticks.
+//   });
+//
+//   it('increments the stored tick count on each update cycle', () => {
+//     // Arrange: instantiate a TimeSystem and initialize it.
+//     // Act: call update multiple times.
+//     // Assert: the TimeComponent ticks property increases by one for every update call.
+//   });
+//
+//   it('lazily creates the time entity when update is called before init', () => {
+//     // Arrange: instantiate a TimeSystem without calling init explicitly.
+//     // Act: call update.
+//     // Assert: the system should auto-initialize, create the entity, and increment ticks to one.
+//   });
+// });


### PR DESCRIPTION
## Summary
- add a `System` interface that defines init, update, and destroy hooks
- implement a `SystemManager` capable of ordering systems and running their lifecycle methods
- introduce a `TimeComponent` and `TimeSystem` that create a time-tracking entity and increment its ticks each update
- capture comment-only tests describing the expected initialization and update flow for the `TimeSystem`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8bac49d30832a8040489498d9c80f