### PR TITLE
Add lifecycle-managed system base class

### DIFF
--- a/verifications/20250926T043849Z.log
+++ b/verifications/20250926T043849Z.log
@@ -1,0 +1,25 @@
+Running repository checks at 2025-09-26T04:38:49Z
+
+[PASS] Required file present: tools/index.md
+[PASS] Required directory present: workspaces/Describing_Simulation_0
+[PASS] Required file present: AGENTS.md
+[PASS] Required file present: instruction_documents/Describing_Simulation_0_master_prompt.md
+[PASS] Required file present: instruction_documents/Describing_Simulation_0_bootstraps.md
+[PASS] Required directory present: memory/ways
+[PASS] Required file present: instruction_documents/index.md
+[PASS] Required file present: instruction_documents/Describing_Simulation_0_codifying_simulations.md
+[PASS] Required directory present: verifications
+[PASS] Required file present: instruction_documents/Describing_Simulation_0_theory.md
+[PASS] Required directory present: memory/records
+
+All required paths are present.
+
+Running Describing Simulation 0 project tests...
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> @describing-simulation/core@0.1.0 test
+> jest --runInBand --runInBand
+
+sh: 1: jest: not found
+
+[FAIL] Workspace project tests failed.

--- a/verifications/20250926T043857Z.log
+++ b/verifications/20250926T043857Z.log
@@ -1,0 +1,33 @@
+Running repository checks at 2025-09-26T04:38:57Z
+
+[PASS] Required file present: tools/index.md
+[PASS] Required directory present: workspaces/Describing_Simulation_0
+[PASS] Required file present: AGENTS.md
+[PASS] Required file present: instruction_documents/Describing_Simulation_0_master_prompt.md
+[PASS] Required file present: instruction_documents/Describing_Simulation_0_bootstraps.md
+[PASS] Required directory present: memory/ways
+[PASS] Required file present: instruction_documents/index.md
+[PASS] Required file present: instruction_documents/Describing_Simulation_0_codifying_simulations.md
+[PASS] Required directory present: verifications
+[PASS] Required file present: instruction_documents/Describing_Simulation_0_theory.md
+[PASS] Required directory present: memory/records
+
+All required paths are present.
+
+Running Describing Simulation 0 project tests...
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> @describing-simulation/core@0.1.0 test
+> jest --runInBand --runInBand
+
+PASS tests/ComponentManager.spec.ts
+PASS tests/EntityManager.spec.ts
+PASS tests/System.spec.ts
+
+Test Suites: 3 passed, 3 total
+Tests:       8 passed, 8 total
+Snapshots:   0 total
+Time:        2.622 s
+Ran all test suites.
+
+[PASS] Workspace project tests succeeded.

--- a/workspaces/Describing_Simulation_0/project/package-lock.json
+++ b/workspaces/Describing_Simulation_0/project/package-lock.json
@@ -1,13 +1,12 @@
 {
-  "name": "project",
-  "version": "1.0.0",
+  "name": "@describing-simulation/core",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "project",
-      "version": "1.0.0",
-      "license": "ISC",
+      "name": "@describing-simulation/core",
+      "version": "0.1.0",
       "devDependencies": {
         "@types/jest": "^30.0.0",
         "jest": "^30.1.3",

--- a/workspaces/Describing_Simulation_0/project/src/core/systems/System.ts
+++ b/workspaces/Describing_Simulation_0/project/src/core/systems/System.ts
@@ -1,0 +1,57 @@
+/**
+ * Base class for simulation systems exposing a simple lifecycle contract.
+ */
+export abstract class System {
+  private initialized = false;
+  private destroyed = false;
+
+  /**
+   * Prepares the system for execution. The initialization hook is executed only once.
+   */
+  init(): void {
+    if (this.destroyed) {
+      throw new Error('Cannot initialize a system that has been destroyed.');
+    }
+
+    if (!this.initialized) {
+      this.initialized = true;
+      this.onInit();
+    }
+  }
+
+  /**
+   * Executes one update tick, ensuring the system has been initialized and not yet destroyed.
+   */
+  tick(deltaTime: number): void {
+    if (!this.initialized) {
+      this.init();
+    }
+
+    if (this.destroyed) {
+      throw new Error('Cannot update a system that has been destroyed.');
+    }
+
+    this.update(deltaTime);
+  }
+
+  /**
+   * Tears the system down, invoking the teardown hook once.
+   */
+  destroy(): void {
+    if (!this.initialized || this.destroyed) {
+      return;
+    }
+
+    this.destroyed = true;
+    this.onDestroy();
+  }
+
+  /** Lifecycle hook for subclasses to override during initialization. */
+  protected onInit(): void {}
+
+  /** Lifecycle hook for subclasses to override during teardown. */
+  protected onDestroy(): void {}
+
+  /** Subclasses implement their execution logic here. */
+  protected abstract update(deltaTime: number): void;
+}

--- a/workspaces/Describing_Simulation_0/project/tests/System.spec.ts
+++ b/workspaces/Describing_Simulation_0/project/tests/System.spec.ts
@@ -1,0 +1,46 @@
+// Test intents:
+// - Systems initialize before running their first update tick.
+// - Systems invoke teardown once and reject further updates after destruction.
+
+import { System } from 'src/core/systems/System';
+
+describe('System', () => {
+  it('runs initialization before the first update and records execution order', () => {
+    class TestSystem extends System {
+      public readonly calls: string[] = [];
+
+      protected override onInit(): void {
+        this.calls.push('init');
+      }
+
+      protected override update(deltaTime: number): void {
+        this.calls.push(`update:${deltaTime}`);
+      }
+
+      protected override onDestroy(): void {
+        this.calls.push('destroy');
+      }
+    }
+
+    const system = new TestSystem();
+
+    system.tick(0.016);
+    system.tick(0.02);
+    system.destroy();
+
+    expect(system.calls).toEqual(['init', 'update:0.016', 'update:0.02', 'destroy']);
+  });
+
+  it('prevents updates once destroyed', () => {
+    class DisposableSystem extends System {
+      protected override update(): void {}
+    }
+
+    const system = new DisposableSystem();
+
+    system.tick(0);
+    system.destroy();
+
+    expect(() => system.tick(0)).toThrow('Cannot update a system that has been destroyed.');
+  });
+});


### PR DESCRIPTION
## Summary
- add a System base class with initialization, update ticking, and teardown lifecycle hooks
- cover the new lifecycle contract with Jest specs for init-update-destroy ordering
- refresh the workspace lockfile and record verification logs after installing dependencies

## Testing
- ./checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68d618931fd0832a835a1263c920e3a8