### PR TITLE
Add entity tests for identifiers and enumeration

### DIFF
--- a/memory/records/2025-09-16--0348-entity-tests.md
+++ b/memory/records/2025-09-16--0348-entity-tests.md
@@ -1,0 +1,15 @@
+# 2025-09-16 03:48 Entity tests for unique IDs and enumeration
+- **Author:** ChatGPT
+- **Related ways:**
+- **Linked work:**
+
+## Context
+Codified the outstanding Entity test intents by translating the notes into executable Vitest coverage. Implemented the Entity primitive so the new tests exercise concrete behavior instead of documentation-only placeholders.
+
+## Findings
+- Added a static identifier allocator to `Entity` so each instantiation produces a distinct numeric handle.
+- Introduced enumeration helpers on `Entity` that delegate to the component manager, enabling tests to inspect attached components without bypassing the abstraction.
+- Extended the test suite to attach multiple component types and confirm only the owning entity reports them during enumeration.
+
+## Next steps
+- Flesh out the EntityManager contract to coordinate lifecycle operations and propagate component cleanup when entities are destroyed.

--- a/workspaces/Describing_Simulation_0/project/src/ecs/entity/Entity.ts
+++ b/workspaces/Describing_Simulation_0/project/src/ecs/entity/Entity.ts
@@ -1,4 +1,61 @@
+import type { ComponentManager } from '../components/ComponentManager.js';
+import type { ComponentType } from '../components/ComponentType.js';
+
+export type EntityComponentAssociation = {
+  type: ComponentType<unknown>;
+  instance: unknown;
+};
+
 // Represents a unique object within the ECS world.
 export class Entity {
-  // This class will encapsulate an entity identifier and component bookkeeping.
+  private static nextId = 1;
+
+  readonly id: number;
+
+  constructor(existingId?: number) {
+    if (existingId !== undefined) {
+      this.id = existingId;
+      if (existingId >= Entity.nextId) {
+        Entity.nextId = existingId + 1;
+      }
+      return;
+    }
+
+    this.id = Entity.nextId;
+    Entity.nextId += 1;
+  }
+
+  enumerateComponents(componentManager: ComponentManager): EntityComponentAssociation[] {
+    const components = componentManager.getComponents(this.id);
+    const associations: EntityComponentAssociation[] = [];
+
+    for (const [type, instance] of components.entries()) {
+      associations.push({
+        type,
+        instance,
+      });
+    }
+
+    return associations;
+  }
+
+  attachComponent<T>(
+    componentManager: ComponentManager,
+    type: ComponentType<T>,
+    initial?: Partial<T>,
+  ): T {
+    return componentManager.attachComponent(this.id, type, initial);
+  }
+
+  getComponent<T>(componentManager: ComponentManager, type: ComponentType<T>): T | undefined {
+    return componentManager.getComponent(this.id, type);
+  }
+
+  removeComponent<T>(componentManager: ComponentManager, type: ComponentType<T>): boolean {
+    return componentManager.removeComponent(this.id, type);
+  }
+
+  removeAllComponents(componentManager: ComponentManager): void {
+    componentManager.removeAllComponents(this.id);
+  }
 }

--- a/workspaces/Describing_Simulation_0/project/tests/ecs/Entity.test.ts
+++ b/workspaces/Describing_Simulation_0/project/tests/ecs/Entity.test.ts
@@ -1,3 +1,83 @@
-// Test intents for Entity primitive.
-// - Validate creation of unique entity identifiers.
-// - Verify component associations can be enumerated per entity.
+import { describe, expect, it } from 'vitest';
+
+import { Entity } from '../../src/ecs/entity/Entity.js';
+import { ComponentManager } from '../../src/ecs/components/ComponentManager.js';
+import { createComponentType } from '../../src/ecs/components/ComponentType.js';
+
+describe('Entity', () => {
+  it('assigns unique identifiers to each created instance', () => {
+    const entities = Array.from({ length: 50 }, () => new Entity());
+    const identifiers = entities.map((entity) => entity.id);
+
+    expect(new Set(identifiers).size).toBe(identifiers.length);
+  });
+
+  it('enumerates the components associated with the entity', () => {
+    const componentManager = new ComponentManager();
+    const entity = new Entity();
+    const otherEntity = new Entity();
+
+    type PositionComponent = { x: number; y: number };
+    type VelocityComponent = { dx: number; dy: number };
+
+    const positionType = createComponentType<PositionComponent>({
+      id: 'position',
+      name: 'Position',
+      description: 'Tracks spatial coordinates for an entity.',
+      schema: {
+        x: {
+          description: 'Horizontal position',
+          defaultValue: 0,
+        },
+        y: {
+          description: 'Vertical position',
+          defaultValue: 0,
+        },
+      },
+    });
+
+    const velocityType = createComponentType<VelocityComponent>({
+      id: 'velocity',
+      name: 'Velocity',
+      description: 'Tracks how position changes each tick.',
+      schema: {
+        dx: {
+          description: 'Horizontal velocity',
+          defaultValue: 0,
+        },
+        dy: {
+          description: 'Vertical velocity',
+          defaultValue: 0,
+        },
+      },
+    });
+
+    componentManager.registerType(positionType);
+    componentManager.registerType(velocityType);
+
+    const position = componentManager.attachComponent(entity.id, positionType, {
+      x: 12,
+      y: -7,
+    });
+    const velocity = componentManager.attachComponent(entity.id, velocityType);
+
+    const otherVelocity = componentManager.attachComponent(otherEntity.id, velocityType, {
+      dx: 4,
+      dy: -1,
+    });
+
+    const associations = entity.enumerateComponents(componentManager);
+
+    expect(associations).toHaveLength(2);
+    expect(associations).toEqual(
+      expect.arrayContaining([
+        { type: positionType, instance: position },
+        { type: velocityType, instance: velocity },
+      ]),
+    );
+    expect(associations).not.toContainEqual({
+      type: velocityType,
+      instance: otherVelocity,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- translate the Entity test comments into executable Vitest coverage for unique IDs and component enumeration
- implement the Entity helper methods to allocate identifiers and enumerate attached components through the manager
- document the work in a new memory record entry

## Testing
- npm test (workspaces/Describing_Simulation_0/project)
- ./checks.sh


------
https://chatgpt.com/codex/tasks/task_e_68c8dc3ceef4832a9d72f06fcca3258f