### PR TITLE
Add master prompt instruction document

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 # Agent Instructions
 
-1. Review the latest simulation guidelines in `instruction_documents/index.md`, then open the referenced `_theory.md`, `_codifying_simulations.md`, and `_bootstraps.md` files for full context.
+1. Review the latest simulation guidelines in `instruction_documents/index.md`, then open the referenced `_theory.md`, `_codifying_simulations.md`, `_bootstraps.md`, and `_master_prompt.md` files for full context.
 2. When building artifacts, work inside `workspaces/Describing_Simulation_0/` (create it if it does not exist) and rely on the `instruction_documents` materials to guide structure and process.
 3. Add reusable automation to `tools/` with entries in `tools/index.md`, and run validations through the repository-level `checks.sh` script, recording results under `verifications/` when available.

--- a/instruction_documents/_master_prompt.md
+++ b/instruction_documents/_master_prompt.md
@@ -1,0 +1,55 @@
+## Master Prompt
+
+There are two roles for an agent to exclusively execute upon. One who generates tasks, and one who implements tasks.
+
+### Tasker
+
+When you are responsible for determining the next steps open-endedly, examine the state of the present revision workspace and memories and enumerate tasks that forward the state of artifact construction, referencing pertinent instruction documents as guidelines including guidance towards a review of the master prompt.
+
+Phase 1 — Bootstrapping
+
+- Prepare repository structure as described in Bootstraps.
+
+- Split this document into component instruction files.
+
+- Create or update index.md and AGENTS.md for visibility.
+
+- Ensure tools/, workspaces/, and memory/ directories exist.
+
+Phase 2 — Artifact Creation
+
+- Enter the workspace for the current revision.
+
+- Proceed through checkpoints in order.
+
+- Each checkpoint represents a coherent milestone, building on prior ones.
+
+- For each checkpoint:
+
+- Define skeletons (structure, empty methods).
+
+- Write test intents (comment-only).
+
+- Codify tests from intents.
+
+- Implement logic to satisfy tests.
+
+- Validate until all tests pass.
+
+### Task Staging
+
+Generally, individual tasks should touch one of:
+
+- Environment files such compiler configurations, test harnessing
+
+- Source code of the implementation of the artifact
+
+- Test code of implementation files
+
+When generating a collection of tasks, organize them sequentially such that tasks will not cause merge conflicts, as it should be assumed tasks run in parallel, including documentation files. Staging around this can mean generating fewer tasks or stubbing files to arrive at a point where more complexity can be implemented.
+
+As implementers heavily bias the tasks generated, be verbose in relevant documents for review and explicit regarding workspace location.
+
+### Implementer
+
+When you are responsible for executing tasks, do so with respect to development patterns and best practices within instruction documents.

--- a/instruction_documents/index.md
+++ b/instruction_documents/index.md
@@ -14,3 +14,8 @@
 - Directs how to establish the repository structure, split instruction sections, and document their contents for discoverability.
 - Specifies supporting directories—tools, workspaces, memory, and verifications—and the expectations for their maintenance.
 - Outlines the purpose of long-term "ways" and short-term "records" memories alongside the checks.sh entry point for validations.
+
+## `_master_prompt.md`
+- Captures the canonical division of responsibilities between the task-generating and task-implementing agent roles.
+- Enumerates phased bootstrapping and artifact creation expectations, including checkpoint sequencing and validation practices.
+- Advises on staging strategies that minimize conflicts while keeping documentation explicit about workspace context.

--- a/verifications/20250925T215307Z.log
+++ b/verifications/20250925T215307Z.log
@@ -1,0 +1,4 @@
+Running repository checks at 2025-09-25T21:53:07Z
+
+No automated validation commands have been defined yet.
+Update checks.sh with the necessary commands when validations are added.


### PR DESCRIPTION
## Summary
- add a dedicated `_master_prompt.md` containing the master prompt guidance split from the simulation description
- extend the instruction index with a summary of the new document
- reference the master prompt in AGENTS guidance and capture check output in verifications

## Testing
- ./checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68d5b9905cbc832abc56ddcc825078e8