### PR TITLE
docs: update tools readme overview

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -1,1 +1,11 @@
-Placeholder for tooling assets.
+# Tools Overview
+
+This directory hosts helper scripts and supporting assets that streamline local
+setup and maintenance tasks for the project. Refer to
+[`tools/index.md`](./index.md) for detailed documentation on each utility.
+
+## Included utilities
+
+- `bootstrap.sh` &mdash; bootstraps a Python-based development environment,
+  ensuring required system packages are present, creating `.venv/`, and
+  installing dependencies from `requirements.txt`.


### PR DESCRIPTION
## Summary
- replace the placeholder in `tools/README.md` with an overview that points to the detailed index
- highlight the existing `bootstrap.sh` helper and how it provisions the development environment

## Testing
- ./checks.sh *(fails: `vitest` command not found in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c988fcf8bc832aa10eff88df6db195