### PR TITLE
Add negative delta time test and record verification log

### DIFF
--- a/verifications/20250916064042.log.md
+++ b/verifications/20250916064042.log.md
@@ -1,0 +1,34 @@
+Starting verification run at 2025-09-16T06:40:42+00:00
+Writing log to /workspace/simtest0/verifications/20250916064042.log
+
+==== Repository root ====
+/workspace/simtest0
+
+==== npm test (workspaces/Describing_Simulation_0/project) ====
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> describing-simulation-project@0.1.0 test
+> vitest run --passWithNoTests
+
+
+ RUN  v1.6.1 /workspace/simtest0/workspaces/Describing_Simulation_0/project
+
+ ✓ tests/ecs/SystemManager.test.ts  (5 tests) 13ms
+ ✓ tests/ecs/Entity.test.ts  (2 tests) 6ms
+ ✓ tests/ecs/EntityManager.test.ts  (3 tests) 12ms
+ ✓ tests/ecs/ComponentManager.test.ts  (7 tests) 17ms
+ ✓ tests/ecs/TimeSystem.test.ts  (1 test) 5ms
+ ✓ tests/ecs/ComponentType.test.ts  (2 tests) 10ms
+ ✓ tests/ecs/TimeComponent.test.ts  (2 tests) 7ms
+
+ Test Files  7 passed (7)
+      Tests  22 passed (22)
+   Start at  06:40:44
+   Duration  2.07s (transform 807ms, setup 2ms, collect 1.04s, tests 70ms, environment 2ms, prepare 1.75s)
+
+
+==== TypeScript type check (workspaces/Describing_Simulation_0/project) ====
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+All checks completed successfully.
+Verification log: /workspace/simtest0/verifications/20250916064042.log

--- a/workspaces/Describing_Simulation_0/project/tests/ecs/SystemManager.test.ts
+++ b/workspaces/Describing_Simulation_0/project/tests/ecs/SystemManager.test.ts
@@ -86,6 +86,14 @@ describe('SystemManager', () => {
     }
   });
 
+  it('throws when updated with a negative delta time', async () => {
+    const manager = new SystemManager();
+
+    await expect(manager.update(-0.1)).rejects.toThrowError(
+      'deltaTime must be a non-negative number',
+    );
+  });
+
   it('initializes systems in their registration order', async () => {
     const manager = new SystemManager();
     const initializeOrder: string[] = [];


### PR DESCRIPTION
## Summary
- add a SystemManager unit test that ensures negative delta times are rejected
- archive the latest `./checks.sh` output for traceability

## Testing
- ./checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68c905f3eae4832a9a82b3ca684de02c