### PR TITLE
Add IO messaging layer and handlers

### DIFF
--- a/checks.sh
+++ b/checks.sh
@@ -67,6 +67,10 @@ if [ -d "$WORKSPACE_PROJECT_DIR" ] && [ -f "$WORKSPACE_PROJECT_DIR/package.json"
       bash -lc "cd \"$WORKSPACE_PROJECT_DIR\" && npm test"
     steps_run=$((steps_run + 1))
 
+    run_step "Vitest messaging handlers (workspaces/Describing_Simulation_0/project)" \
+      bash -lc "cd \"$WORKSPACE_PROJECT_DIR\" && npx vitest run tests/ecs/messaging/handlers"
+    steps_run=$((steps_run + 1))
+
     # Type-check the workspace project TypeScript sources
     run_step "TypeScript type check (workspaces/Describing_Simulation_0/project)" \
       bash -lc "cd \"$WORKSPACE_PROJECT_DIR\" && npx tsc -p tsconfig.json --noEmit"

--- a/memory/records/2025-09-16--0729-messaging-layer.md
+++ b/memory/records/2025-09-16--0729-messaging-layer.md
@@ -1,0 +1,28 @@
+# 2025-09-16 07:29 UTC Messaging layer foundation
+- **Author:** ChatGPT
+- **Related ways:** _None_
+- **Linked work:** Pending PR for IO messaging handlers
+
+## Context
+Expanded the Describing Simulation 0 workspace to include the messaging
+infrastructure sketched in the orientation documents. The goal was to build out
+command handlers, an IO-aware player, and regression coverage before future
+service layers depend on them.
+
+## Findings
+- Introduced a generic bus, message abstractions, and handlers for start,
+  pause, stop, and entity injection commands while defining acknowledgement and
+  frame message formats.
+- Implemented an `IOPlayer` that extends the base player to process inbound
+  commands, emit acknowledgements, and stream frames on every tick.
+- Added Vitest suites that exercise command routing, entity injection,
+  acknowledgement outcomes, and frame emission control when pausing.
+- Updated `checks.sh` so contributors can run the new messaging tests directly
+  alongside the full workspace suite.
+
+## Next steps
+- Layer additional inbound/outbound handlers as new simulation controls are
+  specified.
+- Integrate the IO player with higher-level service routes once those modules
+  come online.
+- Consider snapshot compression or diffing once frame payloads become large.

--- a/workspaces/Describing_Simulation_0/project/src/ecs/Player.ts
+++ b/workspaces/Describing_Simulation_0/project/src/ecs/Player.ts
@@ -1,0 +1,230 @@
+import type { ComponentType } from './components/ComponentType.js';
+import type { Entity } from './entity/Entity.js';
+import { EntityManager } from './entity/EntityManager.js';
+import { ComponentManager } from './components/ComponentManager.js';
+import { SystemManager } from './systems/SystemManager.js';
+
+export type ComponentBlueprint = {
+  typeId: string;
+  values?: Record<string, unknown>;
+};
+
+export type EntityBlueprint = {
+  id?: number;
+  components?: ComponentBlueprint[];
+};
+
+export type SnapshotEntity = {
+  id: number;
+  components: Record<string, unknown>;
+};
+
+export type PlayerSnapshot = {
+  tick: number;
+  elapsedTime: number;
+  entities: SnapshotEntity[];
+};
+
+export type PlayerState = 'idle' | 'running' | 'paused' | 'stopped';
+
+export interface PlayerOptions {
+  tickIntervalMs?: number;
+  deltaTime?: number;
+}
+
+export class Player {
+  protected readonly entityManager: EntityManager;
+  protected readonly componentManager: ComponentManager;
+  protected readonly systemManager: SystemManager;
+
+  private readonly tickIntervalMs: number;
+  private readonly deltaTime: number;
+
+  private state: PlayerState = 'idle';
+  private timer: NodeJS.Timeout | null = null;
+  private tickCount = 0;
+  private elapsedTime = 0;
+  private initialized = false;
+  private updateInFlight: Promise<void> | null = null;
+
+  constructor(
+    entityManager: EntityManager,
+    componentManager: ComponentManager,
+    systemManager: SystemManager,
+    options: PlayerOptions = {},
+  ) {
+    this.entityManager = entityManager;
+    this.componentManager = componentManager;
+    this.systemManager = systemManager;
+    this.tickIntervalMs = options.tickIntervalMs ?? 16;
+    this.deltaTime = options.deltaTime ?? 1;
+  }
+
+  get status(): PlayerState {
+    return this.state;
+  }
+
+  get ticks(): number {
+    return this.tickCount;
+  }
+
+  get elapsed(): number {
+    return this.elapsedTime;
+  }
+
+  async start(): Promise<void> {
+    if (this.state === 'running') {
+      return;
+    }
+
+    if (!this.initialized) {
+      await this.systemManager.initializeAll();
+      this.initialized = true;
+    }
+
+    this.state = 'running';
+    this.scheduleNextUpdate();
+  }
+
+  async pause(): Promise<void> {
+    if (this.state !== 'running') {
+      return;
+    }
+
+    this.state = 'paused';
+    this.clearScheduledUpdate();
+    await this.awaitPendingUpdate();
+  }
+
+  async stop(): Promise<void> {
+    if (this.state === 'idle' && !this.initialized) {
+      return;
+    }
+
+    this.state = 'stopped';
+    this.clearScheduledUpdate();
+    await this.awaitPendingUpdate();
+
+    if (this.initialized) {
+      await this.systemManager.shutdownAll();
+    }
+
+    this.entityManager.destroyAll();
+    this.tickCount = 0;
+    this.elapsedTime = 0;
+    this.initialized = false;
+  }
+
+  async injectEntity(blueprint: EntityBlueprint): Promise<Entity> {
+    const entity = this.entityManager.create(blueprint.id);
+
+    if (!blueprint.components) {
+      return entity;
+    }
+
+    for (const componentBlueprint of blueprint.components) {
+      const componentType = this.requireComponentType(componentBlueprint.typeId);
+      this.componentManager.attachComponent(
+        entity.id,
+        componentType,
+        componentBlueprint.values as Partial<unknown>,
+      );
+    }
+
+    return entity;
+  }
+
+  protected async afterUpdate(): Promise<void> {
+    // Subclasses can override this hook to react to completed updates.
+  }
+
+  protected captureSnapshot(): PlayerSnapshot {
+    const entities = this.entityManager.getAll();
+
+    return {
+      tick: this.tickCount,
+      elapsedTime: this.elapsedTime,
+      entities: entities.map((entity) => this.snapshotEntity(entity)),
+    };
+  }
+
+  private async runUpdate(): Promise<void> {
+    if (this.state !== 'running') {
+      return;
+    }
+
+    this.updateInFlight = (async () => {
+      await this.systemManager.update(this.deltaTime);
+      this.tickCount += 1;
+      this.elapsedTime += this.deltaTime;
+      await this.afterUpdate();
+    })();
+
+    try {
+      await this.updateInFlight;
+    } finally {
+      this.updateInFlight = null;
+      if (this.state === 'running') {
+        this.scheduleNextUpdate();
+      }
+    }
+  }
+
+  private scheduleNextUpdate(): void {
+    this.clearScheduledUpdate();
+
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      void this.runUpdate();
+    }, this.tickIntervalMs);
+
+    if (this.timer.unref) {
+      this.timer.unref();
+    }
+  }
+
+  private clearScheduledUpdate(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  private async awaitPendingUpdate(): Promise<void> {
+    if (this.updateInFlight) {
+      await this.updateInFlight;
+    }
+  }
+
+  private snapshotEntity(entity: Entity): SnapshotEntity {
+    const associations = entity.enumerateComponents(this.componentManager);
+    const components: Record<string, unknown> = {};
+
+    for (const association of associations) {
+      components[association.type.id] = this.cloneValue(association.instance);
+    }
+
+    return {
+      id: entity.id,
+      components,
+    };
+  }
+
+  private requireComponentType(typeId: string): ComponentType<unknown> {
+    const componentType = this.componentManager.getTypeById(typeId);
+
+    if (!componentType) {
+      throw new Error(`Component type "${typeId}" is not registered`);
+    }
+
+    return componentType as ComponentType<unknown>;
+  }
+
+  private cloneValue<T>(value: T): T {
+    if (typeof globalThis.structuredClone === 'function') {
+      return globalThis.structuredClone(value);
+    }
+
+    return JSON.parse(JSON.stringify(value)) as T;
+  }
+}

