### PR TITLE
Add IO-enabled player and tests

### DIFF
--- a/workspaces/Describing_Simulation_0/project/src/core/IOPlayer.ts
+++ b/workspaces/Describing_Simulation_0/project/src/core/IOPlayer.ts
@@ -1,0 +1,136 @@
+import { Player, type PlayerOptions } from './Player';
+import type { ComponentManager } from './components/ComponentManager';
+import type { EntityManager } from './entity/EntityManager';
+import type { SystemManager } from './systems/SystemManager';
+import type { Bus } from './messaging/Bus';
+import { createFrame, type Frame } from './messaging/outbound/Frame';
+import type { FrameFilter } from './messaging/outbound/FrameFilter';
+import type { InboundHandlerRegistry } from './messaging/inbound/InboundHandlerRegistry';
+
+export interface SnapshotEntity {
+  readonly id: string;
+  readonly components: Record<string, unknown>;
+}
+
+export interface SnapshotPayload {
+  readonly entities: SnapshotEntity[];
+}
+
+export interface SnapshotMetadata extends Record<string, unknown> {
+  readonly tick: number;
+  readonly timestamp: number;
+  readonly deltaSeconds: number;
+}
+
+export type SnapshotFrame = Frame<SnapshotPayload, SnapshotMetadata>;
+
+export interface IOPlayerOptions extends PlayerOptions {
+  /** Predicate used to determine whether a generated frame should be published. */
+  readonly frameFilter?: FrameFilter<SnapshotFrame>;
+  /** Message type used when publishing frames. */
+  readonly frameType?: string;
+}
+
+/**
+ * Extends {@link Player} with IO primitives for inbound commands and outbound state snapshots.
+ */
+export class IOPlayer extends Player {
+  private readonly frameFilter?: FrameFilter<SnapshotFrame>;
+  private readonly frameType: string;
+  private inboundUnsubscribe: (() => void) | null = null;
+  private tickCount = 0;
+
+  constructor(
+    entities: EntityManager,
+    components: ComponentManager,
+    systems: SystemManager,
+    private readonly inboundBus: Bus,
+    private readonly outboundBus: Bus,
+    private readonly inboundRegistry: InboundHandlerRegistry,
+    options: IOPlayerOptions = {},
+  ) {
+    super(entities, components, systems, options);
+
+    this.frameFilter = options.frameFilter;
+    this.frameType = options.frameType ?? 'simulation/frame';
+
+    this.subscribeToInbound();
+  }
+
+  override start(): void {
+    this.subscribeToInbound();
+    super.start();
+  }
+
+  override stop(): void {
+    super.stop();
+    this.tickCount = 0;
+    this.unsubscribeFromInbound();
+  }
+
+  protected override onTick(deltaSeconds: number, timestamp: number): void {
+    this.tickCount += 1;
+    const frame = this.createSnapshotFrame(deltaSeconds, timestamp);
+
+    if (!this.frameFilter || this.frameFilter(frame)) {
+      this.outboundBus.send(frame);
+    }
+  }
+
+  private subscribeToInbound(): void {
+    if (this.inboundUnsubscribe) {
+      return;
+    }
+
+    this.inboundUnsubscribe = this.inboundBus.subscribe((frame, bus) =>
+      this.inboundRegistry.dispatch(frame, bus),
+    );
+  }
+
+  private unsubscribeFromInbound(): void {
+    if (!this.inboundUnsubscribe) {
+      return;
+    }
+
+    this.inboundUnsubscribe();
+    this.inboundUnsubscribe = null;
+  }
+
+  private createSnapshotFrame(
+    deltaSeconds: number,
+    timestamp: number,
+  ): SnapshotFrame {
+    const entities = this.entities
+      .list()
+      .map((entity) => ({
+        id: entity.id,
+        components: this.serializeComponents(entity.id),
+      }))
+      .sort((a, b) => a.id.localeCompare(b.id));
+
+    return createFrame<SnapshotPayload, SnapshotMetadata>(
+      this.frameType,
+      { entities },
+      {
+        tick: this.tickCount,
+        timestamp,
+        deltaSeconds,
+      },
+    );
+  }
+
+  private serializeComponents(entityId: string): Record<string, unknown> {
+    const components = this.components.getComponentsForEntity(entityId);
+
+    const serializedEntries = Array.from(components.entries()).sort((a, b) =>
+      a[0].name.localeCompare(b[0].name),
+    );
+
+    const snapshot: Record<string, unknown> = {};
+    for (const [type, component] of serializedEntries) {
+      snapshot[type.name] = component;
+    }
+
+    return snapshot;
+  }
+}

