### PR TITLE
Add messaging bus infrastructure and tests

### DIFF
--- a/workspaces/Describing_Simulation_0/project/src/core/messaging/Bus.ts
+++ b/workspaces/Describing_Simulation_0/project/src/core/messaging/Bus.ts
@@ -1,0 +1,96 @@
+import {
+  combineAcknowledgements,
+  noAcknowledgement,
+  normalizeAcknowledgement,
+  type Acknowledgement,
+} from './outbound/Acknowledgement';
+import { createFrame, type Frame } from './outbound/Frame';
+import { matchAll, matchType, type FrameFilter } from './outbound/FrameFilter';
+import type { MessageHandler } from './inbound/MessageHandler';
+
+interface Subscriber {
+  readonly filter: FrameFilter;
+  readonly handler: MessageHandler;
+}
+
+/**
+ * Lightweight synchronous message bus used by systems inside the simulation.
+ *
+ * The bus enforces minimal constraints on message shape by working with the
+ * {@link Frame} interface. Code that requires stronger typing can extend the
+ * frame interface through declaration merging, or narrow frames via
+ * {@link FrameFilter}s when subscribing.
+ */
+export class Bus {
+  private readonly subscribers = new Set<Subscriber>();
+
+  subscribe(filter: FrameFilter, handler: MessageHandler): () => void;
+  subscribe(type: string, handler: MessageHandler): () => void;
+  subscribe(handler: MessageHandler): () => void;
+  subscribe(
+    filterOrTypeOrHandler: FrameFilter | string | MessageHandler,
+    maybeHandler?: MessageHandler,
+  ): () => void {
+    let filter: FrameFilter;
+    let handler: MessageHandler;
+
+    if (typeof filterOrTypeOrHandler === 'string') {
+      filter = matchType(filterOrTypeOrHandler);
+      handler = maybeHandler as MessageHandler;
+    } else if (typeof filterOrTypeOrHandler === 'function' && maybeHandler) {
+      filter = filterOrTypeOrHandler as FrameFilter;
+      handler = maybeHandler;
+    } else {
+      filter = matchAll;
+      handler = filterOrTypeOrHandler as MessageHandler;
+    }
+
+    if (typeof handler !== 'function') {
+      throw new Error('A subscriber must provide a handler function.');
+    }
+
+    const subscriber: Subscriber = { filter, handler };
+
+    this.subscribers.add(subscriber);
+
+    return () => {
+      this.subscribers.delete(subscriber);
+    };
+  }
+
+  /**
+   * Sends a frame through the bus to all subscribers whose filter matches.
+   */
+  send(frame: Frame): Acknowledgement;
+  send<TPayload, TMetadata extends Record<string, unknown> = Record<string, unknown>>(
+    type: string,
+    payload: TPayload,
+    metadata?: Partial<TMetadata>,
+  ): Acknowledgement;
+  send(
+    frameOrType: Frame | string,
+    payload?: unknown,
+    metadata?: Record<string, unknown>,
+  ): Acknowledgement {
+    const frame: Frame =
+      typeof frameOrType === 'string'
+        ? createFrame(frameOrType, payload, metadata)
+        : frameOrType;
+
+    const acknowledgements: Acknowledgement[] = [];
+
+    for (const subscriber of this.subscribers) {
+      if (subscriber.filter(frame as never)) {
+        acknowledgements.push(
+          normalizeAcknowledgement(subscriber.handler(frame as never, this)),
+        );
+      }
+    }
+
+    if (acknowledgements.length === 0) {
+      return noAcknowledgement();
+    }
+
+    return combineAcknowledgements(acknowledgements);
+  }
+}

