### PR TITLE
Add simulation player operations and tests

### DIFF
--- a/workspaces/Describing_Simulation_0/project/src/core/simplayer/SimulationPlayer.ts
+++ b/workspaces/Describing_Simulation_0/project/src/core/simplayer/SimulationPlayer.ts
@@ -1,0 +1,97 @@
+import { IOPlayer, type IOPlayerOptions, type SnapshotFrame } from '../IOPlayer';
+import type { ComponentManager } from '../components/ComponentManager';
+import type { EntityManager } from '../entity/EntityManager';
+import type { SystemManager } from '../systems/SystemManager';
+import type { Bus } from '../messaging/Bus';
+import { InboundHandlerRegistry, matchType } from '../messaging';
+import { createStartOperation } from './operations/Start';
+import { createPauseOperation } from './operations/Pause';
+import { createStopOperation } from './operations/Stop';
+import { createInjectSystemOperation } from './operations/InjectSystem';
+
+export interface SimulationPlayerCommandTypes {
+  readonly start: string;
+  readonly pause: string;
+  readonly stop: string;
+  readonly injectSystem: string;
+}
+
+export interface SimulationPlayerOptions extends IOPlayerOptions {
+  readonly commandTypes?: Partial<SimulationPlayerCommandTypes>;
+}
+
+const DEFAULT_FRAME_TYPE = 'simulation/frame';
+
+const DEFAULT_COMMAND_TYPES: SimulationPlayerCommandTypes = {
+  start: 'simulation/start',
+  pause: 'simulation/pause',
+  stop: 'simulation/stop',
+  injectSystem: 'simulation/system.inject',
+};
+
+export class SimulationPlayer extends IOPlayer {
+  private readonly registry: InboundHandlerRegistry;
+  private readonly commandTypes: SimulationPlayerCommandTypes;
+
+  constructor(
+    entities: EntityManager,
+    components: ComponentManager,
+    systems: SystemManager,
+    inboundBus: Bus,
+    outboundBus: Bus,
+    options: SimulationPlayerOptions = {},
+  ) {
+    const registry = new InboundHandlerRegistry();
+    const { commandTypes, frameFilter, frameType, ...playerOptions } = options;
+
+    const resolvedCommandTypes: SimulationPlayerCommandTypes = {
+      ...DEFAULT_COMMAND_TYPES,
+      ...(commandTypes ?? {}),
+    };
+
+    const resolvedFrameType = frameType ?? DEFAULT_FRAME_TYPE;
+    const resolvedFrameFilter =
+      frameFilter ?? matchType<SnapshotFrame>(resolvedFrameType);
+
+    super(entities, components, systems, inboundBus, outboundBus, registry, {
+      ...playerOptions,
+      frameType: resolvedFrameType,
+      frameFilter: resolvedFrameFilter,
+    });
+
+    this.registry = registry;
+    this.commandTypes = resolvedCommandTypes;
+
+    this.registerOperations(systems);
+  }
+
+  /** Returns the registry managing inbound command handlers. */
+  get commandRegistry(): InboundHandlerRegistry {
+    return this.registry;
+  }
+
+  /** Returns the configured message types for built-in commands. */
+  get commands(): SimulationPlayerCommandTypes {
+    return this.commandTypes;
+  }
+
+  private registerOperations(systems: SystemManager): void {
+    this.registry.register(
+      createStartOperation(this, { messageType: this.commandTypes.start }),
+    );
+
+    this.registry.register(
+      createPauseOperation(this, { messageType: this.commandTypes.pause }),
+    );
+
+    this.registry.register(
+      createStopOperation(this, { messageType: this.commandTypes.stop }),
+    );
+
+    this.registry.register(
+      createInjectSystemOperation(systems, {
+        messageType: this.commandTypes.injectSystem,
+      }),
+    );
+  }
+}

