### PR TITLE
Integrate TimeSystem with ECS managers

### DIFF
--- a/memory/records/2025-09-16--0534-time-system-integration.md
+++ b/memory/records/2025-09-16--0534-time-system-integration.md
@@ -1,0 +1,24 @@
+# 2025-09-16 05:34 Time system integration
+- **Author:** ChatGPT
+- **Related ways:**
+- **Linked work:**
+
+## Context
+Integrated the TimeSystem with the ECS managers so temporal state is persisted via
+a component rather than internal counters.
+
+## Findings
+- Updated the TimeSystem to depend on the shared EntityManager and
+  ComponentManager, creating a dedicated entity that carries the registered time
+  component.
+- Ensured each update step reads the component back and increments ticks by its
+  configured `deltaPerUpdate`, keeping the system's accessors in sync with ECS
+  state.
+- Added Vitest coverage validating that the entity/component are created during
+  construction and that ticks advance across multiple updates.
+
+## Next steps
+- Expand system coverage as additional simulation behaviors depend on shared
+  components.
+- Consider surfacing the time entity identifier for orchestration layers that
+  might need to reference it explicitly.

--- a/workspaces/Describing_Simulation_0/project/tests/ecs/TimeSystem.test.ts
+++ b/workspaces/Describing_Simulation_0/project/tests/ecs/TimeSystem.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import { ComponentManager } from '../../src/ecs/components/ComponentManager.js';
+import { timeComponentType } from '../../src/ecs/components/implementations/TimeComponent.js';
+import { EntityManager } from '../../src/ecs/entity/EntityManager.js';
+import { TimeSystem } from '../../src/ecs/systems/implementations/TimeSystem.js';
+
+const createManagers = () => {
+  const componentManager = new ComponentManager();
+  componentManager.registerType(timeComponentType);
+
+  const entityManager = new EntityManager(componentManager);
+  return { entityManager, componentManager };
+};
+
+describe('TimeSystem', () => {
+  it('creates an entity with an attached time component on construction', () => {
+    const { entityManager, componentManager } = createManagers();
+
+    const system = new TimeSystem(entityManager, componentManager);
+
+    const entitiesWithTime = componentManager.getEntitiesWith(timeComponentType);
+    expect(entitiesWithTime).toHaveLength(1);
+
+    const entityId = entitiesWithTime[0]!;
+    expect(entityManager.has(entityId)).toBe(true);
+
+    const timeComponent = componentManager.getComponent(entityId, timeComponentType);
+    expect(timeComponent).toStrictEqual({
+      ticks: 0,
+      deltaPerUpdate: 1,
+    });
+
+    expect(system.ticks).toBe(0);
+    expect(system.deltaTime).toBe(0);
+    expect(system.elapsedTime).toBe(0);
+  });
+
+  it('advances ticks using the time component configuration', () => {
+    const { entityManager, componentManager } = createManagers();
+
+    const system = new TimeSystem(entityManager, componentManager);
+    const entitiesWithTime = componentManager.getEntitiesWith(timeComponentType);
+    expect(entitiesWithTime).toHaveLength(1);
+    const entityId = entitiesWithTime[0]!;
+
+    componentManager.updateComponent(entityId, timeComponentType, {
+      deltaPerUpdate: 3,
+    });
+
+    system.update({
+      deltaTime: 0.5,
+      elapsedTime: 0.5,
+    });
+
+    expect(componentManager.getComponent(entityId, timeComponentType)).toStrictEqual({
+      ticks: 3,
+      deltaPerUpdate: 3,
+    });
+    expect(system.ticks).toBe(3);
+    expect(system.deltaTime).toBe(0.5);
+    expect(system.elapsedTime).toBe(0.5);
+
+    system.update({
+      deltaTime: 0.25,
+      elapsedTime: 0.75,
+    });
+
+    expect(componentManager.getComponent(entityId, timeComponentType)).toStrictEqual({
+      ticks: 6,
+      deltaPerUpdate: 3,
+    });
+    expect(system.ticks).toBe(6);
+    expect(system.deltaTime).toBe(0.25);
+    expect(system.elapsedTime).toBe(0.75);
+  });
+});


### PR DESCRIPTION
## Summary
- update TimeSystem to manage the shared time component via the entity and component managers
- add TimeSystem vitest coverage for entity creation and tick advancement
- capture the integration work in a new memory record entry

## Testing
- ./checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68c8f5112148832a86aa5bc4088afef4