### PR TITLE
Synchronize TimeSystem with time component

### DIFF
--- a/workspaces/Describing_Simulation_0/project/src/ecs/systems/implementations/TimeSystem.ts
+++ b/workspaces/Describing_Simulation_0/project/src/ecs/systems/implementations/TimeSystem.ts
@@ -1,15 +1,24 @@
+import type { ComponentManager } from '../../components/ComponentManager.js';
+import {
+  timeComponentType,
+  type TimeComponent,
+} from '../../components/implementations/TimeComponent.js';
 import type { System, SystemUpdateContext } from '../System.js';
 
-// A minimal system that tracks how many update ticks have occurred.
+// A system that keeps an entity's time component in sync with the simulation clock.
 export class TimeSystem implements System {
   readonly id: string;
 
+  private readonly componentManager: ComponentManager;
+  private readonly entityId: number;
   private tickCount = 0;
   private lastDeltaTime = 0;
   private totalElapsedTime = 0;
 
-  constructor(id = 'time') {
+  constructor(componentManager: ComponentManager, entityId: number, id = 'time') {
     this.id = id;
+    this.componentManager = componentManager;
+    this.entityId = entityId;
   }
 
   get ticks(): number {
@@ -25,7 +34,27 @@ export class TimeSystem implements System {
   }
 
   update(context: SystemUpdateContext): void {
-    this.tickCount += 1;
+    let timeComponent: TimeComponent | undefined = this.componentManager.getComponent(
+      this.entityId,
+      timeComponentType,
+    );
+
+    if (!timeComponent) {
+      timeComponent = this.componentManager.attachComponent(
+        this.entityId,
+        timeComponentType,
+      );
+    }
+
+    timeComponent = this.componentManager.updateComponent(
+      this.entityId,
+      timeComponentType,
+      {
+        ticks: timeComponent.ticks + timeComponent.deltaPerUpdate,
+      },
+    );
+
+    this.tickCount = timeComponent.ticks;
     this.lastDeltaTime = context.deltaTime;
     this.totalElapsedTime = context.elapsedTime;
   }

--- a/workspaces/Describing_Simulation_0/project/tests/ecs/TimeSystem.test.ts
+++ b/workspaces/Describing_Simulation_0/project/tests/ecs/TimeSystem.test.ts
@@ -1,31 +1,77 @@
 import { describe, expect, it } from 'vitest';
 
+import { ComponentManager } from '../../src/ecs/components/ComponentManager.js';
+import { timeComponentType } from '../../src/ecs/components/implementations/TimeComponent.js';
+import { EntityManager } from '../../src/ecs/entity/EntityManager.js';
+import { SystemManager } from '../../src/ecs/systems/SystemManager.js';
 import { TimeSystem } from '../../src/ecs/systems/implementations/TimeSystem.js';
 
 describe('TimeSystem', () => {
-  it('tracks tick counts and timing metadata across updates', () => {
-    const system = new TimeSystem();
+  it('advances an attached time component according to its delta per update', async () => {
+    const componentManager = new ComponentManager();
+    componentManager.registerType(timeComponentType);
 
-    expect(system.ticks).toBe(0);
-    expect(system.deltaTime).toBe(0);
-    expect(system.elapsedTime).toBe(0);
+    const entityManager = new EntityManager(componentManager);
+    const entity = entityManager.create();
 
-    system.update({ deltaTime: 0.016, elapsedTime: 0.016 });
+    componentManager.attachComponent(entity.id, timeComponentType, {
+      ticks: 5,
+      deltaPerUpdate: 2,
+    });
 
-    expect(system.ticks).toBe(1);
-    expect(system.deltaTime).toBeCloseTo(0.016);
-    expect(system.elapsedTime).toBeCloseTo(0.016);
+    const timeSystem = new TimeSystem(componentManager, entity.id);
+    const systemManager = new SystemManager();
+    systemManager.register(timeSystem);
 
-    system.update({ deltaTime: 0.024, elapsedTime: 0.04 });
+    await systemManager.update(0.25);
 
-    expect(system.ticks).toBe(2);
-    expect(system.deltaTime).toBeCloseTo(0.024);
-    expect(system.elapsedTime).toBeCloseTo(0.04);
+    const componentAfterFirstUpdate = componentManager.getComponent(
+      entity.id,
+      timeComponentType,
+    );
 
-    system.update({ deltaTime: 0.01, elapsedTime: 0.05 });
+    expect(componentAfterFirstUpdate).not.toBeUndefined();
+    expect(componentAfterFirstUpdate!.ticks).toBe(7);
+    expect(componentAfterFirstUpdate!.deltaPerUpdate).toBe(2);
+    expect(timeSystem.ticks).toBe(7);
+    expect(timeSystem.deltaTime).toBeCloseTo(0.25);
+    expect(timeSystem.elapsedTime).toBeCloseTo(0.25);
 
-    expect(system.ticks).toBe(3);
-    expect(system.deltaTime).toBeCloseTo(0.01);
-    expect(system.elapsedTime).toBeCloseTo(0.05);
+    await systemManager.update(0.75);
+
+    const componentAfterSecondUpdate = componentManager.getComponent(
+      entity.id,
+      timeComponentType,
+    );
+
+    expect(componentAfterSecondUpdate).not.toBeUndefined();
+    expect(componentAfterSecondUpdate!.ticks).toBe(9);
+    expect(componentAfterSecondUpdate!.deltaPerUpdate).toBe(2);
+    expect(timeSystem.ticks).toBe(9);
+    expect(timeSystem.deltaTime).toBeCloseTo(0.75);
+    expect(timeSystem.elapsedTime).toBeCloseTo(1);
+  });
+
+  it('creates a time component when one is not already attached', async () => {
+    const componentManager = new ComponentManager();
+    componentManager.registerType(timeComponentType);
+
+    const entityManager = new EntityManager(componentManager);
+    const entity = entityManager.create();
+
+    const timeSystem = new TimeSystem(componentManager, entity.id);
+    const systemManager = new SystemManager();
+    systemManager.register(timeSystem);
+
+    await systemManager.update(0.1);
+
+    const component = componentManager.getComponent(entity.id, timeComponentType);
+
+    expect(component).not.toBeUndefined();
+    expect(component!.ticks).toBe(1);
+    expect(component!.deltaPerUpdate).toBe(1);
+    expect(timeSystem.ticks).toBe(1);
+    expect(timeSystem.deltaTime).toBeCloseTo(0.1);
+    expect(timeSystem.elapsedTime).toBeCloseTo(0.1);
   });
 });


### PR DESCRIPTION
## Summary
- update TimeSystem to accept a ComponentManager and entity target so it can synchronize an entity's time component with the simulation clock
- add Vitest coverage that runs TimeSystem through SystemManager updates and confirms time component ticks advance or are created when missing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c909644b9c832a9ba57866a6567eba