### PR TITLE
Fix simulation directory tree formatting

### DIFF
--- a/Describing_Simulation_0.md
+++ b/Describing_Simulation_0.md
@@ -180,7 +180,7 @@ The following sections serve as guidelines for code layout and principles for im
 
 ### Structure
 
-```
+```text
 project/
 ├── src/
 │   ├── core/
@@ -190,52 +190,40 @@ project/
 │   │   │   ├── SimulationPlayer.ts
 │   │   │   └── operations/
 │   │   │       ├── Start.ts
-`│   │   │       ├── ``Pause.ts`
-
+│   │   │       ├── Pause.ts
 │   │   │       ├── Stop.ts
 │   │   │       └── InjectSystem.ts
-│   │   │
 │   │   ├── evalplayer/
 │   │   │   ├── EvaluationPlayer.ts
 │   │   │   └── operations/
 │   │   │       └── InjectFrame.ts
-│   │   │
 │   │   ├── entity/
 │   │   │   ├── EntityManager.ts
 │   │   │   └── Entity.ts
-│   │   │
 │   │   ├── components/
 │   │   │   ├── ComponentType.ts
 │   │   │   ├── ComponentManager.ts
 │   │   │   └── TimeComponent.ts
-│   │   │
 │   │   ├── systems/
 │   │   │   ├── System.ts
 │   │   │   ├── SystemManager.ts
 │   │   │   └── TimeSystem.ts
-│   │   │
 │   │   └── messaging/
 │   │       ├── Bus.ts
 │   │       ├── outbound/
-`│   │       │   ├── ``Frame.ts`
-
+│   │       │   ├── Frame.ts
 │   │       │   ├── FrameFilter.ts
 │   │       │   └── Acknowledgement.ts
-│   │       │
 │   │       └── inbound/
 │   │           ├── Operation.ts
 │   │           ├── MessageHandler.ts
 │   │           └── InboundHandlerRegistry.ts
-│   │
-│   │
 │   ├── routes/
 │   │   ├── apiRoutes.ts
 │   │   ├── controls.ts
 │   │   └── evaluations.ts
-│   │
 │   ├── server.ts
 │   └── main.ts
-│
 ├── plugins/
 │   ├── simulation/
 │   │   ├── components/
@@ -244,7 +232,6 @@ project/
 │   │   │   └── (agent-defined systems)
 │   │   └── operations/
 │   │       └── (agent-defined handlers)
-│   │
 │   └── evaluation/
 │       ├── components/
 │       │   └── (agent-defined evaluation components)
@@ -252,7 +239,6 @@ project/
 │       │   └── (agent-defined evaluation systems)
 │       └── operations/
 │           └── (agent-defined evaluation handlers)
-│
 ├── package.json
 └── README.md
 ```

--- a/instruction_documents/_codifying_simulations.md
+++ b/instruction_documents/_codifying_simulations.md
@@ -42,7 +42,7 @@ The following sections serve as guidelines for code layout and principles for im
 
 ### Structure
 
-```
+```text
 project/
 ├── src/
 │   ├── core/
@@ -52,52 +52,40 @@ project/
 │   │   │   ├── SimulationPlayer.ts
 │   │   │   └── operations/
 │   │   │       ├── Start.ts
-`│   │   │       ├── ``Pause.ts`
-
+│   │   │       ├── Pause.ts
 │   │   │       ├── Stop.ts
 │   │   │       └── InjectSystem.ts
-│   │   │
 │   │   ├── evalplayer/
 │   │   │   ├── EvaluationPlayer.ts
 │   │   │   └── operations/
 │   │   │       └── InjectFrame.ts
-│   │   │
 │   │   ├── entity/
 │   │   │   ├── EntityManager.ts
 │   │   │   └── Entity.ts
-│   │   │
 │   │   ├── components/
 │   │   │   ├── ComponentType.ts
 │   │   │   ├── ComponentManager.ts
 │   │   │   └── TimeComponent.ts
-│   │   │
 │   │   ├── systems/
 │   │   │   ├── System.ts
 │   │   │   ├── SystemManager.ts
 │   │   │   └── TimeSystem.ts
-│   │   │
 │   │   └── messaging/
 │   │       ├── Bus.ts
 │   │       ├── outbound/
-`│   │       │   ├── ``Frame.ts`
-
+│   │       │   ├── Frame.ts
 │   │       │   ├── FrameFilter.ts
 │   │       │   └── Acknowledgement.ts
-│   │       │
 │   │       └── inbound/
 │   │           ├── Operation.ts
 │   │           ├── MessageHandler.ts
 │   │           └── InboundHandlerRegistry.ts
-│   │
-│   │
 │   ├── routes/
 │   │   ├── apiRoutes.ts
 │   │   ├── controls.ts
 │   │   └── evaluations.ts
-│   │
 │   ├── server.ts
 │   └── main.ts
-│
 ├── plugins/
 │   ├── simulation/
 │   │   ├── components/
@@ -106,7 +94,6 @@ project/
 │   │   │   └── (agent-defined systems)
 │   │   └── operations/
 │   │       └── (agent-defined handlers)
-│   │
 │   └── evaluation/
 │       ├── components/
 │       │   └── (agent-defined evaluation components)
@@ -114,7 +101,6 @@ project/
 │       │   └── (agent-defined evaluation systems)
 │       └── operations/
 │           └── (agent-defined evaluation handlers)
-│
 ├── package.json
 └── README.md
 ```


### PR DESCRIPTION
## Summary
- normalize the simulation project tree listing in `_codifying_simulations.md`
- apply the same corrected tree formatting to `Describing_Simulation_0.md`

## Testing
- python - <<'PY'
from rich.console import Console
from rich.markdown import Markdown
from pathlib import Path

console = Console()
for path in [Path('instruction_documents/_codifying_simulations.md'), Path('Describing_Simulation_0.md')]:
    console.rule(str(path))
    console.print(Markdown(path.read_text()))
PY


------
https://chatgpt.com/codex/tasks/task_e_68d5bb4fa094832ab4be87506443e6ff