### PR TITLE
Refactor messaging handlers into inbound/outbound registry

### DIFF
--- a/memory/records/2025-09-16--1550-inbound-handler-registry.md
+++ b/memory/records/2025-09-16--1550-inbound-handler-registry.md
@@ -1,0 +1,9 @@
+# 2025-09-16 15:50 UTC — Inbound handler registry integration
+
+## Summary
+- Moved messaging handler implementations into dedicated inbound/outbound directories to clarify command vs response responsibilities.
+- Introduced an `InboundHandlerRegistry` for registering player command handlers by message type and updated `IOPlayer` to depend on it.
+- Adjusted tests and imports to align with the new layout and ensured the TypeScript suite continues to pass.
+
+## Verification
+- `./checks.sh`

--- a/workspaces/Describing_Simulation_0/project/src/ecs/messaging/handlers/inbound/InboundHandlerRegistry.ts
+++ b/workspaces/Describing_Simulation_0/project/src/ecs/messaging/handlers/inbound/InboundHandlerRegistry.ts
@@ -1,0 +1,42 @@
+import type { Message } from '../../MessageHandler.js';
+
+export interface InboundMessageHandler<
+  TMessage extends Message = Message,
+  TContext = void,
+> {
+  readonly type: TMessage['type'];
+  handle(message: TMessage, context: TContext): Promise<void> | void;
+}
+
+export class InboundHandlerRegistry<
+  TMessage extends Message = Message,
+  TContext = void,
+> {
+  private readonly handlers = new Map<
+    TMessage['type'],
+    InboundMessageHandler<TMessage, TContext>
+  >();
+
+  constructor(handlers: ReadonlyArray<InboundMessageHandler<TMessage, TContext>> = []) {
+    for (const handler of handlers) {
+      this.register(handler);
+    }
+  }
+
+  register<TSpecific extends TMessage>(
+    handler: InboundMessageHandler<TSpecific, TContext>,
+  ): void {
+    if (this.handlers.has(handler.type)) {
+      throw new Error(`Duplicate inbound handler registered for type "${handler.type}"`);
+    }
+
+    this.handlers.set(
+      handler.type,
+      handler as InboundMessageHandler<TMessage, TContext>,
+    );
+  }
+
+  resolve(type: TMessage['type']): InboundMessageHandler<TMessage, TContext> | undefined {
+    return this.handlers.get(type);
+  }
+}

--- a/workspaces/Describing_Simulation_0/project/src/ecs/messaging/handlers/inbound/implementations/InjectEntity.ts
+++ b/workspaces/Describing_Simulation_0/project/src/ecs/messaging/handlers/inbound/implementations/InjectEntity.ts
@@ -1,11 +1,11 @@
 import type {
   EntityBlueprint,
   Player,
-} from '../../Player.js';
+} from '../../../../Player.js';
 import type {
   Message,
   MessageHandler,
-} from '../MessageHandler.js';
+} from '../../../MessageHandler.js';
 
 export type InjectEntityMessage = Message<'inject-entity', EntityBlueprint>;
 

--- a/workspaces/Describing_Simulation_0/project/src/ecs/messaging/handlers/inbound/implementations/Pause.ts
+++ b/workspaces/Describing_Simulation_0/project/src/ecs/messaging/handlers/inbound/implementations/Pause.ts
@@ -1,8 +1,8 @@
-import type { Player } from '../../Player.js';
+import type { Player } from '../../../../Player.js';
 import type {
   Message,
   MessageHandler,
-} from '../MessageHandler.js';
+} from '../../../MessageHandler.js';
 
 export type PauseMessage = Message<'pause', Record<string, never>>;
 

--- a/workspaces/Describing_Simulation_0/project/src/ecs/messaging/handlers/inbound/implementations/Start.ts
+++ b/workspaces/Describing_Simulation_0/project/src/ecs/messaging/handlers/inbound/implementations/Start.ts
@@ -1,8 +1,8 @@
-import type { Player } from '../../Player.js';
+import type { Player } from '../../../../Player.js';
 import type {
   Message,
   MessageHandler,
-} from '../MessageHandler.js';
+} from '../../../MessageHandler.js';
 
 export type StartMessage = Message<'start', Record<string, never>>;
 

