### PR TITLE
Normalize descriptions tree formatting

### DIFF
--- a/Describing_Simulation_0.md
+++ b/Describing_Simulation_0.md
@@ -477,20 +477,15 @@ This is a flow we will revisit at various points when enough information has bee
 Descriptions
 
 ├─► Stage 1: Skeletons (structure, empty methods)
-
-└─► Stage 2: Test Intents (comment-only requirements)
-
-Stage 3: Codify Tests
-
-└─ Join (Skeletons + Test Intents) → Actual tests
-
-Stage 4: Implement Logic
-
-└─ Fill skeletons to satisfy tests
-
-Stage 5: Validate
-
-└─ Run tests → Errors → Iterate until green
+│   └─► Draft the file layout and placeholder methods
+├─► Stage 2: Test Intents (comment-only requirements)
+│   └─► Capture desired behaviors as descriptive comments
+├─► Stage 3: Codify Tests
+│   └─► Join Skeletons + Test Intents → Actual tests
+├─► Stage 4: Implement Logic
+│   └─► Fill skeletons to satisfy tests
+└─► Stage 5: Validate
+    └─► Run tests → Errors → Iterate until green
 
 To be clear, this document upon delivery to you, the reader, should provide logic that is compilable to code.
 

--- a/verifications/20250925T222111Z.log
+++ b/verifications/20250925T222111Z.log
@@ -1,0 +1,15 @@
+Running repository checks at 2025-09-25T22:21:11Z
+
+[PASS] Required file present: tools/index.md
+[PASS] Required directory present: workspaces/Describing_Simulation_0
+[PASS] Required file present: AGENTS.md
+[PASS] Required file present: instruction_documents/Describing_Simulation_0_master_prompt.md
+[PASS] Required file present: instruction_documents/Describing_Simulation_0_bootstraps.md
+[PASS] Required directory present: memory/ways
+[PASS] Required file present: instruction_documents/index.md
+[PASS] Required file present: instruction_documents/Describing_Simulation_0_codifying_simulations.md
+[PASS] Required directory present: verifications
+[PASS] Required file present: instruction_documents/Describing_Simulation_0_theory.md
+[PASS] Required directory present: memory/records
+
+All required paths are present.


### PR DESCRIPTION
## Summary
- rewrite the Descriptions workflow tree so each stage uses consistent branch markers and indented notes
- document the per-stage guidance directly beneath each stage to keep the tree readable in rendered Markdown

## Testing
- ./checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68d5c02137d0832a9354e07fb3577c3e