### PR TITLE
Add ECS scaffolding placeholders

### DIFF
--- a/workspaces/Describing_Simulation_0/project/src/ecs/components/ComponentManager.ts
+++ b/workspaces/Describing_Simulation_0/project/src/ecs/components/ComponentManager.ts
@@ -1,0 +1,4 @@
+// Oversees storage and retrieval of component instances across entities.
+export class ComponentManager {
+  // This manager will coordinate component registration, updates, and lookups.
+}

--- a/workspaces/Describing_Simulation_0/project/src/ecs/components/ComponentType.ts
+++ b/workspaces/Describing_Simulation_0/project/src/ecs/components/ComponentType.ts
@@ -1,0 +1,4 @@
+// Describes the metadata and construction contract for a component kind.
+export interface ComponentType<T = unknown> {
+  // Implementations will expose identifiers and factory helpers for components of type T.
+}

--- a/workspaces/Describing_Simulation_0/project/src/ecs/entity/Entity.ts
+++ b/workspaces/Describing_Simulation_0/project/src/ecs/entity/Entity.ts
@@ -1,0 +1,4 @@
+// Represents a unique object within the ECS world.
+export class Entity {
+  // This class will encapsulate an entity identifier and component bookkeeping.
+}

--- a/workspaces/Describing_Simulation_0/project/src/ecs/entity/EntityManager.ts
+++ b/workspaces/Describing_Simulation_0/project/src/ecs/entity/EntityManager.ts
@@ -1,0 +1,4 @@
+// Coordinates creation, destruction, and lookup of entities.
+export class EntityManager {
+  // This manager will maintain entity lifecycles and provide query utilities.
+}

--- a/workspaces/Describing_Simulation_0/project/tests/ecs/ComponentManager.test.ts
+++ b/workspaces/Describing_Simulation_0/project/tests/ecs/ComponentManager.test.ts
@@ -1,0 +1,3 @@
+// Test intents for ComponentManager primitive.
+// - Verify registration of component types enables entity attachment.
+// - Confirm component updates propagate to the correct entity records.

--- a/workspaces/Describing_Simulation_0/project/tests/ecs/ComponentType.test.ts
+++ b/workspaces/Describing_Simulation_0/project/tests/ecs/ComponentType.test.ts
@@ -1,0 +1,3 @@
+// Test intents for ComponentType primitive.
+// - Validate component type metadata describes schema and defaults.
+// - Ensure factory logic produces component instances with expected shape.

--- a/workspaces/Describing_Simulation_0/project/tests/ecs/Entity.test.ts
+++ b/workspaces/Describing_Simulation_0/project/tests/ecs/Entity.test.ts
@@ -1,0 +1,3 @@
+// Test intents for Entity primitive.
+// - Validate creation of unique entity identifiers.
+// - Verify component associations can be enumerated per entity.

--- a/workspaces/Describing_Simulation_0/project/tests/ecs/EntityManager.test.ts
+++ b/workspaces/Describing_Simulation_0/project/tests/ecs/EntityManager.test.ts
@@ -1,0 +1,3 @@
+// Test intents for EntityManager primitive.
+// - Ensure entities can be created and destroyed in order.
+// - Confirm lookup helpers return expected entity handles.


### PR DESCRIPTION
## Summary
- create initial ECS entity and component scaffolding with placeholder exports
- document intended responsibilities for each primitive via inline comments
- add comment-only test intent files covering the new ECS scaffolding

## Testing
- ./checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68c8cdf9c02c832aa9ef255876473052