--- a/workspaces/Describing_Simulation_0/project/src/ecs/messaging/handlers/inbound/implementations/Stop.ts
+++ b/workspaces/Describing_Simulation_0/project/src/ecs/messaging/handlers/inbound/implementations/Stop.ts
@@ -1,8 +1,8 @@
-import type { Player } from '../../Player.js';
+import type { Player } from '../../../../Player.js';
 import type {
   Message,
   MessageHandler,
-} from '../MessageHandler.js';
+} from '../../../MessageHandler.js';
 
 export type StopMessage = Message<'stop', Record<string, never>>;
 

--- a/workspaces/Describing_Simulation_0/project/src/ecs/messaging/handlers/outbound/implementations/Acknowledgement.ts
+++ b/workspaces/Describing_Simulation_0/project/src/ecs/messaging/handlers/outbound/implementations/Acknowledgement.ts
@@ -1,4 +1,4 @@
-import type { Message } from '../MessageHandler.js';
+import type { Message } from '../../../MessageHandler.js';
 
 export type AcknowledgementStatus = 'success' | 'error';
 

--- a/workspaces/Describing_Simulation_0/project/src/ecs/messaging/handlers/outbound/implementations/Frame.ts
+++ b/workspaces/Describing_Simulation_0/project/src/ecs/messaging/handlers/outbound/implementations/Frame.ts
@@ -1,5 +1,5 @@
-import type { PlayerSnapshot } from '../../Player.js';
-import type { Message } from '../MessageHandler.js';
+import type { PlayerSnapshot } from '../../../../Player.js';
+import type { Message } from '../../../MessageHandler.js';
 
 export type FramePayload = PlayerSnapshot;
 

--- a/workspaces/Describing_Simulation_0/project/tests/ecs/messaging/handlers/IOPlayer.test.ts
+++ b/workspaces/Describing_Simulation_0/project/tests/ecs/messaging/handlers/IOPlayer.test.ts
@@ -9,12 +9,23 @@ import {
   type InboundMessage,
   type OutboundMessage,
 } from '../../../../src/ecs/messaging/IOPlayer.js';
-import type { FrameMessage } from '../../../../src/ecs/messaging/handlers/Frame.js';
-import type { AcknowledgementMessage } from '../../../../src/ecs/messaging/handlers/Acknowledgement.js';
-import type { InjectEntityMessage } from '../../../../src/ecs/messaging/handlers/InjectEntity.js';
-import type { PauseMessage } from '../../../../src/ecs/messaging/handlers/Pause.js';
-import type { StartMessage } from '../../../../src/ecs/messaging/handlers/Start.js';
-import type { StopMessage } from '../../../../src/ecs/messaging/handlers/Stop.js';
+import type { SnapshotEntity } from '../../../../src/ecs/Player.js';
+import type { FrameMessage } from '../../../../src/ecs/messaging/handlers/outbound/implementations/Frame.js';
+import type {
+  AcknowledgementMessage,
+} from '../../../../src/ecs/messaging/handlers/outbound/implementations/Acknowledgement.js';
+import type {
+  InjectEntityMessage,
+} from '../../../../src/ecs/messaging/handlers/inbound/implementations/InjectEntity.js';
+import type {
+  PauseMessage,
+} from '../../../../src/ecs/messaging/handlers/inbound/implementations/Pause.js';
+import type {
+  StartMessage,
+} from '../../../../src/ecs/messaging/handlers/inbound/implementations/Start.js';
+import type {
+  StopMessage,
+} from '../../../../src/ecs/messaging/handlers/inbound/implementations/Stop.js';
 import { SystemManager } from '../../../../src/ecs/systems/SystemManager.js';
 import { TimeSystem } from '../../../../src/ecs/systems/implementations/TimeSystem.js';
 
@@ -197,7 +208,9 @@ describe('IOPlayer messaging handlers', () => {
     const latestFrame = framesAfterStart.at(-1);
     expect(latestFrame?.payload.tick).toBeGreaterThanOrEqual(3);
 
-    const entitySnapshot = latestFrame?.payload.entities.find((entity) => entity.id === entityId);
+    const entitySnapshot = latestFrame?.payload.entities.find(
+      (entity: SnapshotEntity) => entity.id === entityId,
+    );
     expect(entitySnapshot?.components[timeComponentType.id]).toEqual({
       ticks: latestFrame?.payload.tick,
       deltaPerUpdate: 1,


### PR DESCRIPTION
## Summary
- organize the messaging handler implementations into inbound and outbound folders and add an inbound handler registry
- refactor IOPlayer to resolve inbound commands through the registry and update dependent imports/tests
- record the restructuring in the shared memory log

## Testing
- ./checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68c982df86e0832a8601010350bab8a5