### PR TITLE
Ensure entities clean up components on removal

### DIFF
--- a/workspaces/Describing_Simulation_0/project/src/core/entity/EntityManager.ts
+++ b/workspaces/Describing_Simulation_0/project/src/core/entity/EntityManager.ts
@@ -1,3 +1,4 @@
+import { ComponentManager } from '../components/ComponentManager';
 import { Entity } from './Entity';
 
 /**
@@ -6,6 +7,8 @@ import { Entity } from './Entity';
 export class EntityManager {
   private readonly entities = new Map<string, Entity>();
   private nextId = 1;
+
+  constructor(private readonly componentManager?: ComponentManager) {}
 
   /**
    * Creates a new {@link Entity}. When an explicit id is not provided a
@@ -43,7 +46,14 @@ export class EntityManager {
    * @returns `true` when the entity existed and has been removed.
    */
   remove(id: string): boolean {
-    return this.entities.delete(id);
+    const existed = this.entities.has(id);
+    if (!existed) {
+      return false;
+    }
+
+    this.componentManager?.removeAllComponents(id);
+    this.entities.delete(id);
+    return true;
   }
 
   /**

--- a/workspaces/Describing_Simulation_0/project/tests/EntityManager.spec.ts
+++ b/workspaces/Describing_Simulation_0/project/tests/EntityManager.spec.ts
@@ -1,8 +1,11 @@
 // Test intents:
 // - Creating entities without an explicit id yields sequential identifiers.
 // - Entities can be retrieved after creation and are removed cleanly.
+// - Removing an entity automatically clears its registered components.
 
 import { EntityManager } from 'src/core/entity/EntityManager';
+import { ComponentManager } from 'src/core/components/ComponentManager';
+import { ComponentType } from 'src/core/components/ComponentType';
 
 describe('EntityManager', () => {
   it('creates entities with sequential identifiers by default', () => {
@@ -32,5 +35,20 @@ describe('EntityManager', () => {
     expect(manager.remove(entity.id)).toBe(true);
     expect(manager.get(entity.id)).toBeUndefined();
     expect(manager.remove(entity.id)).toBe(false);
+  });
+
+  it('cleans up components when removing entities', () => {
+    const componentManager = new ComponentManager();
+    const manager = new EntityManager(componentManager);
+    const health = new ComponentType<{ hp: number }>('health');
+
+    componentManager.register(health);
+
+    const entity = manager.create();
+    componentManager.setComponent(entity.id, health, { hp: 10 });
+    expect(componentManager.hasComponent(entity.id, health)).toBe(true);
+
+    expect(manager.remove(entity.id)).toBe(true);
+    expect(componentManager.hasComponent(entity.id, health)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- allow `EntityManager` to receive a `ComponentManager` dependency and clear entity components before deletion
- extend the `EntityManager` test suite to cover automatic component cleanup and document the new intent

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d61de2d7e8832a83a089080eb70e57