--- a/workspaces/Describing_Simulation_0/project/src/core/simplayer/operations/InjectSystem.ts
+++ b/workspaces/Describing_Simulation_0/project/src/core/simplayer/operations/InjectSystem.ts
@@ -1,0 +1,43 @@
+import type { Operation } from '../../messaging/inbound/Operation';
+import { matchType } from '../../messaging/outbound/FrameFilter';
+import { acknowledge } from '../../messaging/outbound/Acknowledgement';
+import type { Frame } from '../../messaging/outbound/Frame';
+import type { System } from '../../systems/System';
+import type { SystemManager } from '../../systems/SystemManager';
+
+export interface InjectSystemPayload {
+  readonly system: System;
+  readonly priority?: number;
+}
+
+export type InjectSystemFrame = Frame<InjectSystemPayload>;
+
+export interface InjectSystemOperationOptions {
+  readonly messageType?: string;
+}
+
+const DEFAULT_MESSAGE_TYPE = 'simulation/system.inject';
+const OPERATION_ID = 'simulation.inject-system';
+
+export function createInjectSystemOperation(
+  systems: Pick<SystemManager, 'register'>,
+  options: InjectSystemOperationOptions = {},
+): Operation {
+  const messageType = options.messageType ?? DEFAULT_MESSAGE_TYPE;
+
+  return {
+    id: OPERATION_ID,
+    filter: matchType(messageType),
+    handle: (frame) => {
+      const { system, priority } = (frame as InjectSystemFrame).payload;
+
+      if (typeof priority === 'number') {
+        systems.register(system, priority);
+      } else {
+        systems.register(system);
+      }
+
+      return acknowledge();
+    },
+  };
+}

--- a/workspaces/Describing_Simulation_0/project/src/core/simplayer/operations/Pause.ts
+++ b/workspaces/Describing_Simulation_0/project/src/core/simplayer/operations/Pause.ts
@@ -1,0 +1,27 @@
+import type { Operation } from '../../messaging/inbound/Operation';
+import { matchType } from '../../messaging/outbound/FrameFilter';
+import { acknowledge } from '../../messaging/outbound/Acknowledgement';
+import type { Player } from '../../Player';
+
+export interface PauseOperationOptions {
+  readonly messageType?: string;
+}
+
+const DEFAULT_MESSAGE_TYPE = 'simulation/pause';
+const OPERATION_ID = 'simulation.pause';
+
+export function createPauseOperation(
+  player: Pick<Player, 'pause'>,
+  options: PauseOperationOptions = {},
+): Operation {
+  const messageType = options.messageType ?? DEFAULT_MESSAGE_TYPE;
+
+  return {
+    id: OPERATION_ID,
+    filter: matchType(messageType),
+    handle: () => {
+      player.pause();
+      return acknowledge();
+    },
+  };
+}

--- a/workspaces/Describing_Simulation_0/project/src/core/simplayer/operations/Start.ts
+++ b/workspaces/Describing_Simulation_0/project/src/core/simplayer/operations/Start.ts
@@ -1,0 +1,28 @@
+import type { Operation } from '../../messaging/inbound/Operation';
+import { matchType } from '../../messaging/outbound/FrameFilter';
+import { acknowledge } from '../../messaging/outbound/Acknowledgement';
+import type { Player } from '../../Player';
+
+export interface StartOperationOptions {
+  readonly messageType?: string;
+}
+
+const DEFAULT_MESSAGE_TYPE = 'simulation/start';
+const OPERATION_ID = 'simulation.start';
+
+export function createStartOperation(
+  player: Pick<Player, 'start' | 'resume'>,
+  options: StartOperationOptions = {},
+): Operation {
+  const messageType = options.messageType ?? DEFAULT_MESSAGE_TYPE;
+
+  return {
+    id: OPERATION_ID,
+    filter: matchType(messageType),
+    handle: () => {
+      player.start();
+      player.resume();
+      return acknowledge();
+    },
+  };
+}