--- a/workspaces/Describing_Simulation_0/project/src/core/Player.ts
+++ b/workspaces/Describing_Simulation_0/project/src/core/Player.ts
@@ -21,15 +21,15 @@ type PlayerState = 'idle' | 'running' | 'paused';
  */
 export class Player {
   private readonly tickIntervalMs: number;
-  private readonly timeProvider: () => number;
+  protected readonly timeProvider: () => number;
   private loopHandle: NodeJS.Timeout | null = null;
   private state: PlayerState = 'idle';
   private lastTickTime: number | null = null;
 
   constructor(
-    private readonly entities: EntityManager,
-    private readonly components: ComponentManager,
-    private readonly systems: SystemManager,
+    protected readonly entities: EntityManager,
+    protected readonly components: ComponentManager,
+    protected readonly systems: SystemManager,
     options: PlayerOptions = {}
   ) {
     const interval = options.tickIntervalMs ?? 16;
@@ -101,8 +101,14 @@ export class Player {
     this.lastTickTime = currentTime;
 
     const deltaMs = Math.max(0, currentTime - previousTime);
-    this.systems.tick(deltaMs / 1000);
+    const deltaSeconds = deltaMs / 1000;
+    this.systems.tick(deltaSeconds);
+    this.onTick(deltaSeconds, currentTime);
   }
+
+  /** Hook invoked after each successful system tick. */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  protected onTick(deltaSeconds: number, timestamp: number): void {}
 
   private teardown(): void {
     this.systems.destroyAll();

--- a/workspaces/Describing_Simulation_0/project/tests/IOPlayer.spec.ts
+++ b/workspaces/Describing_Simulation_0/project/tests/IOPlayer.spec.ts
@@ -1,0 +1,132 @@
+import { IOPlayer } from '../src/core/IOPlayer';
+import { ComponentManager } from '../src/core/components/ComponentManager';
+import { ComponentType } from '../src/core/components/ComponentType';
+import { EntityManager } from '../src/core/entity/EntityManager';
+import { SystemManager } from '../src/core/systems/SystemManager';
+import {
+  Bus,
+  InboundHandlerRegistry,
+  acknowledge,
+  matchType,
+  noAcknowledgement,
+} from 'src/core/messaging';
+import type { SnapshotFrame } from '../src/core/IOPlayer';
+
+describe('IOPlayer', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it('dispatches inbound commands and propagates acknowledgements', () => {
+    const components = new ComponentManager();
+    const entities = new EntityManager(components);
+    const systems = new SystemManager();
+    const inboundBus = new Bus();
+    const outboundBus = new Bus();
+    const registry = new InboundHandlerRegistry();
+
+    let player!: IOPlayer;
+    registry.register({
+      id: 'start',
+      filter: matchType('start'),
+      handle: () => {
+        player.start();
+        return acknowledge();
+      },
+    });
+    registry.register({
+      id: 'pause',
+      filter: matchType('pause'),
+      handle: () => {
+        player.pause();
+        return acknowledge();
+      },
+    });
+    registry.register({
+      id: 'stop',
+      filter: matchType('stop'),
+      handle: () => {
+        player.stop();
+        return acknowledge();
+      },
+    });
+
+    player = new IOPlayer(
+      entities,
+      components,
+      systems,
+      inboundBus,
+      outboundBus,
+      registry,
+      { tickIntervalMs: 5 },
+    );
+
+    expect(inboundBus.send('start', undefined)).toEqual(acknowledge());
+    expect(inboundBus.send('pause', undefined)).toEqual(acknowledge());
+    expect(inboundBus.send('stop', undefined)).toEqual(acknowledge());
+
+    expect(inboundBus.send('pause', undefined)).toEqual(noAcknowledgement());
+
+    player.start();
+
+    expect(inboundBus.send('pause', undefined)).toEqual(acknowledge());
+  });
+
+  it('publishes filtered frame snapshots on each tick', () => {
+    const components = new ComponentManager();
+    const entities = new EntityManager(components);
+    const systems = new SystemManager();
+    const inboundBus = new Bus();
+    const outboundBus = new Bus();
+    const registry = new InboundHandlerRegistry();
+
+    const SampleComponent = new ComponentType<{ value: number }>('sample');
+    components.register(SampleComponent);
+    const entity = entities.create('entity-a');
+    components.setComponent(entity.id, SampleComponent, { value: 42 });
+
+    let currentTime = 0;
+    const timeProvider = jest.fn(() => currentTime);
+
+    const frames: SnapshotFrame[] = [];
+    outboundBus.subscribe((frame) => {
+      frames.push(frame as SnapshotFrame);
+      return acknowledge();
+    });
+
+    const player = new IOPlayer(
+      entities,
+      components,
+      systems,
+      inboundBus,
+      outboundBus,
+      registry,
+      {
+        tickIntervalMs: 10,
+        timeProvider,
+        frameFilter: (frame) => frame.metadata.tick % 2 === 1,
+      },
+    );
+
+    player.start();
+
+    for (let i = 0; i < 3; i += 1) {
+      currentTime += 10;
+      jest.advanceTimersByTime(10);
+    }
+
+    expect(frames).toHaveLength(2);
+    expect(frames[0].metadata.tick).toBe(1);
+    expect(frames[0].metadata.deltaSeconds).toBeCloseTo(0.01);
+    expect(frames[0].payload.entities).toEqual([
+      { id: 'entity-a', components: { sample: { value: 42 } } },
+    ]);
+
+    expect(frames[1].metadata.tick).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- expose hook points in `Player` so subclasses can observe ticks
- add `IOPlayer` to bridge inbound/outbound buses and publish filtered frame snapshots
- cover IOPlayer command handling and cadence with new Jest tests

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d623b9d710832aadc65d3b68f2d775