--- a/workspaces/Describing_Simulation_0/project/src/core/messaging/inbound/InboundHandlerRegistry.ts
+++ b/workspaces/Describing_Simulation_0/project/src/core/messaging/inbound/InboundHandlerRegistry.ts
@@ -1,0 +1,59 @@
+import type { Bus } from '../Bus';
+import type { Operation } from './Operation';
+import {
+  combineAcknowledgements,
+  noAcknowledgement,
+  normalizeAcknowledgement,
+  type Acknowledgement,
+} from '../outbound/Acknowledgement';
+import type { Frame } from '../outbound/Frame';
+
+/**
+ * Registry that coordinates inbound message handlers.
+ *
+ * The registry mirrors the subscription semantics of {@link Bus} while keeping
+ * handler management separate. It enables systems to register declarative
+ * operations and let the registry handle dispatch bookkeeping.
+ */
+export class InboundHandlerRegistry {
+  private readonly operations = new Map<string, Operation>();
+
+  /**
+   * Registers an operation with the registry.
+   *
+   * Returns a function that removes the operation when invoked. Duplicate
+   * identifiers are rejected to prevent accidental double-registration.
+   */
+  register(operation: Operation): () => void {
+    if (this.operations.has(operation.id)) {
+      throw new Error(`Operation with id "${operation.id}" is already registered.`);
+    }
+
+    this.operations.set(operation.id, operation);
+
+    return () => {
+      this.operations.delete(operation.id);
+    };
+  }
+
+  /**
+   * Dispatches the provided frame to all matching operations.
+   */
+  dispatch(frame: Frame, bus: Bus): Acknowledgement {
+    const acknowledgements: Acknowledgement[] = [];
+
+    for (const operation of this.operations.values()) {
+      if (operation.filter(frame as never)) {
+        acknowledgements.push(
+          normalizeAcknowledgement(operation.handle(frame as never, bus)),
+        );
+      }
+    }
+
+    if (acknowledgements.length === 0) {
+      return noAcknowledgement();
+    }
+
+    return combineAcknowledgements(acknowledgements);
+  }
+}

--- a/workspaces/Describing_Simulation_0/project/src/core/messaging/inbound/MessageHandler.ts
+++ b/workspaces/Describing_Simulation_0/project/src/core/messaging/inbound/MessageHandler.ts
@@ -1,0 +1,15 @@
+import type { Bus } from '../Bus';
+import type { Acknowledgement } from '../outbound/Acknowledgement';
+import type { Frame } from '../outbound/Frame';
+
+/**
+ * Function signature for processing inbound frames.
+ *
+ * Handlers can return an {@link Acknowledgement} when they need to influence the
+ * aggregate delivery reporting. Omitting the return value implies that the frame
+ * was consumed successfully.
+ */
+export type MessageHandler<TFrame extends Frame = Frame> = (
+  frame: TFrame,
+  bus: Bus,
+) => Acknowledgement | void;

--- a/workspaces/Describing_Simulation_0/project/src/core/messaging/inbound/Operation.ts
+++ b/workspaces/Describing_Simulation_0/project/src/core/messaging/inbound/Operation.ts
@@ -1,0 +1,17 @@
+import type { Frame } from '../outbound/Frame';
+import type { FrameFilter } from '../outbound/FrameFilter';
+import type { MessageHandler } from './MessageHandler';
+
+/**
+ * Describes a handler that should be invoked when an inbound frame matches the
+ * associated {@link FrameFilter}. Operations can be uniquely identified to make
+ * debugging and registry manipulation easier.
+ */
+export interface Operation<TFrame extends Frame = Frame> {
+  /** Debug-friendly identifier for the handler. */
+  readonly id: string;
+  /** Predicate used to determine whether the handler should receive the frame. */
+  readonly filter: FrameFilter<TFrame>;
+  /** Function that processes the frame when the filter matches. */
+  readonly handle: MessageHandler<TFrame>;
+}

--- a/workspaces/Describing_Simulation_0/project/src/core/messaging/index.ts
+++ b/workspaces/Describing_Simulation_0/project/src/core/messaging/index.ts
@@ -1,0 +1,7 @@
+export * from './Bus';
+export * from './outbound/Acknowledgement';
+export * from './outbound/Frame';
+export * from './outbound/FrameFilter';
+export * from './inbound/InboundHandlerRegistry';
+export * from './inbound/MessageHandler';
+export * from './inbound/Operation';

