### PR TITLE
Add ECS system abstractions and manager tests

### DIFF
--- a/workspaces/Describing_Simulation_0/project/src/ecs/systems/System.ts
+++ b/workspaces/Describing_Simulation_0/project/src/ecs/systems/System.ts
@@ -1,0 +1,28 @@
+// Defines the contract for systems that participate in the ECS update loop.
+// Systems are executed sequentially by the SystemManager and may opt into
+// lifecycle hooks for setup and teardown.
+export type SystemLifecycleContext = {
+  // The total amount of simulated time that has elapsed in seconds.
+  elapsedTime: number;
+};
+
+export type SystemUpdateContext = SystemLifecycleContext & {
+  // The amount of simulated time that has progressed since the previous
+  // update call in seconds.
+  deltaTime: number;
+};
+
+export interface System {
+  // A unique identifier for the system within a SystemManager instance.
+  readonly id: string;
+
+  // Optional hook invoked before the update loop begins.
+  initialize?(context: SystemLifecycleContext): void | Promise<void>;
+
+  // Called every frame to advance the simulation.
+  update(context: SystemUpdateContext): void | Promise<void>;
+
+  // Optional hook invoked when the system is being removed or when the
+  // SystemManager is shutting down.
+  shutdown?(context: SystemLifecycleContext): void | Promise<void>;
+}

--- a/workspaces/Describing_Simulation_0/project/src/ecs/systems/SystemManager.ts
+++ b/workspaces/Describing_Simulation_0/project/src/ecs/systems/SystemManager.ts
@@ -1,0 +1,80 @@
+import type {
+  System,
+  SystemLifecycleContext,
+  SystemUpdateContext,
+} from './System.js';
+
+// Coordinates the execution of registered systems in a deterministic order.
+export class SystemManager {
+  private readonly systems: System[] = [];
+  private readonly systemsById = new Map<string, System>();
+  private elapsedTime = 0;
+
+  register(system: System): void {
+    if (this.systemsById.has(system.id)) {
+      throw new Error(`System with id "${system.id}" is already registered`);
+    }
+
+    this.systems.push(system);
+    this.systemsById.set(system.id, system);
+  }
+
+  has(systemId: string): boolean {
+    return this.systemsById.has(systemId);
+  }
+
+  get(systemId: string): System | undefined {
+    return this.systemsById.get(systemId);
+  }
+
+  getAll(): System[] {
+    return this.systems.slice();
+  }
+
+  getElapsedTime(): number {
+    return this.elapsedTime;
+  }
+
+  async initializeAll(): Promise<void> {
+    for (const system of this.systems) {
+      if (!system.initialize) {
+        continue;
+      }
+
+      const context: SystemLifecycleContext = {
+        elapsedTime: this.elapsedTime,
+      };
+      await system.initialize(context);
+    }
+  }
+
+  async shutdownAll(): Promise<void> {
+    for (const system of [...this.systems].reverse()) {
+      if (!system.shutdown) {
+        continue;
+      }
+
+      const context: SystemLifecycleContext = {
+        elapsedTime: this.elapsedTime,
+      };
+      await system.shutdown(context);
+    }
+  }
+
+  async update(deltaTime: number): Promise<void> {
+    if (deltaTime < 0) {
+      throw new Error('deltaTime must be a non-negative number');
+    }
+
+    this.elapsedTime += deltaTime;
+
+    for (const system of this.systems) {
+      const context: SystemUpdateContext = {
+        deltaTime,
+        elapsedTime: this.elapsedTime,
+      };
+
+      await system.update(context);
+    }
+  }
+}

--- a/workspaces/Describing_Simulation_0/project/src/ecs/systems/implementations/TimeSystem.ts
+++ b/workspaces/Describing_Simulation_0/project/src/ecs/systems/implementations/TimeSystem.ts
@@ -1,0 +1,32 @@
+import type { System, SystemUpdateContext } from '../System.js';
+
+// A minimal system that tracks how many update ticks have occurred.
+export class TimeSystem implements System {
+  readonly id: string;
+
+  private tickCount = 0;
+  private lastDeltaTime = 0;
+  private totalElapsedTime = 0;
+
+  constructor(id = 'time') {
+    this.id = id;
+  }
+
+  get ticks(): number {
+    return this.tickCount;
+  }
+
+  get deltaTime(): number {
+    return this.lastDeltaTime;
+  }
+
+  get elapsedTime(): number {
+    return this.totalElapsedTime;
+  }
+
+  update(context: SystemUpdateContext): void {
+    this.tickCount += 1;
+    this.lastDeltaTime = context.deltaTime;
+    this.totalElapsedTime = context.elapsedTime;
+  }
+}

--- a/workspaces/Describing_Simulation_0/project/tests/ecs/SystemManager.test.ts
+++ b/workspaces/Describing_Simulation_0/project/tests/ecs/SystemManager.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import { SystemManager } from '../../src/ecs/systems/SystemManager.js';
+import type { System, SystemUpdateContext } from '../../src/ecs/systems/System.js';
+
+const createSystem = (
+  id: string,
+  onUpdate: (context: SystemUpdateContext) => void,
+): System => ({
+  id,
+  update: onUpdate,
+});
+
+describe('SystemManager', () => {
+  it('registers systems and prevents duplicate identifiers', () => {
+    const manager = new SystemManager();
+
+    const alpha = createSystem('alpha', () => {});
+    manager.register(alpha);
+
+    expect(manager.has('alpha')).toBe(true);
+    expect(manager.get('alpha')).toBe(alpha);
+    expect(manager.getAll()).toEqual([alpha]);
+    expect(manager.getElapsedTime()).toBe(0);
+
+    const duplicate = createSystem('alpha', () => {});
+
+    expect(() => manager.register(duplicate)).toThrowError(
+      'System with id "alpha" is already registered',
+    );
+  });
+
+  it('executes systems sequentially while tracking elapsed time', async () => {
+    const manager = new SystemManager();
+    const executionOrder: string[] = [];
+    const contexts = new Map<string, SystemUpdateContext[]>();
+
+    const trackSystem = (id: string): System =>
+      createSystem(id, (context) => {
+        executionOrder.push(id);
+        const history = contexts.get(id) ?? [];
+        history.push({ ...context });
+        contexts.set(id, history);
+      });
+
+    manager.register(trackSystem('first'));
+    manager.register(trackSystem('second'));
+    manager.register(trackSystem('third'));
+
+    await manager.update(0.25);
+    await manager.update(0.5);
+
+    expect(executionOrder).toEqual([
+      'first',
+      'second',
+      'third',
+      'first',
+      'second',
+      'third',
+    ]);
+
+    expect(manager.getElapsedTime()).toBeCloseTo(0.75);
+
+    const firstContexts = contexts.get('first') ?? [];
+    const secondContexts = contexts.get('second') ?? [];
+    const thirdContexts = contexts.get('third') ?? [];
+
+    for (const history of [firstContexts, secondContexts, thirdContexts]) {
+      expect(history.map((entry) => entry.deltaTime)).toEqual([0.25, 0.5]);
+      expect(history.map((entry) => entry.elapsedTime)).toEqual([0.25, 0.75]);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- define ECS system interface and lifecycle/update context helpers
- implement a SystemManager that registers systems and executes them sequentially while tracking elapsed time
- add a stub TimeSystem implementation for ticking behavior and accompanying SystemManager tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8e309be90832aa2a430f6e107d507