### PR TITLE
Add entity component queries to ComponentManager

### DIFF
--- a/workspaces/Describing_Simulation_0/project/src/core/components/ComponentManager.ts
+++ b/workspaces/Describing_Simulation_0/project/src/core/components/ComponentManager.ts
@@ -37,6 +37,25 @@ export class ComponentManager {
     return store.has(entityId);
   }
 
+  getComponentsForEntity(entityId: string): Map<ComponentType<unknown>, unknown> {
+    const components = new Map<ComponentType<unknown>, unknown>();
+
+    for (const [typeName, store] of this.stores.entries()) {
+      if (!store.has(entityId)) {
+        continue;
+      }
+
+      const type = this.registry.get(typeName);
+      if (!type) {
+        continue;
+      }
+
+      components.set(type, store.get(entityId));
+    }
+
+    return components;
+  }
+
   removeComponent(entityId: string, type: ComponentType<unknown>): boolean {
     const store = this.getStore(type);
     return store.delete(entityId);
@@ -52,6 +71,11 @@ export class ComponentManager {
 
   registeredTypes(): ComponentType<unknown>[] {
     return Array.from(this.registry.values());
+  }
+
+  entitiesWithComponent(type: ComponentType<unknown>): string[] {
+    const store = this.getStore(type);
+    return Array.from(store.keys());
   }
 
   private getStore(type: ComponentType<unknown>): Map<string, unknown> {

--- a/workspaces/Describing_Simulation_0/project/tests/ComponentManager.spec.ts
+++ b/workspaces/Describing_Simulation_0/project/tests/ComponentManager.spec.ts
@@ -1,6 +1,7 @@
 // Test intents:
 // - Register component types once and guard against duplicates.
 // - Attach, query, update, and remove components for entities.
+// - Query every component stored by an entity and all entities storing a component.
 // - Clearing an entity removes all of its registered components.
 
 import { ComponentManager } from 'src/core/components/ComponentManager';
@@ -36,6 +37,56 @@ describe('ComponentManager', () => {
     expect(componentManager.removeComponent(entity.id, health)).toBe(true);
     expect(componentManager.hasComponent(entity.id, health)).toBe(false);
     expect(componentManager.removeComponent(entity.id, health)).toBe(false);
+  });
+
+  it('lists all components stored for an entity by their type', () => {
+    const entityManager = new EntityManager();
+    const componentManager = new ComponentManager();
+    const health = new ComponentType<{ hp: number }>('health');
+    const position = new ComponentType<{ x: number; y: number }>('position');
+
+    componentManager.register(health);
+    componentManager.register(position);
+
+    const player = entityManager.create('player');
+    const npc = entityManager.create('npc');
+
+    componentManager.setComponent(player.id, health, { hp: 12 });
+    componentManager.setComponent(player.id, position, { x: 5, y: 6 });
+    componentManager.setComponent(npc.id, health, { hp: 3 });
+
+    const playerComponents = componentManager.getComponentsForEntity(player.id);
+    expect(playerComponents.size).toBe(2);
+    expect(playerComponents.get(health)).toEqual({ hp: 12 });
+    expect(playerComponents.get(position)).toEqual({ x: 5, y: 6 });
+
+    const npcComponents = componentManager.getComponentsForEntity(npc.id);
+    expect(npcComponents.size).toBe(1);
+    expect(npcComponents.get(health)).toEqual({ hp: 3 });
+    expect(npcComponents.has(position)).toBe(false);
+  });
+
+  it('lists entity ids storing a specific component type', () => {
+    const entityManager = new EntityManager();
+    const componentManager = new ComponentManager();
+    const health = new ComponentType<{ hp: number }>('health');
+    const position = new ComponentType<{ x: number; y: number }>('position');
+
+    componentManager.register(health);
+    componentManager.register(position);
+
+    const player = entityManager.create('player');
+    const npc = entityManager.create('npc');
+
+    componentManager.setComponent(player.id, health, { hp: 8 });
+    componentManager.setComponent(npc.id, health, { hp: 4 });
+    componentManager.setComponent(player.id, position, { x: 1, y: 2 });
+
+    expect(componentManager.entitiesWithComponent(health)).toEqual([player.id, npc.id]);
+    expect(componentManager.entitiesWithComponent(position)).toEqual([player.id]);
+
+    componentManager.removeComponent(player.id, health);
+    expect(componentManager.entitiesWithComponent(health)).toEqual([npc.id]);
   });
 
   it('clears all components for a removed entity', () => {


### PR DESCRIPTION
## Summary
- add an API that collects every component stored for an entity keyed by its component type
- expose a helper to list every entity currently storing a given component type
- extend the ComponentManager tests to document the new queries alongside existing behaviors

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d61d3093c8832abaff5bea88bd5e5a