### PR TITLE
Add time tracking system and component

### DIFF
--- a/workspaces/Describing_Simulation_0/project/src/core/components/TimeComponent.ts
+++ b/workspaces/Describing_Simulation_0/project/src/core/components/TimeComponent.ts
@@ -1,0 +1,13 @@
+import { ComponentType } from './ComponentType';
+
+/**
+ * Component tracking the accumulated simulation time in seconds.
+ */
+export interface TimeComponent {
+  /** Total elapsed simulation time in seconds. */
+  elapsed: number;
+}
+
+/** Identifier for the shared {@link TimeComponent} instance. */
+export const TIME_COMPONENT = new ComponentType<TimeComponent>('time');
+

--- a/workspaces/Describing_Simulation_0/project/src/core/systems/TimeSystem.ts
+++ b/workspaces/Describing_Simulation_0/project/src/core/systems/TimeSystem.ts
@@ -1,0 +1,47 @@
+import { ComponentManager } from '../components/ComponentManager';
+import { TIME_COMPONENT, TimeComponent } from '../components/TimeComponent';
+import { EntityManager } from '../entity/EntityManager';
+import { System } from './System';
+
+/**
+ * Maintains a single global time entity whose component accumulates elapsed seconds.
+ */
+export class TimeSystem extends System {
+  private static readonly ENTITY_ID = 'time';
+  private timeEntityId: string | undefined;
+
+  constructor(
+    private readonly entities: EntityManager,
+    private readonly components: ComponentManager
+  ) {
+    super();
+  }
+
+  protected override onInit(): void {
+    if (!this.components.isRegistered(TIME_COMPONENT)) {
+      this.components.register(TIME_COMPONENT);
+    }
+
+    const entity =
+      this.entities.get(TimeSystem.ENTITY_ID) ??
+      this.entities.create(TimeSystem.ENTITY_ID);
+
+    this.timeEntityId = entity.id;
+
+    if (!this.components.hasComponent(entity.id, TIME_COMPONENT)) {
+      this.components.setComponent(entity.id, TIME_COMPONENT, { elapsed: 0 });
+    }
+  }
+
+  protected override update(deltaTime: number): void {
+    if (!this.timeEntityId) {
+      throw new Error('Time entity not initialized.');
+    }
+
+    const current = this.components.getComponent(this.timeEntityId, TIME_COMPONENT);
+    const elapsed = (current?.elapsed ?? 0) + deltaTime;
+    const next: TimeComponent = { elapsed };
+
+    this.components.setComponent(this.timeEntityId, TIME_COMPONENT, next);
+  }
+}

--- a/workspaces/Describing_Simulation_0/project/tests/TimeSystem.spec.ts
+++ b/workspaces/Describing_Simulation_0/project/tests/TimeSystem.spec.ts
@@ -1,0 +1,36 @@
+// Test intents:
+// - Ensure the time system creates a singleton time entity on initialization.
+// - Accumulate elapsed seconds on the time component for each update tick.
+
+import { ComponentManager } from 'src/core/components/ComponentManager';
+import { TIME_COMPONENT } from 'src/core/components/TimeComponent';
+import { EntityManager } from 'src/core/entity/EntityManager';
+import { TimeSystem } from 'src/core/systems/TimeSystem';
+
+describe('TimeSystem', () => {
+  it('creates the time entity with a zeroed component when initialized', () => {
+    const entities = new EntityManager();
+    const components = new ComponentManager();
+    const system = new TimeSystem(entities, components);
+
+    system.init();
+
+    expect(entities.has('time')).toBe(true);
+    const timeEntity = entities.get('time');
+    expect(timeEntity).toBeDefined();
+    const timeComponent = components.getComponent(timeEntity!.id, TIME_COMPONENT);
+    expect(timeComponent).toEqual({ elapsed: 0 });
+  });
+
+  it('increments the time component by delta each update', () => {
+    const entities = new EntityManager();
+    const components = new ComponentManager();
+    const system = new TimeSystem(entities, components);
+
+    system.tick(0.5);
+    system.tick(1.5);
+
+    const timeComponent = components.getComponent('time', TIME_COMPONENT);
+    expect(timeComponent).toEqual({ elapsed: 2 });
+  });
+});


### PR DESCRIPTION
## Summary
- add a time component descriptor for tracking elapsed seconds
- implement a time system that creates the global time entity and accumulates elapsed time
- cover the new behaviour with Jest unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d619c2cbbc832aa50a10cbd42fa1e3