### PR TITLE
Document Player messaging references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@
 
 ## Documentation Hygiene
 - Update `index.md`, `AGENTS.md`, and any instruction indices when the directory layout or development practices evolve.
+- Surface new engine orchestration or messaging interfaces (for example, Player loops and IO buses) in `index.md` and `instruction_documents/index.md` so contributors can quickly locate control-path documentation.
 - Use clear, dated commit messages and reference the relevant records in `memory/` when adding or modifying instruction
   artifacts.
 

--- a/index.md
+++ b/index.md
@@ -7,6 +7,7 @@ textual specifications into executable models.
 ## Directory Layout
 
 - `Describing_Simulation_0.md` – master instruction document outlining the simulation-building approach and agent roles.
+- `instruction_documents/` – modular excerpts of the master instructions, including the latest guidance on the Player loop, messaging buses, and IO Player orchestration for simulation state visibility.
 - `verifications/` – timestamped logs of verification or testing runs (for example, outputs produced by `checks.sh`).
 - `index.md` – quick-reference overview of the repository structure and intent (this file).
 

--- a/instruction_documents/index.md
+++ b/instruction_documents/index.md
@@ -4,6 +4,6 @@ This directory collects reusable sections from `Describing_Simulation_0.md`.
 
 - [Describing_Simulation_0_theory.md](Describing_Simulation_0_theory.md) - Establishes the conceptual framing for simulations, including hypotheses classification, formal definitions, and baseline assumptions.
 - [Describing_Simulation_0_bootstraps.md](Describing_Simulation_0_bootstraps.md) - Outlines repository bootstrapping steps, directory expectations, and verification workflows for setting up the project environment.
-- [Describing_Simulation_0_codifying_simulations.md](Describing_Simulation_0_codifying_simulations.md) - Defines the ECS-focused scaffolding, architectural checkpoints, and supporting services needed to codify simulations from the specification.
+- [Describing_Simulation_0_codifying_simulations.md](Describing_Simulation_0_codifying_simulations.md) - Defines the ECS-focused scaffolding, architectural checkpoints, and supporting services needed to codify simulations from the specification, including the Player loop, messaging buses, and IO Player extensions that expose state streams and inbound command handling.
 - [Describing_Simulation_0_master_prompt.md](Describing_Simulation_0_master_prompt.md) - Details the task generation and execution roles, including staging guidance for coordinating implementation work.
 

--- a/memory/ways/surface-engine-interfaces-in-indexes.md
+++ b/memory/ways/surface-engine-interfaces-in-indexes.md
@@ -1,0 +1,16 @@
+# Surface engine interfaces in shared indexes
+- **Status:** Active
+- **Created:** 2025-09-16
+- **Source records:** Player and messaging index refresh (2025-09-16)
+- **Last reviewed:** 2025-09-16
+
+## Guidance
+- Keep cross-cutting engine entry points such as the Player loop, IO Player, and messaging buses described in top-level indexes (`index.md` and `instruction_documents/index.md`) whenever they are introduced or changed.
+- Note in change logs when messaging surfaces evolve so downstream documentation remains discoverable.
+
+## Signals
+- Introducing or modifying orchestration components that impact how contributors start, pause, stop, or observe simulations.
+- Adding inbound or outbound messaging or telemetry features that require explicit mention for other contributors.
+
+## Revision history
+- 2025-09-16 — Established principle after documenting Player and messaging surfaces across indexes.


### PR DESCRIPTION
## Summary
- highlight Player, messaging, and IO Player coverage in the instruction document index
- expand the root index to mention modular instruction excerpts with Player and messaging guidance
- add documentation hygiene guidance for surfacing orchestration interfaces and capture the long-term principle in memory/ways

## Testing
- ./checks.sh *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c90cce833c832ab6bdca73f4623c22