--- a/workspaces/Describing_Simulation_0/project/src/core/messaging/outbound/Acknowledgement.ts
+++ b/workspaces/Describing_Simulation_0/project/src/core/messaging/outbound/Acknowledgement.ts
@@ -1,0 +1,67 @@
+/**
+ * Represents the result of delivering a message frame to one or more subscribers.
+ *
+ * The acknowledgement structure intentionally keeps the surface area small so that
+ * future systems (e.g. remote transports) can extend it with additional delivery
+ * metadata without breaking the synchronous bus helpers defined in this module.
+ */
+export interface Acknowledgement {
+  /** Number of handlers that received the frame. */
+  readonly deliveries: number;
+  /** Convenience flag indicating whether at least one handler consumed the frame. */
+  readonly acknowledged: boolean;
+}
+
+/**
+ * Creates a successful acknowledgement for a given number of deliveries.
+ *
+ * @param deliveries - Count of handlers that processed the frame (defaults to one).
+ */
+export function acknowledge(deliveries: number = 1): Acknowledgement {
+  if (deliveries < 0) {
+    throw new Error('Acknowledgement deliveries cannot be negative.');
+  }
+
+  return {
+    deliveries,
+    acknowledged: deliveries > 0,
+  };
+}
+
+/**
+ * Creates a negative acknowledgement indicating that no handler consumed the frame.
+ */
+export function noAcknowledgement(): Acknowledgement {
+  return acknowledge(0);
+}
+
+/**
+ * Normalizes optional acknowledgement return values from handlers.
+ */
+export function normalizeAcknowledgement(
+  acknowledgement?: Acknowledgement | void,
+): Acknowledgement {
+  if (!acknowledgement) {
+    return acknowledge();
+  }
+
+  return acknowledgement;
+}
+
+/**
+ * Reduces a list of acknowledgements into a single aggregate acknowledgement.
+ *
+ * This helper is used by the bus and registry utilities to report whether a frame
+ * was consumed by any handler while preserving the total delivery count.
+ */
+export function combineAcknowledgements(
+  acknowledgements: Iterable<Acknowledgement>,
+): Acknowledgement {
+  let deliveries = 0;
+
+  for (const acknowledgement of acknowledgements) {
+    deliveries += acknowledgement.deliveries;
+  }
+
+  return acknowledge(deliveries);
+}

--- a/workspaces/Describing_Simulation_0/project/src/core/messaging/outbound/Frame.ts
+++ b/workspaces/Describing_Simulation_0/project/src/core/messaging/outbound/Frame.ts
@@ -1,0 +1,37 @@
+/**
+ * Canonical description of an outbound message within the simulation runtime.
+ *
+ * Frames are intentionally small data objects. They can be serialized to travel
+ * across processes yet remain ergonomic for synchronous in-memory dispatching.
+ * Future systems can refine {@link Frame#payload} and {@link Frame#metadata} via
+ * declaration merging or generics to encode richer domain information.
+ */
+export interface Frame<
+  TPayload = unknown,
+  TMetadata extends Record<string, unknown> = Record<string, unknown>,
+> {
+  /** Well known message type identifier. */
+  readonly type: string;
+  /** Arbitrary data specific to the message type. */
+  readonly payload: TPayload;
+  /** Optional additional context that accompanies the payload. */
+  readonly metadata: TMetadata;
+}
+
+/**
+ * Helper to create a frame with sensible defaults for optional metadata.
+ */
+export function createFrame<
+  TPayload,
+  TMetadata extends Record<string, unknown> = Record<string, unknown>,
+>(
+  type: string,
+  payload: TPayload,
+  metadata?: Partial<TMetadata>,
+): Frame<TPayload, TMetadata> {
+  return {
+    type,
+    payload,
+    metadata: ({ ...(metadata ?? {}) } as TMetadata),
+  };
+}

