### PR TITLE
Document tools directory and add bootstrap stub

### DIFF
--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Bootstrap script for setting up the local development environment.
+# TODO: Populate this script with dependency installation and setup steps.
+
+set -euo pipefail
+
+echo "[bootstrap] Environment bootstrap steps are not yet implemented."

--- a/tools/index.md
+++ b/tools/index.md
@@ -1,0 +1,27 @@
+# Tools Directory
+
+## Purpose
+
+The `tools` directory centralizes helper scripts that support development,
+validation, and operational workflows for this repository. Use this space to
+capture automation that developers can run locally or in CI to set up the
+project, manage dependencies, or perform routine maintenance.
+
+## Available Scripts
+
+### `bootstrap.sh`
+
+A placeholder Bash script intended to orchestrate environment bootstrap tasks
+(e.g., installing dependencies or preparing configuration files). The script
+currently acts as documentation only and prints a notice while the concrete
+steps are defined.
+
+```
+./bootstrap.sh
+```
+
+## Planned Utilities
+
+Additional helper scripts should be added here as the project matures. When a
+new script is introduced, document its purpose, usage, and any prerequisites in
+this index to keep contributors aligned on available tooling.


### PR DESCRIPTION
## Summary
- add an index describing the purpose of the `tools` directory and how to document helper scripts
- add a stubbed `bootstrap.sh` script that currently only reports its unimplemented state

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68c8bef83c60832a93f3e77b603ca9d5