### PR TITLE
Document master prompt file in instruction trees

### DIFF
--- a/Describing_Simulation_0.md
+++ b/Describing_Simulation_0.md
@@ -527,6 +527,7 @@ Create instructions for future visitors to review the latest version of this doc
 │   ├── <this document's file name>_theory.md
 │   ├── <this document's file name>_bootstraps.md
 │   ├── <this document's file name>_codifying_simulations.md
+│   ├── <this document's file name>_master_prompt.md
 │   └── index.md
 ├── tools/
 │   └── index.md

--- a/instruction_documents/Describing_Simulation_0_bootstraps.md
+++ b/instruction_documents/Describing_Simulation_0_bootstraps.md
@@ -23,6 +23,7 @@ Create instructions for future visitors to review the latest version of this doc
 │   ├── <this document's file name>_theory.md
 │   ├── <this document's file name>_bootstraps.md
 │   ├── <this document's file name>_codifying_simulations.md
+│   ├── <this document's file name>_master_prompt.md
 │   └── index.md
 ├── tools/
 │   └── index.md

--- a/verifications/20250925T222049Z.log
+++ b/verifications/20250925T222049Z.log
@@ -1,0 +1,15 @@
+Running repository checks at 2025-09-25T22:20:49Z
+
+[PASS] Required file present: tools/index.md
+[PASS] Required directory present: workspaces/Describing_Simulation_0
+[PASS] Required file present: AGENTS.md
+[PASS] Required file present: instruction_documents/Describing_Simulation_0_master_prompt.md
+[PASS] Required file present: instruction_documents/Describing_Simulation_0_bootstraps.md
+[PASS] Required directory present: memory/ways
+[PASS] Required file present: instruction_documents/index.md
+[PASS] Required file present: instruction_documents/Describing_Simulation_0_codifying_simulations.md
+[PASS] Required directory present: verifications
+[PASS] Required file present: instruction_documents/Describing_Simulation_0_theory.md
+[PASS] Required directory present: memory/records
+
+All required paths are present.


### PR DESCRIPTION
## Summary
- add the master prompt instruction file to the repository layout tree in the main description document
- mirror the tree update in the bootstraps instruction to keep the diagrams aligned
- record the latest repository checks output

## Testing
- ./checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68d5c0202268832aa8aac92f17d182be