### PR TITLE
Add destroyAll coverage for EntityManager

### DIFF
--- a/workspaces/Describing_Simulation_0/project/tests/ecs/EntityManager.test.ts
+++ b/workspaces/Describing_Simulation_0/project/tests/ecs/EntityManager.test.ts
@@ -90,4 +90,38 @@ describe('EntityManager', () => {
     expect(manager.has(created.id)).toBe(false);
     expect(manager.getAll()).toEqual([]);
   });
+
+  it('destroyAll tears down every entity and removes their components', () => {
+    const componentManager = new ComponentManager();
+    const entityManager = new EntityManager(componentManager);
+
+    componentManager.registerType(healthType);
+
+    const first = entityManager.create();
+    const second = entityManager.create();
+    const third = entityManager.create();
+
+    componentManager.attachComponent(first.id, healthType, { value: 50 });
+    componentManager.attachComponent(second.id, healthType);
+    componentManager.attachComponent(third.id, healthType, { value: 5 });
+
+    const removeAllSpy = vi.spyOn(componentManager, 'removeAllComponents');
+
+    try {
+      entityManager.destroyAll();
+
+      expect(entityManager.getAll()).toEqual([]);
+
+      expect(removeAllSpy).toHaveBeenCalledTimes(3);
+      expect(removeAllSpy).toHaveBeenCalledWith(first.id);
+      expect(removeAllSpy).toHaveBeenCalledWith(second.id);
+      expect(removeAllSpy).toHaveBeenCalledWith(third.id);
+
+      expect(componentManager.getComponent(first.id, healthType)).toBeUndefined();
+      expect(componentManager.getComponent(second.id, healthType)).toBeUndefined();
+      expect(componentManager.getComponent(third.id, healthType)).toBeUndefined();
+    } finally {
+      removeAllSpy.mockRestore();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- add a regression test ensuring EntityManager.destroyAll clears all entities
- verify removeAllComponents is invoked for each destroyed entity and components are removed

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8fc31471c832ab30cdab62818cf35