### PR TITLE
Capture IOPlayer outbound stream in verification log

### DIFF
--- a/verifications/20250916165120-ioplayer-example.log
+++ b/verifications/20250916165120-ioplayer-example.log
@@ -1,0 +1,51 @@
+Starting verification run at 2025-09-16T16:51:20+00:00
+Writing log to /workspace/simtest0/verifications/20250916165120.log
+
+==== Repository root ====
+/workspace/simtest0
+
+==== npm test (workspaces/Describing_Simulation_0/project) ====
+
+> describing-simulation-project@0.1.0 test
+> vitest run --passWithNoTests
+
+
+ RUN  v1.6.1 /workspace/simtest0/workspaces/Describing_Simulation_0/project
+
+ ✓ tests/ecs/ComponentManager.test.ts  (9 tests) 29ms
+ ✓ tests/ecs/Entity.test.ts  (3 tests) 26ms
+ ✓ tests/ecs/SystemManager.test.ts  (7 tests) 41ms
+ ✓ tests/ecs/messaging/handlers/IOPlayer.test.ts  (4 tests) 158ms
+ ✓ tests/ecs/Player.test.ts  (4 tests) 86ms
+ ✓ tests/ecs/TimeSystem.test.ts  (2 tests) 9ms
+ ✓ tests/ecs/EntityManager.test.ts  (3 tests) 20ms
+ ✓ tests/examples/IOPlayerEndToEnd.test.ts  (1 test) 23ms
+ ✓ tests/ecs/messaging/Bus.test.ts  (4 tests) 39ms
+ ✓ tests/ecs/ComponentType.test.ts  (2 tests) 11ms
+ ✓ tests/ecs/messaging/handlers/InboundHandlerRegistry.test.ts  (3 tests) 7ms
+ ✓ tests/ecs/TimeComponent.test.ts  (2 tests) 22ms
+
+ Test Files  12 passed (12)
+      Tests  44 passed (44)
+   Start at  16:51:23
+   Duration  4.93s (transform 1.44s, setup 1ms, collect 2.53s, tests 471ms, environment 6ms, prepare 5.25s)
+
+
+==== Vitest messaging suite (workspaces/Describing_Simulation_0/project) ====
+
+ RUN  v1.6.1 /workspace/simtest0/workspaces/Describing_Simulation_0/project
+
+ ✓ tests/ecs/messaging/handlers/InboundHandlerRegistry.test.ts  (3 tests) 12ms
+ ✓ tests/ecs/messaging/Bus.test.ts  (4 tests) 20ms
+ ✓ tests/ecs/messaging/handlers/IOPlayer.test.ts  (4 tests) 66ms
+
+ Test Files  3 passed (3)
+      Tests  11 passed (11)
+   Start at  16:51:31
+   Duration  2.19s (transform 752ms, setup 0ms, collect 1.03s, tests 98ms, environment 1ms, prepare 1.23s)
+
+
+==== TypeScript type check (workspaces/Describing_Simulation_0/project) ====
+
+All checks completed successfully.
+Verification log: /workspace/simtest0/verifications/20250916165120.log

--- a/verifications/20250916171336.log
+++ b/verifications/20250916171336.log
@@ -1,0 +1,54 @@
+Starting verification run at 2025-09-16T17:13:36+00:00
+Writing log to /workspace/simtest0/verifications/20250916171336.log
+
+==== Repository root ====
+/workspace/simtest0
+
+==== npm test (workspaces/Describing_Simulation_0/project) ====
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> describing-simulation-project@0.1.0 test
+> vitest run --passWithNoTests
+
+
+ RUN  v1.6.1 /workspace/simtest0/workspaces/Describing_Simulation_0/project
+
+ ✓ tests/ecs/SystemManager.test.ts  (7 tests) 35ms
+ ✓ tests/ecs/ComponentManager.test.ts  (9 tests) 44ms
+ ✓ tests/examples/IOPlayerEndToEnd.test.ts  (1 test) 36ms
+ ✓ tests/ecs/messaging/handlers/IOPlayer.test.ts  (4 tests) 35ms
+ ✓ tests/ecs/Entity.test.ts  (3 tests) 11ms
+ ✓ tests/ecs/Player.test.ts  (4 tests) 45ms
+ ✓ tests/ecs/TimeSystem.test.ts  (2 tests) 9ms
+ ✓ tests/ecs/EntityManager.test.ts  (3 tests) 40ms
+ ✓ tests/ecs/messaging/Bus.test.ts  (4 tests) 15ms
+ ✓ tests/ecs/ComponentType.test.ts  (2 tests) 7ms
+ ✓ tests/ecs/messaging/handlers/InboundHandlerRegistry.test.ts  (3 tests) 35ms
+ ✓ tests/ecs/TimeComponent.test.ts  (2 tests) 10ms
+
+ Test Files  12 passed (12)
+      Tests  44 passed (44)
+   Start at  17:13:39
+   Duration  4.60s (transform 1.16s, setup 2ms, collect 2.02s, tests 322ms, environment 6ms, prepare 4.89s)
+
+
+==== Vitest messaging suite (workspaces/Describing_Simulation_0/project) ====
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+ RUN  v1.6.1 /workspace/simtest0/workspaces/Describing_Simulation_0/project
+
+ ✓ tests/ecs/messaging/handlers/InboundHandlerRegistry.test.ts  (3 tests) 18ms
+ ✓ tests/ecs/messaging/Bus.test.ts  (4 tests) 24ms
+ ✓ tests/ecs/messaging/handlers/IOPlayer.test.ts  (4 tests) 57ms
+
+ Test Files  3 passed (3)
+      Tests  11 passed (11)
+   Start at  17:13:47
+   Duration  1.89s (transform 820ms, setup 0ms, collect 1.05s, tests 99ms, environment 1ms, prepare 787ms)
+
+
+==== TypeScript type check (workspaces/Describing_Simulation_0/project) ====
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+All checks completed successfully.
+Verification log: /workspace/simtest0/verifications/20250916171336.log

