### PR TITLE
Add ComponentType metadata tests and builder

### DIFF
--- a/memory/records/2025-09-16--0315-component-type-tests.md
+++ b/memory/records/2025-09-16--0315-component-type-tests.md
@@ -1,0 +1,16 @@
+# 2025-09-16 03:15 ComponentType test coverage
+- **Author:** ChatGPT
+- **Related ways:**
+- **Linked work:**
+
+## Context
+Converted the ComponentType test intents into executable Vitest suites to check the metadata contract and factory behavior for ECS components.
+
+## Findings
+- Added concrete tests that assert the component schema metadata exposes descriptions and default values for each field.
+- Exercised a component factory helper to confirm it merges defaults with overrides without mutating stored defaults.
+- Introduced the initial ComponentType builder implementation so the new tests have a subject under test.
+
+## Next steps
+- Extend the remaining ECS primitives with similar test coverage as their intents are codified.
+- Flesh out ComponentManager and Entity primitives so they satisfy future tests driven by the new contract.

--- a/workspaces/Describing_Simulation_0/project/src/ecs/components/ComponentType.ts
+++ b/workspaces/Describing_Simulation_0/project/src/ecs/components/ComponentType.ts
@@ -1,4 +1,62 @@
 // Describes the metadata and construction contract for a component kind.
-export interface ComponentType<T = unknown> {
-  // Implementations will expose identifiers and factory helpers for components of type T.
+
+export type ComponentFieldDefinition<TValue> = {
+  description: string;
+  defaultValue: TValue;
+};
+
+export type ComponentSchema<TComponent> = {
+  [K in keyof TComponent]-?: ComponentFieldDefinition<TComponent[K]>;
+};
+
+export interface ComponentTypeMetadata<TComponent> {
+  id: string;
+  name: string;
+  description: string;
+  schema: ComponentSchema<TComponent>;
+  defaults: TComponent;
+}
+
+export interface ComponentTypeConfig<TComponent> {
+  id: string;
+  name: string;
+  description: string;
+  schema: ComponentSchema<TComponent>;
+}
+
+export interface ComponentType<TComponent = unknown> {
+  id: string;
+  metadata: ComponentTypeMetadata<TComponent>;
+  create(overrides?: Partial<TComponent>): TComponent;
+}
+
+export function createComponentType<TComponent>(
+  config: ComponentTypeConfig<TComponent>,
+): ComponentType<TComponent> {
+  const defaults = Object.keys(config.schema).reduce((accumulator, key) => {
+    const typedKey = key as keyof TComponent;
+    const field = config.schema[typedKey];
+
+    accumulator[typedKey] = field.defaultValue;
+    return accumulator;
+  }, {} as TComponent);
+
+  const metadata: ComponentTypeMetadata<TComponent> = {
+    id: config.id,
+    name: config.name,
+    description: config.description,
+    schema: config.schema,
+    defaults,
+  };
+
+  return {
+    id: config.id,
+    metadata,
+    create(overrides) {
+      return {
+        ...metadata.defaults,
+        ...(overrides ?? {}),
+      };
+    },
+  };
 }

--- a/workspaces/Describing_Simulation_0/project/tests/ecs/ComponentType.test.ts
+++ b/workspaces/Describing_Simulation_0/project/tests/ecs/ComponentType.test.ts
@@ -1,3 +1,71 @@
-// Test intents for ComponentType primitive.
-// - Validate component type metadata describes schema and defaults.
-// - Ensure factory logic produces component instances with expected shape.
+import { describe, expect, it } from 'vitest';
+
+import {
+  createComponentType,
+  type ComponentSchema,
+} from '../../src/ecs/components/ComponentType.js';
+
+describe('ComponentType', () => {
+  interface TimeComponent {
+    ticks: number;
+    deltaPerUpdate: number;
+  }
+
+  const timeSchema = {
+    ticks: {
+      description: 'Total elapsed ticks since the simulation began.',
+      defaultValue: 0,
+    },
+    deltaPerUpdate: {
+      description: 'How many ticks to advance on each update step.',
+      defaultValue: 1,
+    },
+  } satisfies ComponentSchema<TimeComponent>;
+
+  const timeDescriptor = createComponentType<TimeComponent>({
+    id: 'time',
+    name: 'Time',
+    description: 'Tracks the advancement of simulated time.',
+    schema: timeSchema,
+  });
+
+  it('describes component schema fields and default values through metadata', () => {
+    expect(timeDescriptor.metadata).toMatchObject({
+      id: 'time',
+      name: 'Time',
+      description: 'Tracks the advancement of simulated time.',
+    });
+    expect(timeDescriptor.metadata.schema).toStrictEqual(timeSchema);
+    expect(timeDescriptor.metadata.defaults).toStrictEqual({
+      ticks: 0,
+      deltaPerUpdate: 1,
+    });
+  });
+
+  it('creates component instances by merging defaults with provided overrides', () => {
+    const defaultInstance = timeDescriptor.create();
+    expect(defaultInstance).toStrictEqual({
+      ticks: 0,
+      deltaPerUpdate: 1,
+    });
+
+    const overriddenInstance = timeDescriptor.create({ ticks: 5 });
+    expect(overriddenInstance).toStrictEqual({
+      ticks: 5,
+      deltaPerUpdate: 1,
+    });
+    expect(overriddenInstance).not.toBe(timeDescriptor.metadata.defaults);
+
+    const deltaOnlyInstance = timeDescriptor.create({ deltaPerUpdate: 3 });
+    expect(deltaOnlyInstance).toStrictEqual({
+      ticks: 0,
+      deltaPerUpdate: 3,
+    });
+
+    // Ensure defaults remain unchanged after creating new instances.
+    expect(timeDescriptor.metadata.defaults).toStrictEqual({
+      ticks: 0,
+      deltaPerUpdate: 1,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- codify the ComponentType contract with schema metadata, defaults, and a factory helper
- implement Vitest coverage that validates metadata shape and factory behavior
- log the work session in a new memory record

## Testing
- npm test
- ./checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68c8d3f99fa8832a8bf9bc9f92dd0491