--- a/workspaces/Describing_Simulation_0/project/src/core/messaging/outbound/FrameFilter.ts
+++ b/workspaces/Describing_Simulation_0/project/src/core/messaging/outbound/FrameFilter.ts
@@ -1,0 +1,37 @@
+import { Frame } from './Frame';
+
+/**
+ * Predicate used to determine whether a subscriber should receive a frame.
+ */
+export type FrameFilter<TFrame extends Frame = Frame> = (frame: TFrame) => boolean;
+
+/**
+ * Filter that always matches, useful for catch-all handlers.
+ */
+export const matchAll: FrameFilter = () => true;
+
+/**
+ * Creates a filter that matches a single message type.
+ */
+export const matchType = <TFrame extends Frame = Frame>(type: string): FrameFilter<TFrame> => (
+  frame,
+) => frame.type === type;
+
+/**
+ * Creates a filter that matches any message type in the provided list.
+ */
+export const matchAnyType = <TFrame extends Frame = Frame>(
+  ...types: string[]
+): FrameFilter<TFrame> => {
+  const knownTypes = new Set(types);
+
+  return (frame) => knownTypes.has(frame.type);
+};
+
+/**
+ * Creates a filter that matches on a metadata field equality check.
+ */
+export const matchMetadata = <TFrame extends Frame = Frame>(
+  key: keyof TFrame['metadata'],
+  value: unknown,
+): FrameFilter<TFrame> => (frame) => frame.metadata?.[key as string] === value;

--- a/workspaces/Describing_Simulation_0/project/tests/messaging/Bus.spec.ts
+++ b/workspaces/Describing_Simulation_0/project/tests/messaging/Bus.spec.ts
@@ -1,0 +1,101 @@
+// Test intents:
+// - Bus subscriptions deliver frames according to their filters and can be removed.
+// - Acknowledgement helpers report delivery counts and normalization.
+// - Frame filters support type and metadata based routing.
+
+import {
+  Bus,
+  acknowledge,
+  combineAcknowledgements,
+  createFrame,
+  matchAnyType,
+  matchMetadata,
+  matchType,
+  noAcknowledgement,
+  normalizeAcknowledgement,
+} from 'src/core/messaging';
+
+describe('Bus', () => {
+  it('delivers frames to matching subscribers and supports unsubscribe', () => {
+    const bus = new Bus();
+    const deliveries: string[] = [];
+
+    const unsubscribe = bus.subscribe(matchType('ping'), (frame) => {
+      deliveries.push(`ping:${frame.payload}`);
+    });
+
+    bus.subscribe((frame) => {
+      deliveries.push(`any:${frame.type}`);
+    });
+
+    const firstAck = bus.send('ping', 'first');
+
+    expect(firstAck).toEqual({ deliveries: 2, acknowledged: true });
+    expect(deliveries).toEqual(['ping:first', 'any:ping']);
+
+    unsubscribe();
+
+    const secondAck = bus.send(createFrame('ping', 'second'));
+
+    expect(secondAck).toEqual({ deliveries: 1, acknowledged: true });
+    expect(deliveries).toEqual(['ping:first', 'any:ping', 'any:ping']);
+  });
+
+  it('returns a negative acknowledgement when no subscribers match', () => {
+    const bus = new Bus();
+
+    const acknowledgement = bus.send('unknown', {});
+
+    expect(acknowledgement).toEqual(noAcknowledgement());
+  });
+});
+
+describe('Acknowledgements', () => {
+  it('normalizes optional values into acknowledged deliveries', () => {
+    expect(normalizeAcknowledgement()).toEqual({ deliveries: 1, acknowledged: true });
+
+    const explicit = normalizeAcknowledgement(acknowledge(5));
+    expect(explicit).toEqual({ deliveries: 5, acknowledged: true });
+  });
+
+  it('combines acknowledgements by summing deliveries', () => {
+    const combined = combineAcknowledgements([
+      acknowledge(2),
+      noAcknowledgement(),
+      acknowledge(1),
+    ]);
+
+    expect(combined).toEqual({ deliveries: 3, acknowledged: true });
+  });
+});
+
+describe('Frame filters', () => {
+  it('matchAnyType routes frames to subscribers interested in multiple types', () => {
+    const bus = new Bus();
+    const received: string[] = [];
+
+    bus.subscribe(matchAnyType('alpha', 'beta'), (frame) => {
+      received.push(frame.type);
+    });
+
+    bus.send('alpha', {});
+    bus.send('gamma', {});
+    bus.send('beta', {});
+
+    expect(received).toEqual(['alpha', 'beta']);
+  });
+
+  it('matchMetadata filters frames using metadata equality checks', () => {
+    const bus = new Bus();
+    const received: string[] = [];
+
+    bus.subscribe(matchMetadata('scope', 'local'), (frame) => {
+      received.push(frame.payload as string);
+    });
+
+    bus.send('event', 'first', { scope: 'local' });
+    bus.send('event', 'second', { scope: 'remote' });
+
+    expect(received).toEqual(['first']);
+  });
+});

