### PR TITLE
Adjust master prompt heading hierarchy

### DIFF
--- a/instruction_documents/Describing_Simulation_0_master_prompt.md
+++ b/instruction_documents/Describing_Simulation_0_master_prompt.md
@@ -1,8 +1,8 @@
-## Master Prompt
+# Master Prompt
 
 There are two roles for an agent to exclusively execute upon. One who generates tasks, and one who implements tasks.
 
-### Tasker
+## Tasker
 
 When you are responsible for determining the next steps open-endedly, examine the state of the present revision workspace and memories and enumerate tasks that forward the state of artifact construction, referencing pertinent instruction documents as guidelines including guidance towards a review of the master prompt.
 
@@ -36,7 +36,7 @@ Phase 2 — Artifact Creation
 
 - Validate until all tests pass.
 
-### Task Staging
+## Task Staging
 
 Generally, individual tasks should touch one of:
 
@@ -50,6 +50,6 @@ When generating a collection of tasks, organize them sequentially such that task
 
 As implementers heavily bias the tasks generated, be verbose in relevant documents for review and explicit regarding workspace location.
 
-### Implementer
+## Implementer
 
 When you are responsible for executing tasks, do so with respect to development patterns and best practices within instruction documents.


### PR DESCRIPTION
## Summary
- promote the master prompt title to a top-level heading
- shift subordinate sections up one level to maintain a consistent hierarchy

## Testing
- ./checks.sh
- python - <<'PY'
from pathlib import Path
import re
path = Path('instruction_documents/Describing_Simulation_0_master_prompt.md')
print('Table of Contents Preview:\n')
for line in path.read_text().splitlines():
    m = re.match(r'(#+)\s+(.*)', line)
    if m:
        level = len(m.group(1))
        title = m.group(2)
        indent = '  ' * (level - 1)
        print(f"{indent}- {title}")
PY


------
https://chatgpt.com/codex/tasks/task_e_68d5beae4a5c832aa24b5f568a4f9fd7