### PR TITLE
Add component type unregistration support

### DIFF
--- a/workspaces/Describing_Simulation_0/project/src/ecs/components/ComponentManager.ts
+++ b/workspaces/Describing_Simulation_0/project/src/ecs/components/ComponentManager.ts
@@ -23,6 +23,18 @@ export class ComponentManager {
     });
   }
 
+  unregisterType<T>(type: ComponentType<T>): boolean {
+    const record = this.registry.get(type.id);
+
+    if (!record) {
+      return false;
+    }
+
+    record.instances.clear();
+    this.registry.delete(type.id);
+    return true;
+  }
+
   attachComponent<T>(
     entityId: number,
     type: ComponentType<T>,


### PR DESCRIPTION
## Summary
- add an unregisterType method to ComponentManager to drop type records and their stored instances
- extend ComponentManager tests to verify unregistration clears state and prevents operations until re-registration

## Testing
- ./checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68c905fe8f10832a8e2db02051fef353