### PR TITLE
Document memory contribution conventions

### DIFF
--- a/memory/README.md
+++ b/memory/README.md
@@ -1,1 +1,43 @@
-Placeholder for memory-related data.
+# Memory Knowledge Base
+
+The `memory/` directory is the shared knowledge base for Simulation 0. It preserves
+context that outlives a single coding task and keeps the reasoning trail behind
+implementation decisions accessible to future contributors.
+
+## Directory layout
+
+- `ways/` &mdash; long-lived heuristics, principles, and "rules of thumb" that have
+  proven useful and should guide future work.
+- `records/` &mdash; timestamped progress notes that document the current state of a
+  task, research session, or investigation.
+
+## Authoring flow
+
+1. Capture day-to-day discoveries, open questions, and decisions inside a new
+   record under `records/`.
+2. When a pattern keeps reappearing or a record establishes a durable lesson,
+   promote it into a dedicated way under `ways/` and link the source records.
+3. Update existing entries as understanding evolves so the most recent
+   perspective is always obvious to the next reader.
+
+## Naming conventions
+
+- All entries use Markdown (`.md`).
+- Ways use short, descriptive, kebab-case filenames that identify the enduring
+  principle (for example, `api-contract-triage.md`).
+- Records are timestamped using `YYYY-MM-DD--HHMM-topic.md` so that chronological
+  sorting matches the git history (for example, `2024-05-12--1430-schema-sync.md`).
+
+## Write and delete policies
+
+- Prefer editing an existing file over creating duplicates for the same topic;
+  summarize what changed in a dedicated *Revision History* section inside the
+  file.
+- Do not delete ways or records once published. If guidance becomes obsolete,
+  mark it as `Deprecated` inside the document and explain the replacement.
+- Corrections should be added as follow-up entries instead of amending past
+  statements. Use inline notes such as `**Update (2024-05-12):** …` so the
+  evolution remains visible.
+
+Refer to the READMEs in `ways/` and `records/` for templates that illustrate how
+individual entries should be structured.

--- a/memory/records/README.md
+++ b/memory/records/README.md
@@ -1,1 +1,53 @@
-Placeholder for memory record storage.
+# Records Directory
+
+The `records/` folder stores chronological notes about active work, research
+threads, and short-term decisions. Treat each record as a snapshot of what was
+known at a specific moment so future contributors can reconstruct the context of
+past changes.
+
+## When to create a record
+
+- Log the start and end of focused work sessions, experiments, or meetings.
+- Capture unanswered questions and link them to follow-up issues or commits.
+- Summarize any decision that might influence future work, even if it feels
+  provisional.
+
+## File naming conventions
+
+- Name records using `YYYY-MM-DD--HHMM-topic.md`. The timestamp should be in
+  24-hour time and reflect when the note was created or the session ended.
+- Keep the topic slug short, lowercase, and hyphen-separated (for example,
+  `2024-05-12--1430-schema-sync.md`).
+- If multiple notes are created in the same minute, append a differentiator such
+  as `-a`, `-b`, etc. (for example, `2024-05-12--1430-schema-sync-b.md`).
+
+## Recommended structure
+
+Author each record in Markdown using the template below. Replace placeholders in
+angle brackets before committing the file.
+
+```markdown
+# <YYYY-MM-DD HH:MM> <Short description>
+- **Author:** <Name or GitHub handle>
+- **Related ways:** [way-title](../ways/way-title.md) (optional)
+- **Linked work:** PR #, issue, or commit reference (optional)
+
+## Context
+Briefly explain what prompted the work or investigation.
+
+## Findings
+- Bullet the key observations, decisions, or blockers.
+
+## Next steps
+- Enumerate follow-up actions or questions.
+```
+
+## Writing and deletion policy
+
+- Append updates by creating new records rather than editing past ones; if you
+  must clarify a previous entry, add an **Update** subsection with the current
+  date.
+- Never delete records. If a note was created by mistake, add a short correction
+  at the top explaining why it is no longer relevant.
+- Link forward whenever possible so readers can follow the trail into commits,
+  issues, or newer records.

--- a/memory/ways/README.md
+++ b/memory/ways/README.md
@@ -1,1 +1,54 @@
-Placeholder for memory way definitions.
+# Ways Directory
+
+The `ways/` folder captures durable heuristics and operating principles that
+should guide future contributors. Each file distills a lesson that has matured
+beyond a single task or experiment.
+
+## When to create or update a way
+
+- Promote a concept from `memory/records/` once it has proven reliable across
+  multiple records or decisions.
+- Update an existing way whenever the guidance changes. Add a dated note to the
+  *Revision History* section instead of rewriting the past.
+- Only mark a way as deprecated when it actively conflicts with current
+  practices; leave the document in place with a pointer to the successor.
+
+## File naming conventions
+
+- Use lowercase, kebab-case filenames that summarize the principle, such as
+  `structured-playbook-updates.md` or `api-compatibility-checklist.md`.
+- Avoid timestamps in the filename; the guidance should be timeless. Track
+  creation dates inside the file instead.
+
+## Recommended structure
+
+Author each way in Markdown using the template below. Replace the placeholders
+in angle brackets with the appropriate content.
+
+```markdown
+# <Concise way title>
+- **Status:** Active | Reviewing | Deprecated
+- **Created:** YYYY-MM-DD
+- **Source records:** [YYYY-MM-DD--HHMM-topic](../records/YYYY-MM-DD--HHMM-topic.md)
+- **Last reviewed:** YYYY-MM-DD
+
+## Guidance
+- Key instruction or principle.
+- Additional clarifications that keep future work aligned.
+
+## Signals
+- Evidence that tells a contributor when this way applies.
+- Warning signs that a different approach is required.
+
+## Revision history
+- YYYY-MM-DD — Summary of what changed and why.
+```
+
+## Writing and deletion policy
+
+- Keep ways succinct and actionable; link to deeper research or rationale if
+  needed, but avoid duplicating entire records.
+- Never delete a way outright. If a principle is replaced, update the **Status**
+  to `Deprecated` and reference the document that supersedes it.
+- When editing, explain the reason for the change in the **Revision history**
+  section so readers can track the evolution at a glance.


### PR DESCRIPTION
## Summary
- expand `memory/README.md` with directory purpose, contribution flow, and file naming policies
- document how to author long-lived "ways" including template, naming, and retention guidance
- document how to capture timestamped "records" with structure, naming, and retention rules

## Testing
- ./checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68c8c1d9eb58832aba35946022b8e2e9