--- a/workspaces/Describing_Simulation_0/project/src/ecs/components/ComponentManager.ts
+++ b/workspaces/Describing_Simulation_0/project/src/ecs/components/ComponentManager.ts
@@ -23,6 +23,16 @@ export class ComponentManager {
     });
   }
 
+  getTypeById<T>(typeId: string): ComponentType<T> | undefined {
+    const record = this.registry.get(typeId);
+
+    if (!record) {
+      return undefined;
+    }
+
+    return record.type as ComponentType<T>;
+  }
+
   unregisterType<T>(type: ComponentType<T>): boolean {
     const record = this.registry.get(type.id);
 

--- a/workspaces/Describing_Simulation_0/project/src/ecs/messaging/Bus.ts
+++ b/workspaces/Describing_Simulation_0/project/src/ecs/messaging/Bus.ts
@@ -1,0 +1,39 @@
+// A lightweight publish/subscribe bus used to exchange messages between the
+// simulation player and external callers.
+export type BusSubscription = () => void;
+
+export type BusSubscriber<TMessage> = (
+  message: TMessage,
+) => void | Promise<void>;
+
+export class Bus<TMessage> {
+  private readonly subscribers = new Set<BusSubscriber<TMessage>>();
+
+  subscribe(callback: BusSubscriber<TMessage>): BusSubscription {
+    this.subscribers.add(callback);
+    return () => {
+      this.subscribers.delete(callback);
+    };
+  }
+
+  async publish(message: TMessage): Promise<void> {
+    const results = await Promise.allSettled(
+      Array.from(this.subscribers).map(async (subscriber) => subscriber(message)),
+    );
+
+    const errors = results
+      .filter((result): result is PromiseRejectedResult => result.status === 'rejected')
+      .map((result) => result.reason);
+
+    if (errors.length === 1) {
+      throw errors[0];
+    }
+
+    if (errors.length > 1) {
+      const message = errors
+        .map((error) => (error instanceof Error ? error.message : String(error)))
+        .join('; ');
+      throw new Error(`Multiple bus subscribers failed: ${message}`);
+    }
+  }
+}

--- a/workspaces/Describing_Simulation_0/project/src/ecs/messaging/IOPlayer.ts
+++ b/workspaces/Describing_Simulation_0/project/src/ecs/messaging/IOPlayer.ts
@@ -1,0 +1,117 @@
+import { Player, type PlayerOptions, type PlayerSnapshot } from '../Player.js';
+import { Bus } from './Bus.js';
+import {
+  createErrorAcknowledgement,
+  createSuccessAcknowledgement,
+  type AcknowledgementMessage,
+} from './handlers/Acknowledgement.js';
+import { createFrameMessage, type FrameMessage } from './handlers/Frame.js';
+import { InjectEntityHandler, type InjectEntityMessage } from './handlers/InjectEntity.js';
+import { PauseHandler, type PauseMessage } from './handlers/Pause.js';
+import { StartHandler, type StartMessage } from './handlers/Start.js';
+import { StopHandler, type StopMessage } from './handlers/Stop.js';
+
+export type InboundMessage =
+  | StartMessage
+  | PauseMessage
+  | StopMessage
+  | InjectEntityMessage;
+
+export type OutboundMessage = AcknowledgementMessage | FrameMessage;
+
+type InboundMessageType = InboundMessage['type'];
+
+type HandlerExecutor = (message: InboundMessage) => Promise<void>;
+
+type PlayerCommandHandler<TMessage extends InboundMessage = InboundMessage> = {
+  readonly type: TMessage['type'];
+  handle(message: TMessage, player: Player): Promise<void> | void;
+};
+
+export interface IOPlayerOptions extends PlayerOptions {
+  handlers?: PlayerCommandHandler[];
+}
+
+export class IOPlayer extends Player {
+  private readonly inputBus: Bus<InboundMessage>;
+  private readonly outputBus: Bus<OutboundMessage>;
+  private readonly handlerExecutors = new Map<InboundMessageType, HandlerExecutor>();
+  private unsubscribeInput?: () => void;
+
+  constructor(
+    entityManager: Player['entityManager'],
+    componentManager: Player['componentManager'],
+    systemManager: Player['systemManager'],
+    inputBus: Bus<InboundMessage>,
+    outputBus: Bus<OutboundMessage>,
+    options: IOPlayerOptions = {},
+  ) {
+    super(entityManager, componentManager, systemManager, options);
+
+    this.inputBus = inputBus;
+    this.outputBus = outputBus;
+
+    const handlers: PlayerCommandHandler[] = options.handlers ?? [
+      new StartHandler(),
+      new PauseHandler(),
+      new StopHandler(),
+      new InjectEntityHandler(),
+    ];
+
+    for (const handler of handlers) {
+      if (this.handlerExecutors.has(handler.type)) {
+        throw new Error(`Duplicate handler registered for type "${handler.type}"`);
+      }
+
+      this.handlerExecutors.set(handler.type, async (message: InboundMessage) => {
+        await handler.handle(message as never, this);
+      });
+    }
+
+    this.unsubscribeInput = this.inputBus.subscribe((message) => this.handleInbound(message));
+  }
+
+  override async stop(): Promise<void> {
+    await super.stop();
+    await this.emitFrame();
+  }
+
+  dispose(): void {
+    if (this.unsubscribeInput) {
+      this.unsubscribeInput();
+      this.unsubscribeInput = undefined;
+    }
+  }
+
+  protected override async afterUpdate(): Promise<void> {
+    await super.afterUpdate();
+    await this.emitFrame();
+  }
+
+  private async handleInbound(message: InboundMessage): Promise<void> {
+    const executor = this.handlerExecutors.get(message.type);
+
+    if (!executor) {
+      await this.outputBus.publish(
+        createErrorAcknowledgement(
+          message.id,
+          `Unsupported message type: ${message.type}`,
+        ),
+      );
+      return;
+    }
+
+    try {
+      await executor(message);
+      await this.outputBus.publish(createSuccessAcknowledgement(message.id));
+      await this.emitFrame();
+    } catch (error) {
+      await this.outputBus.publish(createErrorAcknowledgement(message.id, error));
+    }
+  }
+
+  private async emitFrame(): Promise<void> {
+    const snapshot: PlayerSnapshot = this.captureSnapshot();
+    await this.outputBus.publish(createFrameMessage(snapshot));
+  }
+}

--- a/workspaces/Describing_Simulation_0/project/src/ecs/messaging/MessageHandler.ts
+++ b/workspaces/Describing_Simulation_0/project/src/ecs/messaging/MessageHandler.ts
@@ -1,0 +1,16 @@
+// Shared message and handler abstractions for the messaging layer.
+export type MessageType = string;
+
+export type Message<TType extends MessageType = MessageType, TPayload = unknown> = {
+  id?: string;
+  type: TType;
+  payload: TPayload;
+};
+
+export interface MessageHandler<
+  TMessage extends Message = Message,
+  TContext = void,
+> {
+  readonly type: TMessage['type'];
+  handle(message: TMessage, context: TContext): void | Promise<void>;
+}

--- a/workspaces/Describing_Simulation_0/project/src/ecs/messaging/handlers/Acknowledgement.ts
+++ b/workspaces/Describing_Simulation_0/project/src/ecs/messaging/handlers/Acknowledgement.ts
@@ -1,0 +1,40 @@
+import type { Message } from '../MessageHandler.js';
+
+export type AcknowledgementStatus = 'success' | 'error';
+
+export type AcknowledgementPayload = {
+  status: AcknowledgementStatus;
+  messageId?: string;
+  error?: string;
+};
+
+export type AcknowledgementMessage = Message<
+  'acknowledgement',
+  AcknowledgementPayload
+>;
+
+export function createSuccessAcknowledgement(
+  messageId?: string,
+): AcknowledgementMessage {
+  return {
+    type: 'acknowledgement',
+    payload: {
+      status: 'success',
+      messageId,
+    },
+  };
+}
+
+export function createErrorAcknowledgement(
+  messageId: string | undefined,
+  error: unknown,
+): AcknowledgementMessage {
+  return {
+    type: 'acknowledgement',
+    payload: {
+      status: 'error',
+      messageId,
+      error: error instanceof Error ? error.message : String(error),
+    },
+  };
+}

--- a/workspaces/Describing_Simulation_0/project/src/ecs/messaging/handlers/Frame.ts
+++ b/workspaces/Describing_Simulation_0/project/src/ecs/messaging/handlers/Frame.ts
@@ -1,0 +1,13 @@
+import type { PlayerSnapshot } from '../../Player.js';
+import type { Message } from '../MessageHandler.js';
+
+export type FramePayload = PlayerSnapshot;
+
+export type FrameMessage = Message<'frame', FramePayload>;
+
+export function createFrameMessage(payload: FramePayload): FrameMessage {
+  return {
+    type: 'frame',
+    payload,
+  };
+}

--- a/workspaces/Describing_Simulation_0/project/src/ecs/messaging/handlers/InjectEntity.ts
+++ b/workspaces/Describing_Simulation_0/project/src/ecs/messaging/handlers/InjectEntity.ts
@@ -1,0 +1,20 @@
+import type {
+  EntityBlueprint,
+  Player,
+} from '../../Player.js';
+import type {
+  Message,
+  MessageHandler,
+} from '../MessageHandler.js';
+
+export type InjectEntityMessage = Message<'inject-entity', EntityBlueprint>;
+
+export class InjectEntityHandler
+  implements MessageHandler<InjectEntityMessage, Player>
+{
+  readonly type = 'inject-entity';
+
+  async handle(message: InjectEntityMessage, player: Player): Promise<void> {
+    await player.injectEntity(message.payload);
+  }
+}

--- a/workspaces/Describing_Simulation_0/project/src/ecs/messaging/handlers/Pause.ts
+++ b/workspaces/Describing_Simulation_0/project/src/ecs/messaging/handlers/Pause.ts
@@ -1,0 +1,15 @@
+import type { Player } from '../../Player.js';
+import type {
+  Message,
+  MessageHandler,
+} from '../MessageHandler.js';
+
+export type PauseMessage = Message<'pause', Record<string, never>>;
+
+export class PauseHandler implements MessageHandler<PauseMessage, Player> {
+  readonly type = 'pause';
+
+  async handle(_message: PauseMessage, player: Player): Promise<void> {
+    await player.pause();
+  }
+}

--- a/workspaces/Describing_Simulation_0/project/src/ecs/messaging/handlers/Start.ts
+++ b/workspaces/Describing_Simulation_0/project/src/ecs/messaging/handlers/Start.ts
@@ -1,0 +1,15 @@
+import type { Player } from '../../Player.js';
+import type {
+  Message,
+  MessageHandler,
+} from '../MessageHandler.js';
+
+export type StartMessage = Message<'start', Record<string, never>>;
+
+export class StartHandler implements MessageHandler<StartMessage, Player> {
+  readonly type = 'start';
+
+  async handle(_message: StartMessage, player: Player): Promise<void> {
+    await player.start();
+  }
+}

--- a/workspaces/Describing_Simulation_0/project/src/ecs/messaging/handlers/Stop.ts
+++ b/workspaces/Describing_Simulation_0/project/src/ecs/messaging/handlers/Stop.ts
@@ -1,0 +1,15 @@
+import type { Player } from '../../Player.js';
+import type {
+  Message,
+  MessageHandler,
+} from '../MessageHandler.js';
+
+export type StopMessage = Message<'stop', Record<string, never>>;
+
+export class StopHandler implements MessageHandler<StopMessage, Player> {
+  readonly type = 'stop';
+
+  async handle(_message: StopMessage, player: Player): Promise<void> {
+    await player.stop();
+  }
+}

--- a/workspaces/Describing_Simulation_0/project/tests/ecs/messaging/handlers/IOPlayer.test.ts
+++ b/workspaces/Describing_Simulation_0/project/tests/ecs/messaging/handlers/IOPlayer.test.ts
@@ -1,0 +1,215 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ComponentManager } from '../../../../src/ecs/components/ComponentManager.js';
+import { createComponentType } from '../../../../src/ecs/components/ComponentType.js';
+import { timeComponentType } from '../../../../src/ecs/components/implementations/TimeComponent.js';
+import { EntityManager } from '../../../../src/ecs/entity/EntityManager.js';
+import { Bus } from '../../../../src/ecs/messaging/Bus.js';
+import {
+  IOPlayer,
+  type InboundMessage,
+  type OutboundMessage,
+} from '../../../../src/ecs/messaging/IOPlayer.js';
+import type { FrameMessage } from '../../../../src/ecs/messaging/handlers/Frame.js';
+import type { AcknowledgementMessage } from '../../../../src/ecs/messaging/handlers/Acknowledgement.js';
+import type { InjectEntityMessage } from '../../../../src/ecs/messaging/handlers/InjectEntity.js';
+import type { PauseMessage } from '../../../../src/ecs/messaging/handlers/Pause.js';
+import type { StartMessage } from '../../../../src/ecs/messaging/handlers/Start.js';
+import type { StopMessage } from '../../../../src/ecs/messaging/handlers/Stop.js';
+import { SystemManager } from '../../../../src/ecs/systems/SystemManager.js';
+import { TimeSystem } from '../../../../src/ecs/systems/implementations/TimeSystem.js';
+
+const positionType = createComponentType({
+  id: 'position',
+  name: 'Position',
+  description: 'Tracks 2D position.',
+  schema: {
+    x: {
+      description: 'Horizontal coordinate.',
+      defaultValue: 0,
+    },
+    y: {
+      description: 'Vertical coordinate.',
+      defaultValue: 0,
+    },
+  },
+});
+
+describe('IOPlayer messaging handlers', () => {
+  let componentManager: ComponentManager;
+  let entityManager: EntityManager;
+  let systemManager: SystemManager;
+  let inboundBus: Bus<InboundMessage>;
+  let outboundBus: Bus<OutboundMessage>;
+  let player: IOPlayer;
+  let outboundMessages: OutboundMessage[];
+
+  beforeEach(() => {
+    componentManager = new ComponentManager();
+    entityManager = new EntityManager(componentManager);
+    systemManager = new SystemManager();
+    inboundBus = new Bus<InboundMessage>();
+    outboundBus = new Bus<OutboundMessage>();
+    outboundMessages = [];
+
+    outboundBus.subscribe(async (message) => {
+      outboundMessages.push(message);
+    });
+
+    player = new IOPlayer(
+      entityManager,
+      componentManager,
+      systemManager,
+      inboundBus,
+      outboundBus,
+      { tickIntervalMs: 10, deltaTime: 1 },
+    );
+  });
+
+  afterEach(async () => {
+    await player.stop();
+    player.dispose();
+    vi.useRealTimers();
+  });
+
+  const getAcknowledgements = (): AcknowledgementMessage[] =>
+    outboundMessages.filter(
+      (message): message is AcknowledgementMessage =>
+        message.type === 'acknowledgement',
+    );
+
+  const getFrames = (): FrameMessage[] =>
+    outboundMessages.filter((message): message is FrameMessage => message.type === 'frame');
+
+  it('processes start, pause, and stop commands with acknowledgements', async () => {
+    vi.useFakeTimers();
+    const startMessage: StartMessage = { id: 'start-1', type: 'start', payload: {} };
+    const pauseMessage: PauseMessage = { id: 'pause-1', type: 'pause', payload: {} };
+    const stopMessage: StopMessage = { id: 'stop-1', type: 'stop', payload: {} };
+
+    await inboundBus.publish(startMessage);
+    await inboundBus.publish(pauseMessage);
+    await inboundBus.publish(stopMessage);
+
+    const acknowledgements = getAcknowledgements();
+    expect(acknowledgements).toHaveLength(3);
+    expect(acknowledgements.map((ack) => ack.payload)).toEqual([
+      { status: 'success', messageId: 'start-1' },
+      { status: 'success', messageId: 'pause-1' },
+      { status: 'success', messageId: 'stop-1' },
+    ]);
+  });
+
+  it('injects entities using provided component payloads', async () => {
+    componentManager.registerType(positionType);
+
+    const message: InjectEntityMessage = {
+      id: 'inject-1',
+      type: 'inject-entity',
+      payload: {
+        id: 42,
+        components: [
+          {
+            typeId: positionType.id,
+            values: { x: 5, y: -3 },
+          },
+        ],
+      },
+    };
+
+    await inboundBus.publish(message);
+
+    const acknowledgements = getAcknowledgements();
+    expect(acknowledgements).toHaveLength(1);
+    expect(acknowledgements[0]?.payload).toEqual({
+      status: 'success',
+      messageId: 'inject-1',
+    });
+
+    expect(entityManager.has(42)).toBe(true);
+    expect(componentManager.getComponent(42, positionType)).toEqual({ x: 5, y: -3 });
+
+    const frames = getFrames();
+    const latestFrame = frames.at(-1);
+    expect(latestFrame?.payload.entities).toContainEqual({
+      id: 42,
+      components: {
+        [positionType.id]: { x: 5, y: -3 },
+      },
+    });
+  });
+
+  it('returns an error acknowledgement when injecting unknown component types', async () => {
+    const message: InjectEntityMessage = {
+      id: 'inject-error',
+      type: 'inject-entity',
+      payload: {
+        id: 7,
+        components: [
+          {
+            typeId: 'non-existent',
+            values: {},
+          },
+        ],
+      },
+    };
+
+    await inboundBus.publish(message);
+
+    const acknowledgements = getAcknowledgements();
+    expect(acknowledgements).toHaveLength(1);
+    expect(acknowledgements[0]?.payload.status).toBe('error');
+    expect(acknowledgements[0]?.payload.messageId).toBe('inject-error');
+    expect(acknowledgements[0]?.payload.error).toMatch(
+      'Component type "non-existent" is not registered',
+    );
+  });
+
+  it('emits frames while running and halts emission after pause', async () => {
+    vi.useFakeTimers();
+
+    componentManager.registerType(timeComponentType);
+
+    const entityId = 99;
+    const injectMessage: InjectEntityMessage = {
+      id: 'inject-time',
+      type: 'inject-entity',
+      payload: {
+        id: entityId,
+        components: [
+          {
+            typeId: timeComponentType.id,
+          },
+        ],
+      },
+    };
+
+    await inboundBus.publish(injectMessage);
+
+    const timeSystem = new TimeSystem(componentManager, entityId);
+    systemManager.register(timeSystem);
+
+    const startMessage: StartMessage = { id: 'start-loop', type: 'start', payload: {} };
+    await inboundBus.publish(startMessage);
+
+    await vi.advanceTimersByTimeAsync(30);
+
+    const framesAfterStart = getFrames();
+    const latestFrame = framesAfterStart.at(-1);
+    expect(latestFrame?.payload.tick).toBeGreaterThanOrEqual(3);
+
+    const entitySnapshot = latestFrame?.payload.entities.find((entity) => entity.id === entityId);
+    expect(entitySnapshot?.components[timeComponentType.id]).toEqual({
+      ticks: latestFrame?.payload.tick,
+      deltaPerUpdate: 1,
+    });
+
+    const pauseMessage: PauseMessage = { id: 'pause-loop', type: 'pause', payload: {} };
+    await inboundBus.publish(pauseMessage);
+
+    const framesBeforePause = getFrames().length;
+
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(getFrames().length).toBe(framesBeforePause);
+  });
+});


### PR DESCRIPTION
## Summary
- introduce a base `Player` with scheduling, entity injection, and snapshot support for messaging
- add bus, message abstractions, command handlers, and an `IOPlayer` that sends acknowledgements and frames
- extend the Vitest suite for messaging workflows, update `checks.sh`, and log the new layer in memory records

## Testing
- `./checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c90ccaa498832a961d05c9c7c37abe