### PR TITLE
Add simulation player lifecycle controller

### DIFF
--- a/workspaces/Describing_Simulation_0/project/src/core/Player.ts
+++ b/workspaces/Describing_Simulation_0/project/src/core/Player.ts
@@ -1,0 +1,129 @@
+import { ComponentManager } from './components/ComponentManager';
+import { EntityManager } from './entity/EntityManager';
+import { SystemManager } from './systems/SystemManager';
+
+export interface PlayerOptions {
+  /** Interval between ticks in milliseconds. */
+  tickIntervalMs?: number;
+  /**
+   * Provides the current timestamp in milliseconds. Used for calculating delta
+   * time between ticks. Defaults to {@link Date.now}.
+   */
+  timeProvider?: () => number;
+}
+
+type PlayerState = 'idle' | 'running' | 'paused';
+
+/**
+ * Coordinates simulation execution by advancing registered systems on a fixed
+ * cadence while exposing lifecycle controls to pause or tear down the
+ * simulation state.
+ */
+export class Player {
+  private readonly tickIntervalMs: number;
+  private readonly timeProvider: () => number;
+  private loopHandle: NodeJS.Timeout | null = null;
+  private state: PlayerState = 'idle';
+  private lastTickTime: number | null = null;
+
+  constructor(
+    private readonly entities: EntityManager,
+    private readonly components: ComponentManager,
+    private readonly systems: SystemManager,
+    options: PlayerOptions = {}
+  ) {
+    const interval = options.tickIntervalMs ?? 16;
+    this.tickIntervalMs = interval > 0 ? interval : 1;
+    this.timeProvider = options.timeProvider ?? (() => Date.now());
+  }
+
+  /** Starts the simulation loop if it has not yet begun. */
+  start(): void {
+    if (this.state !== 'idle') {
+      return;
+    }
+
+    this.state = 'running';
+    this.beginLoop();
+  }
+
+  /** Temporarily halts the simulation loop without tearing down state. */
+  pause(): void {
+    if (this.state !== 'running') {
+      return;
+    }
+
+    this.state = 'paused';
+    this.clearLoop();
+  }
+
+  /** Resumes the simulation loop after a {@link pause}. */
+  resume(): void {
+    if (this.state !== 'paused') {
+      return;
+    }
+
+    this.state = 'running';
+    this.beginLoop();
+  }
+
+  /** Stops the simulation loop and tears down all managed state. */
+  stop(): void {
+    if (this.state === 'running' || this.state === 'paused') {
+      this.clearLoop();
+    }
+
+    this.state = 'idle';
+    this.lastTickTime = null;
+    this.teardown();
+  }
+
+  private beginLoop(): void {
+    this.lastTickTime = this.timeProvider();
+    this.clearLoop();
+    this.loopHandle = setInterval(() => this.step(), this.tickIntervalMs);
+  }
+
+  private clearLoop(): void {
+    if (this.loopHandle) {
+      clearInterval(this.loopHandle);
+      this.loopHandle = null;
+    }
+  }
+
+  private step(): void {
+    if (this.state !== 'running') {
+      return;
+    }
+
+    const currentTime = this.timeProvider();
+    const previousTime = this.lastTickTime ?? currentTime;
+    this.lastTickTime = currentTime;
+
+    const deltaMs = Math.max(0, currentTime - previousTime);
+    this.systems.tick(deltaMs / 1000);
+  }
+
+  private teardown(): void {
+    this.systems.destroyAll();
+
+    const entityIds = new Set<string>();
+    for (const entity of this.entities.list()) {
+      entityIds.add(entity.id);
+    }
+
+    for (const type of this.components.registeredTypes()) {
+      for (const entityId of this.components.entitiesWithComponent(type)) {
+        entityIds.add(entityId);
+      }
+    }
+
+    for (const entityId of entityIds) {
+      if (this.entities.has(entityId)) {
+        this.entities.remove(entityId);
+      }
+
+      this.components.removeAllComponents(entityId);
+    }
+  }
+}

