### PR TITLE
Add ECS time component descriptor and tests

### DIFF
--- a/workspaces/Describing_Simulation_0/project/src/ecs/components/implementations/TimeComponent.ts
+++ b/workspaces/Describing_Simulation_0/project/src/ecs/components/implementations/TimeComponent.ts
@@ -1,0 +1,28 @@
+/**
+ * Component plugins extend the ECS by defining new descriptors with `createComponentType` and
+ * exporting them so hosts can register them through `ComponentManager.registerType` during
+ * initialization. Once registered, systems can depend on the component just like built-in
+ * descriptors declared in this directory.
+ */
+import { createComponentType } from '../ComponentType.js';
+
+export type TimeComponent = {
+  ticks: number;
+  deltaPerUpdate: number;
+};
+
+export const timeComponentType = createComponentType<TimeComponent>({
+  id: 'time',
+  name: 'Time',
+  description: 'Tracks the advancement of simulated time.',
+  schema: {
+    ticks: {
+      description: 'Total elapsed ticks since the simulation began.',
+      defaultValue: 0,
+    },
+    deltaPerUpdate: {
+      description: 'How many ticks to advance on each update step.',
+      defaultValue: 1,
+    },
+  },
+});

--- a/workspaces/Describing_Simulation_0/project/tests/ecs/TimeComponent.test.ts
+++ b/workspaces/Describing_Simulation_0/project/tests/ecs/TimeComponent.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { timeComponentType } from '../../src/ecs/components/implementations/TimeComponent.js';
+
+describe('TimeComponent', () => {
+  it('exposes metadata describing the component schema and defaults', () => {
+    expect(timeComponentType.metadata).toMatchObject({
+      id: 'time',
+      name: 'Time',
+      description: 'Tracks the advancement of simulated time.',
+    });
+
+    expect(timeComponentType.metadata.schema).toStrictEqual({
+      ticks: {
+        description: 'Total elapsed ticks since the simulation began.',
+        defaultValue: 0,
+      },
+      deltaPerUpdate: {
+        description: 'How many ticks to advance on each update step.',
+        defaultValue: 1,
+      },
+    });
+
+    expect(timeComponentType.metadata.defaults).toStrictEqual({
+      ticks: 0,
+      deltaPerUpdate: 1,
+    });
+  });
+
+  it('creates component instances while preserving defaults', () => {
+    expect(timeComponentType.create()).toStrictEqual({
+      ticks: 0,
+      deltaPerUpdate: 1,
+    });
+
+    const advanced = timeComponentType.create({ ticks: 12 });
+    expect(advanced).toStrictEqual({
+      ticks: 12,
+      deltaPerUpdate: 1,
+    });
+
+    expect(timeComponentType.metadata.defaults).toStrictEqual({
+      ticks: 0,
+      deltaPerUpdate: 1,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a time component descriptor that documents plugin registration expectations
- expose the time tracking schema and defaults for reuse across systems
- cover the descriptor with tests that assert metadata and default construction

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8e4ae82f4832a8352c1780fc7510c