--- a/verifications/ioplayer/2025-09-16_17-13-40-ioplayer-outbound-21618091-d785-4475-8f0a-3485739d8eb5.log
+++ b/verifications/ioplayer/2025-09-16_17-13-40-ioplayer-outbound-21618091-d785-4475-8f0a-3485739d8eb5.log
@@ -1,0 +1,101 @@
+IOPlayer outbound stream log
+Created at 2025-09-16T17:13:40.988Z
+
+[2025-09-16T17:13:40.991Z] ACKNOWLEDGEMENT
+{
+  "type": "acknowledgement",
+  "payload": {
+    "status": "success",
+    "messageId": "start-message"
+  }
+}
+
+[2025-09-16T17:13:40.991Z] FRAME
+{
+  "type": "frame",
+  "payload": {
+    "tick": 0,
+    "elapsedTime": 0,
+    "entities": []
+  }
+}
+
+[2025-09-16T17:13:41.991Z] FRAME
+{
+  "type": "frame",
+  "payload": {
+    "tick": 1,
+    "elapsedTime": 1,
+    "entities": []
+  }
+}
+
+[2025-09-16T17:13:42.991Z] FRAME
+{
+  "type": "frame",
+  "payload": {
+    "tick": 2,
+    "elapsedTime": 2,
+    "entities": []
+  }
+}
+
+[2025-09-16T17:13:43.991Z] FRAME
+{
+  "type": "frame",
+  "payload": {
+    "tick": 3,
+    "elapsedTime": 3,
+    "entities": []
+  }
+}
+
+[2025-09-16T17:13:44.991Z] FRAME
+{
+  "type": "frame",
+  "payload": {
+    "tick": 4,
+    "elapsedTime": 4,
+    "entities": []
+  }
+}
+
+[2025-09-16T17:13:45.991Z] FRAME
+{
+  "type": "frame",
+  "payload": {
+    "tick": 5,
+    "elapsedTime": 5,
+    "entities": []
+  }
+}
+
+[2025-09-16T17:13:45.991Z] FRAME
+{
+  "type": "frame",
+  "payload": {
+    "tick": 0,
+    "elapsedTime": 0,
+    "entities": []
+  }
+}
+
+[2025-09-16T17:13:45.991Z] ACKNOWLEDGEMENT
+{
+  "type": "acknowledgement",
+  "payload": {
+    "status": "success",
+    "messageId": "stop-message"
+  }
+}
+
+[2025-09-16T17:13:45.991Z] FRAME
+{
+  "type": "frame",
+  "payload": {
+    "tick": 0,
+    "elapsedTime": 0,
+    "entities": []
+  }
+}
+

