### PR TITLE
Add ECS player loop with lifecycle tests

### DIFF
--- a/memory/records/2025-09-16--0721-player-loop.md
+++ b/memory/records/2025-09-16--0721-player-loop.md
@@ -1,0 +1,16 @@
+# 2025-09-16 07:21 Player loop implementation
+- **Author:** ChatGPT
+- **Related ways:**
+- **Linked work:**
+
+## Context
+Implemented the base simulation player to drive the ECS systems and codified the dormant Player test intents into executable Vitest suites.
+
+## Findings
+- Added a Player class that owns the component, entity, and system managers, exposes start/pause/stop controls, and manages a timed update loop with configurable delta handling.
+- Ensured the loop schedules sequential updates, respects pause and stop transitions, and triggers system lifecycle hooks alongside entity cleanup on stop.
+- Converted the Player test outline into concrete Vitest cases covering initial start, pause/resume behavior, and shutdown/reset expectations.
+
+## Next steps
+- Integrate the Player with forthcoming IO bus handlers once those specifications are codified.
+- Consider providing explicit elapsed-time reset support in SystemManager so future stop cycles can zero accumulated time without reinstantiating managers.

--- a/verifications/20250916072156.log.md
+++ b/verifications/20250916072156.log.md
@@ -1,0 +1,35 @@
+Starting verification run at 2025-09-16T07:21:56+00:00
+Writing log to /workspace/simtest0/verifications/20250916072156.log
+
+==== Repository root ====
+/workspace/simtest0
+
+==== npm test (workspaces/Describing_Simulation_0/project) ====
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> describing-simulation-project@0.1.0 test
+> vitest run --passWithNoTests
+
+
+ RUN  v1.6.1 /workspace/simtest0/workspaces/Describing_Simulation_0/project
+
+ ✓ tests/ecs/Entity.test.ts  (3 tests) 8ms
+ ✓ tests/ecs/SystemManager.test.ts  (7 tests) 22ms
+ ✓ tests/ecs/EntityManager.test.ts  (3 tests) 10ms
+ ✓ tests/ecs/ComponentManager.test.ts  (9 tests) 29ms
+ ✓ tests/ecs/TimeComponent.test.ts  (2 tests) 11ms
+ ✓ tests/ecs/ComponentType.test.ts  (2 tests) 9ms
+ ✓ tests/ecs/TimeSystem.test.ts  (2 tests) 7ms
+ ✓ tests/ecs/Player.test.ts  (3 tests) 42ms
+
+ Test Files  8 passed (8)
+      Tests  31 passed (31)
+   Start at  07:21:57
+   Duration  1.82s (transform 743ms, setup 2ms, collect 1.06s, tests 138ms, environment 2ms, prepare 1.41s)
+
+
+==== TypeScript type check (workspaces/Describing_Simulation_0/project) ====
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+All checks completed successfully.
+Verification log: /workspace/simtest0/verifications/20250916072156.log