--- a/workspaces/Describing_Simulation_0/project/tests/Player.spec.ts
+++ b/workspaces/Describing_Simulation_0/project/tests/Player.spec.ts
@@ -1,0 +1,112 @@
+import { Player } from '../src/core/Player';
+import { ComponentManager } from '../src/core/components/ComponentManager';
+import { ComponentType } from '../src/core/components/ComponentType';
+import { EntityManager } from '../src/core/entity/EntityManager';
+import { SystemManager } from '../src/core/systems/SystemManager';
+
+describe('Player', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it('advances registered systems on the configured cadence', () => {
+    const components = new ComponentManager();
+    const entities = new EntityManager(components);
+    const systems = new SystemManager();
+    const tickSpy = jest.spyOn(systems, 'tick');
+
+    let currentTime = 0;
+    const timeProvider = jest.fn(() => currentTime);
+
+    const player = new Player(entities, components, systems, {
+      tickIntervalMs: 20,
+      timeProvider,
+    });
+
+    player.start();
+
+    expect(timeProvider).toHaveBeenCalledTimes(1);
+
+    currentTime += 20;
+    jest.advanceTimersByTime(20);
+
+    expect(tickSpy).toHaveBeenCalledTimes(1);
+    expect(tickSpy).toHaveBeenLastCalledWith(0.02);
+
+    currentTime += 20;
+    jest.advanceTimersByTime(20);
+
+    expect(tickSpy).toHaveBeenCalledTimes(2);
+    expect(tickSpy).toHaveBeenLastCalledWith(0.02);
+
+    player.stop();
+  });
+
+  it('pauses and resumes without accumulating paused time', () => {
+    const components = new ComponentManager();
+    const entities = new EntityManager(components);
+    const systems = new SystemManager();
+    const tickSpy = jest.spyOn(systems, 'tick');
+
+    let currentTime = 0;
+    const timeProvider = jest.fn(() => currentTime);
+
+    const player = new Player(entities, components, systems, {
+      tickIntervalMs: 10,
+      timeProvider,
+    });
+
+    player.start();
+
+    currentTime += 10;
+    jest.advanceTimersByTime(10);
+    expect(tickSpy).toHaveBeenCalledTimes(1);
+    expect(tickSpy).toHaveBeenLastCalledWith(0.01);
+
+    player.pause();
+
+    currentTime += 50;
+    jest.advanceTimersByTime(50);
+    expect(tickSpy).toHaveBeenCalledTimes(1);
+
+    player.resume();
+
+    currentTime += 10;
+    jest.advanceTimersByTime(10);
+    expect(tickSpy).toHaveBeenCalledTimes(2);
+    expect(tickSpy).toHaveBeenLastCalledWith(0.01);
+
+    player.stop();
+  });
+
+  it('tears down entities, components, and systems when stopped', () => {
+    const components = new ComponentManager();
+    const entities = new EntityManager(components);
+    const systems = new SystemManager();
+    const destroySpy = jest.spyOn(systems, 'destroyAll');
+
+    const SampleComponent = new ComponentType<{ value: number }>('sample');
+    components.register(SampleComponent);
+
+    const entity = entities.create('entity');
+    components.setComponent(entity.id, SampleComponent, { value: 42 });
+
+    const player = new Player(entities, components, systems, {
+      tickIntervalMs: 5,
+    });
+
+    player.start();
+    player.stop();
+
+    expect(destroySpy).toHaveBeenCalledTimes(1);
+    expect(entities.list()).toHaveLength(0);
+    expect(
+      components.getComponentsForEntity(entity.id).size
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add a Player controller that manages system ticking, lifecycle transitions, and cleanup
- cover the new lifecycle with Jest specs verifying cadence, pause/resume, and teardown behavior

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d61f6b9bd0832ab1015e23aef41030