--- a/workspaces/Describing_Simulation_0/project/tests/examples/IOPlayerEndToEnd.test.ts
+++ b/workspaces/Describing_Simulation_0/project/tests/examples/IOPlayerEndToEnd.test.ts
@@ -1,0 +1,143 @@
+import { createWriteStream } from 'node:fs';
+import { mkdir, readFile } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ComponentManager } from '../../src/ecs/components/ComponentManager.js';
+import { EntityManager } from '../../src/ecs/entity/EntityManager.js';
+import { SystemManager } from '../../src/ecs/systems/SystemManager.js';
+import { Bus } from '../../src/ecs/messaging/Bus.js';
+import {
+  IOPlayer,
+  type InboundMessage,
+  type OutboundMessage,
+} from '../../src/ecs/messaging/IOPlayer.js';
+
+const testFilePath = fileURLToPath(import.meta.url);
+const testDirectory = path.dirname(testFilePath);
+const repositoryRoot = path.resolve(testDirectory, '..', '..', '..', '..', '..');
+const outboundLogDirectory = path.join(repositoryRoot, 'verifications', 'ioplayer');
+
+const formatTimestampForFilename = (isoTimestamp: string) =>
+  isoTimestamp.replace(/:/g, '-').replace('T', '_').replace(/\..*/, '');
+
+describe('IOPlayer end-to-end example', () => {
+  let logTimestampIso: string;
+
+  beforeEach(() => {
+    logTimestampIso = new Date().toISOString();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('logs frames and acknowledgements when processing start/stop messages', async () => {
+    await mkdir(outboundLogDirectory, { recursive: true });
+
+    const logFilePath = path.join(
+      outboundLogDirectory,
+      `${formatTimestampForFilename(logTimestampIso)}-ioplayer-outbound-${randomUUID()}.log`,
+    );
+
+    const logStream = createWriteStream(logFilePath, { flags: 'w' });
+    let logStreamClosePromise: Promise<void> | null = null;
+    const ensureLogStreamClosed = () => {
+      if (!logStreamClosePromise) {
+        logStreamClosePromise = new Promise<void>((resolve, reject) => {
+          logStream.once('finish', resolve);
+          logStream.once('error', reject);
+          logStream.end();
+        });
+      }
+
+      return logStreamClosePromise;
+    };
+
+    try {
+      logStream.write('IOPlayer outbound stream log\n');
+      logStream.write(`Created at ${logTimestampIso}\n\n`);
+
+      const componentManager = new ComponentManager();
+      const entityManager = new EntityManager(componentManager);
+      const systemManager = new SystemManager();
+
+      const inboundBus = new Bus<InboundMessage>();
+      const outboundBus = new Bus<OutboundMessage>();
+
+      const player = new IOPlayer(
+        entityManager,
+        componentManager,
+        systemManager,
+        inboundBus,
+        outboundBus,
+        {
+          tickIntervalMs: 1_000,
+          deltaTime: 1,
+        },
+      );
+
+      const loggedMessages: OutboundMessage[] = [];
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      outboundBus.subscribe((message) => {
+        const timestamp = new Date().toISOString();
+        const serialized = JSON.stringify(message, null, 2);
+        logStream.write(`[${timestamp}] ${message.type.toUpperCase()}\n${serialized}\n\n`);
+        console.log('Outbound message:', message.type, message);
+        loggedMessages.push(message);
+      });
+
+      await inboundBus.publish({ id: 'start-message', type: 'start', payload: {} });
+
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      await inboundBus.publish({ id: 'stop-message', type: 'stop', payload: {} });
+
+      await vi.runAllTimersAsync();
+
+      player.dispose();
+
+      await ensureLogStreamClosed();
+
+      const acknowledgementMessages = loggedMessages.filter(
+        (message): message is Extract<OutboundMessage, { type: 'acknowledgement' }> =>
+          message.type === 'acknowledgement',
+      );
+      const frameMessages = loggedMessages.filter(
+        (message): message is Extract<OutboundMessage, { type: 'frame' }> =>
+          message.type === 'frame',
+      );
+
+      const acknowledgementIds = acknowledgementMessages.map(
+        (message) => message.payload.messageId,
+      );
+
+      expect(frameMessages.length).toBeGreaterThan(0);
+      expect(acknowledgementMessages).toHaveLength(2);
+      expect(acknowledgementIds).toEqual(
+        expect.arrayContaining(['start-message', 'stop-message']),
+      );
+      expect(acknowledgementMessages.every((message) => message.payload.status === 'success')).toBe(
+        true,
+      );
+
+      const loggedTypes = consoleSpy.mock.calls
+        .filter((call) => call[0] === 'Outbound message:')
+        .map((call) => call[1]);
+
+      expect(loggedTypes).toContain('frame');
+      expect(loggedTypes.filter((type) => type === 'acknowledgement').length).toBeGreaterThanOrEqual(2);
+
+      const outboundStreamLog = await readFile(logFilePath, 'utf-8');
+      expect(outboundStreamLog).toContain('"type": "frame"');
+      expect(outboundStreamLog).toContain('"type": "acknowledgement"');
+    } finally {
+      await ensureLogStreamClosed();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- stream the IOPlayer example's outbound bus messages into timestamped verification logs under `verifications/ioplayer`
- update the end-to-end test to write the log, ensure it closes cleanly, and assert the recorded frames and acknowledgements
- capture the latest `./checks.sh` output in `verifications/20250916171336.log`

## Testing
- ./checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68c992a01eb8832a8427b34f969cbc23