### PR TITLE
Add bus messaging coverage

### DIFF
--- a/checks.sh
+++ b/checks.sh
@@ -67,8 +67,8 @@ if [ -d "$WORKSPACE_PROJECT_DIR" ] && [ -f "$WORKSPACE_PROJECT_DIR/package.json"
       bash -lc "cd \"$WORKSPACE_PROJECT_DIR\" && npm test"
     steps_run=$((steps_run + 1))
 
-    run_step "Vitest messaging handlers (workspaces/Describing_Simulation_0/project)" \
-      bash -lc "cd \"$WORKSPACE_PROJECT_DIR\" && npx vitest run tests/ecs/messaging/handlers"
+    run_step "Vitest messaging suite (workspaces/Describing_Simulation_0/project)" \
+      bash -lc "cd \"$WORKSPACE_PROJECT_DIR\" && npx vitest run tests/ecs/messaging"
     steps_run=$((steps_run + 1))
 
     # Type-check the workspace project TypeScript sources

--- a/memory/records/2025-09-16--1536-bus-messaging-tests.md
+++ b/memory/records/2025-09-16--1536-bus-messaging-tests.md
@@ -1,0 +1,16 @@
+# 2025-09-16 15:36 Bus messaging test coverage
+- **Author:** ChatGPT
+- **Related ways:** _None_
+- **Linked work:** Pending commit
+
+## Context
+Expanded the messaging bus test coverage requested by the latest task, ensuring failure propagation and subscription lifecycles are validated.
+
+## Findings
+- Added a dedicated Vitest suite for the bus to confirm successful delivery, error propagation, and unsubscribe behavior.
+- Updated the shared `checks.sh` harness so messaging tests (including the new suite) run during verification.
+- Planned to capture the verification log produced by `./checks.sh` for traceability.
+
+## Next steps
+- Run the unified verification script and review the resulting log for regressions.
+- Share outcomes with future contributors via the upcoming commit message and verification artifact.

--- a/verifications/20250916153753.log
+++ b/verifications/20250916153753.log
@@ -1,0 +1,50 @@
+Starting verification run at 2025-09-16T15:37:53+00:00
+Writing log to /workspace/simtest0/verifications/20250916153753.log
+
+==== Repository root ====
+/workspace/simtest0
+
+==== npm test (workspaces/Describing_Simulation_0/project) ====
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> describing-simulation-project@0.1.0 test
+> vitest run --passWithNoTests
+
+
+ RUN  v1.6.1 /workspace/simtest0/workspaces/Describing_Simulation_0/project
+
+ ✓ tests/ecs/SystemManager.test.ts  (7 tests) 15ms
+ ✓ tests/ecs/Entity.test.ts  (3 tests) 15ms
+ ✓ tests/ecs/ComponentManager.test.ts  (9 tests) 45ms
+ ✓ tests/ecs/messaging/handlers/IOPlayer.test.ts  (4 tests) 211ms
+ ✓ tests/ecs/EntityManager.test.ts  (3 tests) 93ms
+ ✓ tests/ecs/messaging/Bus.test.ts  (4 tests) 15ms
+ ✓ tests/ecs/TimeSystem.test.ts  (2 tests) 8ms
+ ✓ tests/ecs/ComponentType.test.ts  (2 tests) 9ms
+ ✓ tests/ecs/TimeComponent.test.ts  (2 tests) 17ms
+
+ Test Files  9 passed (9)
+      Tests  36 passed (36)
+   Start at  15:37:55
+   Duration  2.89s (transform 996ms, setup 0ms, collect 1.49s, tests 428ms, environment 3ms, prepare 1.99s)
+
+
+==== Vitest messaging suite (workspaces/Describing_Simulation_0/project) ====
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+ RUN  v1.6.1 /workspace/simtest0/workspaces/Describing_Simulation_0/project
+
+ ✓ tests/ecs/messaging/Bus.test.ts  (4 tests) 19ms
+ ✓ tests/ecs/messaging/handlers/IOPlayer.test.ts  (4 tests) 32ms
+
+ Test Files  2 passed (2)
+      Tests  8 passed (8)
+   Start at  15:38:00
+   Duration  1.34s (transform 476ms, setup 0ms, collect 601ms, tests 51ms, environment 1ms, prepare 375ms)
+
+
+==== TypeScript type check (workspaces/Describing_Simulation_0/project) ====
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+All checks completed successfully.
+Verification log: /workspace/simtest0/verifications/20250916153753.log

--- a/workspaces/Describing_Simulation_0/project/tests/ecs/messaging/Bus.test.ts
+++ b/workspaces/Describing_Simulation_0/project/tests/ecs/messaging/Bus.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Bus } from '../../../src/ecs/messaging/Bus.js';
+
+describe('Bus', () => {
+  it('delivers published messages to every active subscriber', async () => {
+    const bus = new Bus<string>();
+    const firstSubscriber = vi.fn();
+    const secondSubscriber = vi.fn();
+
+    bus.subscribe(firstSubscriber);
+    bus.subscribe(secondSubscriber);
+
+    await bus.publish('ping');
+
+    expect(firstSubscriber).toHaveBeenCalledTimes(1);
+    expect(firstSubscriber).toHaveBeenCalledWith('ping');
+    expect(secondSubscriber).toHaveBeenCalledTimes(1);
+    expect(secondSubscriber).toHaveBeenCalledWith('ping');
+  });
+
+  it('propagates a single subscriber error', async () => {
+    const bus = new Bus<string>();
+    const healthySubscriber = vi.fn();
+    const failure = new Error('subscriber failed');
+
+    bus.subscribe(healthySubscriber);
+    bus.subscribe(() => {
+      throw failure;
+    });
+
+    await expect(bus.publish('event')).rejects.toBe(failure);
+    expect(healthySubscriber).toHaveBeenCalledWith('event');
+  });
+
+  it('aggregates multiple subscriber errors into a combined failure', async () => {
+    const bus = new Bus<string>();
+    const firstError = new Error('first failure');
+    const secondError = new Error('second failure');
+    const healthySubscriber = vi.fn();
+
+    bus.subscribe(() => {
+      throw firstError;
+    });
+    bus.subscribe(() => {
+      throw secondError;
+    });
+    bus.subscribe(healthySubscriber);
+
+    await expect(bus.publish('payload')).rejects.toThrow(
+      'Multiple bus subscribers failed: first failure; second failure',
+    );
+    expect(healthySubscriber).toHaveBeenCalledWith('payload');
+  });
+
+  it('stops invoking callbacks once they are unsubscribed', async () => {
+    const bus = new Bus<number>();
+    const subscriber = vi.fn();
+
+    const unsubscribe = bus.subscribe(subscriber);
+
+    await bus.publish(1);
+    expect(subscriber).toHaveBeenCalledTimes(1);
+    expect(subscriber).toHaveBeenLastCalledWith(1);
+
+    unsubscribe();
+
+    await bus.publish(2);
+    expect(subscriber).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add a Vitest suite for the messaging bus covering delivery, error propagation, and unsubscription behaviour
- update `checks.sh` to execute the full messaging test suite and log the latest verification run
- record the work session details for traceability

## Testing
- `./checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c982e1fbfc832aa901fb39f83659b1