--- a/workspaces/Describing_Simulation_0/project/src/ecs/Player.ts
+++ b/workspaces/Describing_Simulation_0/project/src/ecs/Player.ts
@@ -1,0 +1,182 @@
+import { ComponentManager } from './components/ComponentManager.js';
+import { EntityManager } from './entity/EntityManager.js';
+import { SystemManager } from './systems/SystemManager.js';
+
+// Describes the status of the player in relation to the simulation loop.
+export type PlayerStatus = 'idle' | 'running' | 'paused';
+
+export type PlayerOptions = {
+  // Optional managers to reuse existing state; new instances are created when omitted.
+  componentManager?: ComponentManager;
+  entityManager?: EntityManager;
+  systemManager?: SystemManager;
+  // Desired interval between updates in milliseconds.
+  stepIntervalMs?: number;
+  // If provided, every update uses this delta time in seconds regardless of real time.
+  fixedDeltaTimeSeconds?: number;
+  // Supplies the current timestamp in milliseconds; defaults to Date.now.
+  now?: () => number;
+};
+
+const DEFAULT_STEP_INTERVAL_MS = 1000 / 60;
+
+// Coordinates lifecycle events and the update loop for all registered systems.
+export class Player {
+  readonly componentManager: ComponentManager;
+  readonly entityManager: EntityManager;
+  readonly systemManager: SystemManager;
+
+  private readonly stepIntervalMs: number;
+  private readonly fixedDeltaTimeSeconds?: number;
+  private readonly getTime: () => number;
+
+  private status: PlayerStatus = 'idle';
+  private initialized = false;
+  private timerHandle: ReturnType<typeof setTimeout> | null = null;
+  private activeTick: Promise<void> | null = null;
+  private lastTickTimestamp: number | null = null;
+
+  constructor(options: PlayerOptions = {}) {
+    this.componentManager = options.componentManager ?? new ComponentManager();
+    this.entityManager =
+      options.entityManager ?? new EntityManager(this.componentManager);
+    // Ensure the entity manager operates on the same component manager instance.
+    this.entityManager.setComponentManager(this.componentManager);
+
+    this.systemManager = options.systemManager ?? new SystemManager();
+
+    this.stepIntervalMs = options.stepIntervalMs ?? DEFAULT_STEP_INTERVAL_MS;
+    if (this.stepIntervalMs < 0) {
+      throw new Error('stepIntervalMs must be a non-negative number');
+    }
+
+    if (
+      options.fixedDeltaTimeSeconds !== undefined &&
+      options.fixedDeltaTimeSeconds < 0
+    ) {
+      throw new Error('fixedDeltaTimeSeconds must be a non-negative number');
+    }
+    this.fixedDeltaTimeSeconds = options.fixedDeltaTimeSeconds;
+
+    this.getTime = options.now ?? (() => Date.now());
+  }
+
+  getStatus(): PlayerStatus {
+    return this.status;
+  }
+
+  async start(): Promise<void> {
+    if (this.status === 'running') {
+      return;
+    }
+
+    if (!this.initialized) {
+      await this.systemManager.initializeAll();
+      this.initialized = true;
+    }
+
+    this.status = 'running';
+    this.lastTickTimestamp = null;
+    this.scheduleNextTick();
+  }
+
+  async pause(): Promise<void> {
+    if (this.status !== 'running') {
+      return;
+    }
+
+    this.status = 'paused';
+    this.clearScheduledTick();
+
+    if (this.activeTick) {
+      await this.activeTick;
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (this.status === 'idle' && !this.initialized) {
+      return;
+    }
+
+    this.status = 'idle';
+    this.clearScheduledTick();
+
+    if (this.activeTick) {
+      await this.activeTick;
+    }
+
+    if (this.initialized) {
+      await this.systemManager.shutdownAll();
+      this.initialized = false;
+    }
+
+    this.entityManager.destroyAll();
+    this.lastTickTimestamp = null;
+  }
+
+  private scheduleNextTick(): void {
+    this.clearScheduledTick();
+
+    this.timerHandle = setTimeout(() => {
+      if (this.status !== 'running') {
+        return;
+      }
+
+      const tickPromise = this.performTick();
+      this.activeTick = tickPromise;
+
+      tickPromise
+        .catch((error) => {
+          queueMicrotask(() => {
+            throw error;
+          });
+        })
+        .finally(() => {
+          if (this.activeTick === tickPromise) {
+            this.activeTick = null;
+          }
+
+          if (this.status === 'running') {
+            this.scheduleNextTick();
+          }
+        });
+    }, this.stepIntervalMs);
+  }
+
+  private clearScheduledTick(): void {
+    if (this.timerHandle !== null) {
+      clearTimeout(this.timerHandle);
+      this.timerHandle = null;
+    }
+  }
+
+  private async performTick(): Promise<void> {
+    if (this.status !== 'running') {
+      return;
+    }
+
+    const currentTimestamp = this.getTime();
+    const deltaTimeSeconds = this.computeDeltaTimeSeconds(currentTimestamp);
+
+    await this.systemManager.update(deltaTimeSeconds);
+
+    this.lastTickTimestamp = currentTimestamp;
+  }
+
+  private computeDeltaTimeSeconds(currentTimestamp: number): number {
+    if (this.fixedDeltaTimeSeconds !== undefined) {
+      return this.fixedDeltaTimeSeconds;
+    }
+
+    if (this.lastTickTimestamp === null) {
+      return this.stepIntervalMs / 1000;
+    }
+
+    const deltaMilliseconds = currentTimestamp - this.lastTickTimestamp;
+    if (deltaMilliseconds <= 0) {
+      return 0;
+    }
+
+    return deltaMilliseconds / 1000;
+  }
+}

--- a/workspaces/Describing_Simulation_0/project/tests/ecs/Player.test.ts
+++ b/workspaces/Describing_Simulation_0/project/tests/ecs/Player.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Player } from '../../src/ecs/Player.js';
+import type { System } from '../../src/ecs/systems/System.js';
+
+const advanceBy = async (milliseconds: number) => {
+  await vi.advanceTimersByTimeAsync(milliseconds);
+};
+
+describe('Player', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('starts the update loop and forwards delta times to the system manager', async () => {
+    const player = new Player({
+      stepIntervalMs: 50,
+      fixedDeltaTimeSeconds: 0.05,
+    });
+
+    const deltas: number[] = [];
+    const elapsed: number[] = [];
+
+    player.systemManager.register({
+      id: 'tracker',
+      update: (context) => {
+        deltas.push(context.deltaTime);
+        elapsed.push(context.elapsedTime);
+      },
+    });
+
+    const initializeSpy = vi.spyOn(player.systemManager, 'initializeAll');
+
+    await player.start();
+
+    expect(player.getStatus()).toBe('running');
+    expect(initializeSpy).toHaveBeenCalledTimes(1);
+    initializeSpy.mockRestore();
+
+    await advanceBy(150);
+
+    expect(deltas.length).toBe(3);
+    for (const delta of deltas) {
+      expect(delta).toBeCloseTo(0.05);
+    }
+
+    expect(elapsed.length).toBe(3);
+    expect(elapsed[0]).toBeCloseTo(0.05);
+    expect(elapsed[1]).toBeCloseTo(0.1);
+    expect(elapsed[2]).toBeCloseTo(0.15);
+
+    await player.stop();
+  });
+
+  it('pauses and resumes without reinitializing systems', async () => {
+    const player = new Player({
+      stepIntervalMs: 40,
+      fixedDeltaTimeSeconds: 0.04,
+    });
+
+    const initializeMock = vi.fn();
+    const updateMock = vi.fn();
+    const shutdownMock = vi.fn();
+
+    const system: System = {
+      id: 'loop',
+      initialize: initializeMock,
+      update: updateMock,
+      shutdown: shutdownMock,
+    };
+
+    player.systemManager.register(system);
+
+    const initializeSpy = vi.spyOn(player.systemManager, 'initializeAll');
+
+    await player.start();
+    expect(player.getStatus()).toBe('running');
+    expect(initializeSpy).toHaveBeenCalledTimes(1);
+
+    await advanceBy(80);
+
+    const callsAfterStart = updateMock.mock.calls.length;
+    expect(callsAfterStart).toBeGreaterThan(0);
+
+    await player.pause();
+    expect(player.getStatus()).toBe('paused');
+
+    await advanceBy(200);
+    expect(updateMock.mock.calls.length).toBe(callsAfterStart);
+
+    await player.start();
+    expect(player.getStatus()).toBe('running');
+    expect(initializeSpy).toHaveBeenCalledTimes(1);
+
+    await advanceBy(80);
+    expect(updateMock.mock.calls.length).toBeGreaterThan(callsAfterStart);
+
+    await player.stop();
+    expect(player.getStatus()).toBe('idle');
+    expect(shutdownMock).toHaveBeenCalledTimes(1);
+
+    initializeSpy.mockRestore();
+  });
+
+  it('stops the simulation, shuts down systems, and clears entities', async () => {
+    const player = new Player({
+      stepIntervalMs: 30,
+      fixedDeltaTimeSeconds: 0.03,
+    });
+
+    const initializeMock = vi.fn();
+    const updateMock = vi.fn();
+    const shutdownMock = vi.fn();
+
+    const system: System = {
+      id: 'timekeeper',
+      initialize: initializeMock,
+      update: updateMock,
+      shutdown: shutdownMock,
+    };
+
+    player.systemManager.register(system);
+
+    player.entityManager.create();
+    player.entityManager.create();
+
+    await player.start();
+    await advanceBy(90);
+
+    expect(initializeMock).toHaveBeenCalledTimes(1);
+    expect(updateMock.mock.calls.length).toBeGreaterThan(0);
+    expect(player.entityManager.getAll().length).toBe(2);
+
+    await player.stop();
+
+    expect(player.getStatus()).toBe('idle');
+    expect(shutdownMock).toHaveBeenCalledTimes(1);
+    expect(player.entityManager.getAll()).toEqual([]);
+
+    const callsAfterStop = updateMock.mock.calls.length;
+    await advanceBy(90);
+    expect(updateMock.mock.calls.length).toBe(callsAfterStop);
+
+    await player.start();
+    expect(initializeMock).toHaveBeenCalledTimes(2);
+
+    await player.stop();
+  });
+});


### PR DESCRIPTION
## Summary
- introduce a Player that owns the ECS managers, schedules timed updates, and exposes start/pause/stop controls
- translate the Player test intents into Vitest cases that exercise initialization, pause/resume, and stop/reset behavior
- record the session and verification output for traceability

## Testing
- npm test
- npx tsc -p tsconfig.json --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68c90cc1fd18832a8ca210d917e64db7