### PR TITLE
Add messaging bus with typed handler support

### DIFF
--- a/workspaces/Describing_Simulation_0/project/README.md
+++ b/workspaces/Describing_Simulation_0/project/README.md
@@ -25,7 +25,11 @@ deeper material collected in the [instruction documents index](../../../instruct
 
 - `src/` – TypeScript source organized by subsystem (for example, the `ecs/` folder scaffolds the entity-component-system
   experiments described in the instructions).
+  - `ecs/messaging/` – Strongly typed message bus utilities that let systems publish
+    and subscribe to structured payloads without losing type safety.
 - `tests/` – Vitest suites that encode the behaviors promised in the design notes; mirrors the `src/` structure for clarity.
+  - `ecs/messaging/` – Specifications verifying handler registration, dispatch, and
+    the compile-time payload guarantees offered by the messaging utilities.
 - `package.json` / `package-lock.json` – Dependency manifest and the lockfile that ensures reproducible installs for the
   workspace.
 - `tsconfig.json` – TypeScript compiler configuration tuned for authoring modular simulation components.

--- a/workspaces/Describing_Simulation_0/project/src/ecs/messaging/Bus.ts
+++ b/workspaces/Describing_Simulation_0/project/src/ecs/messaging/Bus.ts
@@ -1,0 +1,99 @@
+// Provides a lightweight message bus with payload-aware handlers.
+import type {
+  MessageDisposer,
+  MessageHandler,
+  MessageTypeMap,
+} from './MessageHandler.js';
+
+/**
+ * Dispatches typed messages to registered handlers.
+ */
+export class Bus<TMessages extends MessageTypeMap> {
+  private readonly handlers = new Map<
+    keyof TMessages,
+    Set<MessageHandler<TMessages, keyof TMessages>>
+  >();
+
+  /**
+   * Registers a handler for a specific message type and returns a disposer to
+   * remove it later.
+   */
+  on<K extends keyof TMessages>(
+    type: K,
+    handler: MessageHandler<TMessages, K>,
+  ): MessageDisposer {
+    const registry = this.ensureRegistry(type);
+    registry.add(handler as MessageHandler<TMessages, keyof TMessages>);
+
+    return () => {
+      this.off(type, handler);
+    };
+  }
+
+  /**
+   * Removes a handler for the provided message type.
+   */
+  off<K extends keyof TMessages>(
+    type: K,
+    handler: MessageHandler<TMessages, K>,
+  ): boolean {
+    const registry = this.handlers.get(type);
+
+    if (!registry) {
+      return false;
+    }
+
+    const removed = registry.delete(
+      handler as MessageHandler<TMessages, keyof TMessages>,
+    );
+
+    if (registry.size === 0) {
+      this.handlers.delete(type);
+    }
+
+    return removed;
+  }
+
+  /**
+   * Dispatches a message to all handlers registered for the message type.
+   */
+  dispatch<K extends keyof TMessages>(type: K, payload: TMessages[K]): void {
+    const registry = this.handlers.get(type) as
+      | Set<MessageHandler<TMessages, K>>
+      | undefined;
+
+    if (!registry) {
+      return;
+    }
+
+    for (const handler of registry) {
+      handler(payload);
+    }
+  }
+
+  /**
+   * Clears all registered handlers across every message type.
+   */
+  clear(): void {
+    this.handlers.clear();
+  }
+
+  private ensureRegistry<K extends keyof TMessages>(
+    type: K,
+  ): Set<MessageHandler<TMessages, K>> {
+    const existing = this.handlers.get(type) as
+      | Set<MessageHandler<TMessages, K>>
+      | undefined;
+
+    if (existing) {
+      return existing;
+    }
+
+    const created = new Set<MessageHandler<TMessages, K>>();
+    this.handlers.set(
+      type,
+      created as Set<MessageHandler<TMessages, keyof TMessages>>,
+    );
+    return created;
+  }
+}

--- a/workspaces/Describing_Simulation_0/project/src/ecs/messaging/MessageHandler.ts
+++ b/workspaces/Describing_Simulation_0/project/src/ecs/messaging/MessageHandler.ts
@@ -1,0 +1,25 @@
+// Defines shared contracts for message handlers in the ECS messaging subsystem.
+
+/**
+ * Maps message type identifiers to the payload shape their handlers expect.
+ *
+ * The map keys are string literal message identifiers and the value is the
+ * payload type each message must carry when dispatched through the bus.
+ */
+export type MessageTypeMap = Record<string, unknown>;
+
+/**
+ * A strongly-typed callback for a specific message type.
+ *
+ * @template TMessages The collection of message payload definitions.
+ * @template TType The message identifier handled by this callback.
+ */
+export type MessageHandler<
+  TMessages extends MessageTypeMap,
+  TType extends keyof TMessages,
+> = (payload: Readonly<TMessages[TType]>) => void;
+
+/**
+ * Function returned by subscriptions to allow callers to unregister.
+ */
+export type MessageDisposer = () => void;

--- a/workspaces/Describing_Simulation_0/project/tests/ecs/messaging/Bus.test.ts
+++ b/workspaces/Describing_Simulation_0/project/tests/ecs/messaging/Bus.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, expectTypeOf, it, vi } from 'vitest';
+import { Bus } from '../../../src/ecs/messaging/Bus.js';
+import type {
+  MessageHandler,
+  MessageTypeMap,
+} from '../../../src/ecs/messaging/MessageHandler.js';
+
+// Test intents:
+// - Verify that handlers registered for a message type receive dispatched payloads.
+// - Confirm that removing handlers prevents them from observing future dispatches.
+// - Demonstrate that TypeScript enforces payload shapes for declared message types.
+
+type SimulationMessages = {
+  entityCreated: {
+    id: number;
+    position: { x: number; y: number };
+  };
+  componentChanged: {
+    entityId: number;
+    component: string;
+    diff: Record<string, unknown>;
+  };
+};
+
+describe('Bus', () => {
+  it('notifies every handler registered for a message type', () => {
+    const bus = new Bus<SimulationMessages>();
+    const handlerA = vi.fn<MessageHandler<SimulationMessages, 'entityCreated'>>();
+    const handlerB = vi.fn<MessageHandler<SimulationMessages, 'entityCreated'>>();
+    const unrelated = vi.fn<MessageHandler<SimulationMessages, 'componentChanged'>>();
+
+    bus.on('entityCreated', handlerA);
+    bus.on('entityCreated', handlerB);
+    bus.on('componentChanged', unrelated);
+
+    const payload: SimulationMessages['entityCreated'] = {
+      id: 7,
+      position: { x: 12, y: -4 },
+    };
+
+    bus.dispatch('entityCreated', payload);
+
+    expect(handlerA).toHaveBeenCalledTimes(1);
+    expect(handlerA).toHaveBeenCalledWith(payload);
+    expect(handlerB).toHaveBeenCalledTimes(1);
+    expect(handlerB).toHaveBeenCalledWith(payload);
+    expect(unrelated).not.toHaveBeenCalled();
+  });
+
+  it('supports removing handlers via disposers returned from registration', () => {
+    const bus = new Bus<SimulationMessages>();
+    const handler = vi.fn<MessageHandler<SimulationMessages, 'componentChanged'>>();
+
+    const dispose = bus.on('componentChanged', handler);
+    bus.dispatch('componentChanged', {
+      entityId: 1,
+      component: 'position',
+      diff: { x: 2 },
+    });
+
+    dispose();
+    bus.dispatch('componentChanged', {
+      entityId: 1,
+      component: 'position',
+      diff: { x: 3 },
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('exposes TypeScript types that preserve the declared payload structure', () => {
+    const bus = new Bus<SimulationMessages>();
+
+    const handler: MessageHandler<SimulationMessages, 'componentChanged'> = (
+      payload,
+    ) => {
+      expectTypeOf(payload.entityId).toEqualTypeOf<number>();
+      expectTypeOf(payload.diff).toEqualTypeOf<Record<string, unknown>>();
+    };
+
+    bus.on('componentChanged', handler);
+    bus.dispatch('componentChanged', {
+      entityId: 5,
+      component: 'rendering',
+      diff: { opacity: 0.4 },
+    });
+
+    const typingOnlyBus = new Bus<SimulationMessages>();
+
+    // @ts-expect-error - Payloads must include all required fields for the message type.
+    typingOnlyBus.dispatch('componentChanged', { entityId: 3 });
+
+    // @ts-expect-error - Message identifiers are limited to declared keys.
+    typingOnlyBus.on('unknownMessage', handler as MessageHandler<MessageTypeMap, string>);
+  });
+});


### PR DESCRIPTION
## Summary
- add an ECS messaging bus with typed handler registration and dispatch helpers
- define shared handler type aliases for enforcing payload shapes across message types
- cover the bus with Vitest suites and document the new messaging module in the workspace README

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c90cc2ffdc832a8e32ff180b2bcb76