### PR TITLE
Nest checkpoint steps as ordered list

### DIFF
--- a/instruction_documents/Describing_Simulation_0_master_prompt.md
+++ b/instruction_documents/Describing_Simulation_0_master_prompt.md
@@ -25,16 +25,11 @@ Phase 2 — Artifact Creation
 - Each checkpoint represents a coherent milestone, building on prior ones.
 
 - For each checkpoint:
-
-- Define skeletons (structure, empty methods).
-
-- Write test intents (comment-only).
-
-- Codify tests from intents.
-
-- Implement logic to satisfy tests.
-
-- Validate until all tests pass.
+    1. Define skeletons (structure, empty methods).
+    2. Write test intents (comment-only).
+    3. Codify tests from intents.
+    4. Implement logic to satisfy tests.
+    5. Validate until all tests pass.
 
 ### Task Staging
 

--- a/verifications/20250925T221513Z.log
+++ b/verifications/20250925T221513Z.log
@@ -1,0 +1,15 @@
+Running repository checks at 2025-09-25T22:15:13Z
+
+[PASS] Required file present: tools/index.md
+[PASS] Required directory present: workspaces/Describing_Simulation_0
+[PASS] Required file present: AGENTS.md
+[PASS] Required file present: instruction_documents/Describing_Simulation_0_master_prompt.md
+[PASS] Required file present: instruction_documents/Describing_Simulation_0_bootstraps.md
+[PASS] Required directory present: memory/ways
+[PASS] Required file present: instruction_documents/index.md
+[PASS] Required file present: instruction_documents/Describing_Simulation_0_codifying_simulations.md
+[PASS] Required directory present: verifications
+[PASS] Required file present: instruction_documents/Describing_Simulation_0_theory.md
+[PASS] Required directory present: memory/records
+
+All required paths are present.


### PR DESCRIPTION
## Summary
- indent the checkpoint workflow so the ordered steps render as a nested list under the parent bullet
- add verification log from running repository checks

## Testing
- ./checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68d5beb21ac8832a8d389b291ca59ba8