### PR TITLE
Add EntityManager lifecycle tests and implementation

### DIFF
--- a/memory/records/2025-09-16--0401-entity-manager-tests.md
+++ b/memory/records/2025-09-16--0401-entity-manager-tests.md
@@ -1,0 +1,15 @@
+# 2025-09-16 04:01 EntityManager tests and lifecycle implementation
+- **Author:** ChatGPT
+- **Related ways:**
+- **Linked work:**
+
+## Context
+Turned the remaining EntityManager test notes into executable coverage and filled in the manager so the suite describes concrete behavior.
+
+## Findings
+- Added Vitest coverage that exercises entity creation order, destruction semantics, and the component cleanup contract.
+- Implemented the EntityManager with create, destroy, and lookup helpers that delegate component removal to the ComponentManager.
+- Installed project dependencies and ran `npm test` to confirm all suites pass under the new coverage.
+
+## Next steps
+- Extend the manager with orchestration helpers once system-level requirements arrive.

--- a/workspaces/Describing_Simulation_0/project/src/ecs/entity/EntityManager.ts
+++ b/workspaces/Describing_Simulation_0/project/src/ecs/entity/EntityManager.ts
@@ -1,4 +1,67 @@
+import { Entity } from './Entity.js';
+import type { ComponentManager } from '../components/ComponentManager.js';
+
 // Coordinates creation, destruction, and lookup of entities.
 export class EntityManager {
-  // This manager will maintain entity lifecycles and provide query utilities.
+  private componentManager?: ComponentManager;
+  private readonly entities = new Map<number, Entity>();
+
+  constructor(componentManager?: ComponentManager) {
+    this.componentManager = componentManager;
+  }
+
+  setComponentManager(componentManager: ComponentManager): void {
+    this.componentManager = componentManager;
+  }
+
+  create(existingId?: number): Entity {
+    const entity = new Entity(existingId);
+
+    if (this.entities.has(entity.id)) {
+      throw new Error(`Entity ${entity.id} is already managed`);
+    }
+
+    this.entities.set(entity.id, entity);
+    return entity;
+  }
+
+  has(entityId: number): boolean {
+    return this.entities.has(entityId);
+  }
+
+  get(entityId: number): Entity | undefined {
+    return this.entities.get(entityId);
+  }
+
+  require(entityId: number): Entity {
+    const entity = this.get(entityId);
+
+    if (!entity) {
+      throw new Error(`Entity ${entityId} is not managed by this EntityManager`);
+    }
+
+    return entity;
+  }
+
+  getAll(): Entity[] {
+    return Array.from(this.entities.values());
+  }
+
+  destroy(target: number | Entity): boolean {
+    const entityId = typeof target === 'number' ? target : target.id;
+
+    if (!this.entities.has(entityId)) {
+      return false;
+    }
+
+    this.componentManager?.removeAllComponents(entityId);
+    this.entities.delete(entityId);
+    return true;
+  }
+
+  destroyAll(): void {
+    for (const entityId of Array.from(this.entities.keys())) {
+      this.destroy(entityId);
+    }
+  }
 }

--- a/workspaces/Describing_Simulation_0/project/tests/ecs/EntityManager.test.ts
+++ b/workspaces/Describing_Simulation_0/project/tests/ecs/EntityManager.test.ts
@@ -1,3 +1,93 @@
-// Test intents for EntityManager primitive.
-// - Ensure entities can be created and destroyed in order.
-// - Confirm lookup helpers return expected entity handles.
+import { describe, expect, it, vi } from 'vitest';
+
+import { EntityManager } from '../../src/ecs/entity/EntityManager.js';
+import { ComponentManager } from '../../src/ecs/components/ComponentManager.js';
+import { createComponentType } from '../../src/ecs/components/ComponentType.js';
+
+type HealthComponent = {
+  value: number;
+};
+
+const healthType = createComponentType<HealthComponent>({
+  id: 'health',
+  name: 'Health',
+  description: 'Tracks the vitality of an entity.',
+  schema: {
+    value: {
+      description: 'Current hit points for the entity.',
+      defaultValue: 100,
+    },
+  },
+});
+
+describe('EntityManager', () => {
+  it('creates entities sequentially and tears them down in destruction order', () => {
+    const componentManager = new ComponentManager();
+    const entityManager = new EntityManager(componentManager);
+
+    componentManager.registerType(healthType);
+
+    const first = entityManager.create();
+    const second = entityManager.create();
+    const third = entityManager.create();
+
+    componentManager.attachComponent(first.id, healthType, { value: 80 });
+    componentManager.attachComponent(second.id, healthType);
+
+    expect(entityManager.getAll().map((entity) => entity.id)).toEqual([
+      first.id,
+      second.id,
+      third.id,
+    ]);
+
+    const cleanupSpy = vi.spyOn(componentManager, 'removeAllComponents');
+
+    try {
+      expect(entityManager.destroy(first)).toBe(true);
+      expect(cleanupSpy).toHaveBeenCalledWith(first.id);
+      expect(entityManager.getAll().map((entity) => entity.id)).toEqual([
+        second.id,
+        third.id,
+      ]);
+
+      expect(entityManager.destroy(second.id)).toBe(true);
+      expect(cleanupSpy).toHaveBeenCalledWith(second.id);
+      expect(entityManager.getAll().map((entity) => entity.id)).toEqual([third.id]);
+
+      expect(entityManager.destroy(third.id)).toBe(true);
+      expect(cleanupSpy).toHaveBeenCalledWith(third.id);
+      expect(entityManager.getAll()).toEqual([]);
+
+      cleanupSpy.mockClear();
+
+      expect(entityManager.destroy(third.id)).toBe(false);
+      expect(cleanupSpy).not.toHaveBeenCalled();
+    } finally {
+      cleanupSpy.mockRestore();
+    }
+  });
+
+  it('provides lookup helpers for entity handles', () => {
+    const manager = new EntityManager();
+
+    const created = manager.create();
+
+    expect(manager.getAll().map((entity) => entity.id)).toEqual([created.id]);
+    expect(manager.has(created.id)).toBe(true);
+    expect(manager.get(created.id)).toBe(created);
+    expect(manager.require(created.id)).toBe(created);
+
+    const missingId = created.id + 999;
+
+    expect(manager.has(missingId)).toBe(false);
+    expect(manager.get(missingId)).toBeUndefined();
+    expect(() => manager.require(missingId)).toThrowError(
+      `Entity ${missingId} is not managed by this EntityManager`,
+    );
+
+    manager.destroy(created.id);
+
+    expect(manager.has(created.id)).toBe(false);
+    expect(manager.getAll()).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- translate the EntityManager test intentions into Vitest coverage for lifecycle order and lookup helpers
- implement the EntityManager with creation, destruction, and lookup APIs that trigger component cleanup
- log the work session in a new memory record for future reference

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8df5ff3c4832ab4d327df21faf233