--- a/workspaces/Describing_Simulation_0/project/tests/messaging/InboundHandlers.spec.ts
+++ b/workspaces/Describing_Simulation_0/project/tests/messaging/InboundHandlers.spec.ts
@@ -1,0 +1,83 @@
+// Test intents:
+// - InboundHandlerRegistry dispatches frames to matching operations and aggregates acknowledgements.
+// - Duplicate registrations are rejected and handlers can be removed via the disposer.
+
+import {
+  Bus,
+  InboundHandlerRegistry,
+  acknowledge,
+  createFrame,
+  matchMetadata,
+  matchType,
+  noAcknowledgement,
+} from 'src/core/messaging';
+
+describe('InboundHandlerRegistry', () => {
+  it('dispatches frames to matching operations', () => {
+    const registry = new InboundHandlerRegistry();
+    const bus = new Bus();
+    const handled: string[] = [];
+
+    registry.register({
+      id: 'ping',
+      filter: matchType('ping'),
+      handle: (frame) => {
+        handled.push(`ping:${frame.payload}`);
+        return acknowledge(2);
+      },
+    });
+
+    registry.register({
+      id: 'local',
+      filter: matchMetadata('scope', 'local'),
+      handle: (frame) => {
+        handled.push(`local:${frame.payload}`);
+      },
+    });
+
+    const acknowledgement = registry.dispatch(
+      createFrame('ping', 'hello', { scope: 'local' }),
+      bus,
+    );
+
+    expect(handled).toEqual(['ping:hello', 'local:hello']);
+    expect(acknowledgement).toEqual({ deliveries: 3, acknowledged: true });
+  });
+
+  it('returns a negative acknowledgement when no operation matches', () => {
+    const registry = new InboundHandlerRegistry();
+    const bus = new Bus();
+
+    const acknowledgement = registry.dispatch(createFrame('missing', 'payload'), bus);
+
+    expect(acknowledgement).toEqual(noAcknowledgement());
+  });
+
+  it('prevents duplicate operation identifiers and allows removal', () => {
+    const registry = new InboundHandlerRegistry();
+    const bus = new Bus();
+    const handled: string[] = [];
+
+    const dispose = registry.register({
+      id: 'unique',
+      filter: matchType('event'),
+      handle: (frame) => {
+        handled.push(frame.type);
+      },
+    });
+
+    expect(() =>
+      registry.register({
+        id: 'unique',
+        filter: matchType('event'),
+        handle: () => {},
+      }),
+    ).toThrow('Operation with id "unique" is already registered.');
+
+    dispose();
+
+    registry.dispatch(createFrame('event', 'ignored'), bus);
+
+    expect(handled).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add a synchronous messaging bus with frame helpers, acknowledgement utilities, and filters
- introduce inbound handler types and registry for dispatching filtered operations
- cover bus behaviour, acknowledgement helpers, filter routing, and registry dispatch with Jest specs

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d6222f1330832a9b458ff57836167c