--- a/workspaces/Describing_Simulation_0/project/src/core/simplayer/operations/Stop.ts
+++ b/workspaces/Describing_Simulation_0/project/src/core/simplayer/operations/Stop.ts
@@ -1,0 +1,27 @@
+import type { Operation } from '../../messaging/inbound/Operation';
+import { matchType } from '../../messaging/outbound/FrameFilter';
+import { acknowledge } from '../../messaging/outbound/Acknowledgement';
+import type { Player } from '../../Player';
+
+export interface StopOperationOptions {
+  readonly messageType?: string;
+}
+
+const DEFAULT_MESSAGE_TYPE = 'simulation/stop';
+const OPERATION_ID = 'simulation.stop';
+
+export function createStopOperation(
+  player: Pick<Player, 'stop'>,
+  options: StopOperationOptions = {},
+): Operation {
+  const messageType = options.messageType ?? DEFAULT_MESSAGE_TYPE;
+
+  return {
+    id: OPERATION_ID,
+    filter: matchType(messageType),
+    handle: () => {
+      player.stop();
+      return acknowledge();
+    },
+  };
+}

--- a/workspaces/Describing_Simulation_0/project/tests/SimulationPlayer.spec.ts
+++ b/workspaces/Describing_Simulation_0/project/tests/SimulationPlayer.spec.ts
@@ -1,0 +1,94 @@
+import { ComponentManager } from 'src/core/components/ComponentManager';
+import { EntityManager } from 'src/core/entity/EntityManager';
+import { Bus, acknowledge } from 'src/core/messaging';
+import { System } from 'src/core/systems/System';
+import { SystemManager } from 'src/core/systems/SystemManager';
+import { SimulationPlayer } from 'src/core/simplayer/SimulationPlayer';
+
+class TestSystem extends System {
+  public updates = 0;
+
+  // eslint-disable-next-line class-methods-use-this
+  protected update(deltaTime: number): void {
+    if (deltaTime >= 0) {
+      this.updates += 1;
+    }
+  }
+}
+
+describe('SimulationPlayer', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it('executes playback commands and acknowledges them', () => {
+    const components = new ComponentManager();
+    const entities = new EntityManager(components);
+    const systems = new SystemManager();
+    const inboundBus = new Bus();
+    const outboundBus = new Bus();
+
+    const player = new SimulationPlayer(
+      entities,
+      components,
+      systems,
+      inboundBus,
+      outboundBus,
+      { tickIntervalMs: 5 },
+    );
+
+    const startSpy = jest.spyOn(player, 'start');
+    const resumeSpy = jest.spyOn(player, 'resume');
+    const pauseSpy = jest.spyOn(player, 'pause');
+    const stopSpy = jest.spyOn(player, 'stop');
+
+    expect(inboundBus.send('simulation/start', undefined)).toEqual(acknowledge());
+    expect(startSpy).toHaveBeenCalledTimes(1);
+    expect(resumeSpy).toHaveBeenCalledTimes(1);
+
+    expect(inboundBus.send('simulation/pause', undefined)).toEqual(acknowledge());
+    expect(pauseSpy).toHaveBeenCalledTimes(1);
+
+    expect(inboundBus.send('simulation/start', undefined)).toEqual(acknowledge());
+    expect(resumeSpy).toHaveBeenCalledTimes(2);
+
+    expect(inboundBus.send('simulation/stop', undefined)).toEqual(acknowledge());
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('injects systems through the system manager', () => {
+    const components = new ComponentManager();
+    const entities = new EntityManager(components);
+    const systems = new SystemManager();
+    const inboundBus = new Bus();
+    const outboundBus = new Bus();
+
+    const player = new SimulationPlayer(
+      entities,
+      components,
+      systems,
+      inboundBus,
+      outboundBus,
+    );
+
+    const registerSpy = jest.spyOn(systems, 'register');
+    const system = new TestSystem();
+
+    expect(
+      inboundBus.send('simulation/system.inject', { system, priority: 3 }),
+    ).toEqual(acknowledge());
+
+    expect(registerSpy).toHaveBeenCalledWith(system, 3);
+
+    const registeredSystems: System[] = [];
+    systems.forEach((registered) => registeredSystems.push(registered));
+    expect(registeredSystems).toContain(system);
+
+    player.stop();
+  });
+});


### PR DESCRIPTION
## Summary
- add start, pause, stop, and system injection operations for the simulation player command bus
- introduce a SimulationPlayer that wires the IO player with default command handlers and frame filtering
- cover the new command behaviour with Jest specs verifying acknowledgements and system routing

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d6263bec44832ab29849a211bc492b