### PR TITLE
Add TypeScript check to workspace verification workflow

### DIFF
--- a/checks.sh
+++ b/checks.sh
@@ -66,6 +66,11 @@ if [ -d "$WORKSPACE_PROJECT_DIR" ] && [ -f "$WORKSPACE_PROJECT_DIR/package.json"
     run_step "npm test (workspaces/Describing_Simulation_0/project)" \
       bash -lc "cd \"$WORKSPACE_PROJECT_DIR\" && npm test"
     steps_run=$((steps_run + 1))
+
+    # Type-check the workspace project TypeScript sources
+    run_step "TypeScript type check (workspaces/Describing_Simulation_0/project)" \
+      bash -lc "cd \"$WORKSPACE_PROJECT_DIR\" && npx tsc -p tsconfig.json --noEmit"
+    steps_run=$((steps_run + 1))
   else
     echo
     echo "Skipping npm test for workspaces/Describing_Simulation_0/project: npm not available on PATH."

--- a/workspaces/Describing_Simulation_0/project/tsconfig.json
+++ b/workspaces/Describing_Simulation_0/project/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "ESNext",
+    "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "types": ["node", "vitest"],
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
- add a TypeScript type-check step for the workspace project in `checks.sh`
- configure the workspace TypeScript compiler options to satisfy the new check

## Testing
- ./checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68c8fc3be8d0832aa74e998a7507dd85