### PR TITLE
Add evaluation player frame ingestion support

### DIFF
--- a/workspaces/Describing_Simulation_0/project/src/core/evalplayer/EvaluationPlayer.ts
+++ b/workspaces/Describing_Simulation_0/project/src/core/evalplayer/EvaluationPlayer.ts
@@ -1,0 +1,61 @@
+import { IOPlayer, type IOPlayerOptions, type SnapshotFrame } from '../IOPlayer';
+import type { ComponentManager } from '../components/ComponentManager';
+import type { EntityManager } from '../entity/EntityManager';
+import type { SystemManager } from '../systems/SystemManager';
+import type { Bus } from '../messaging/Bus';
+import { InboundHandlerRegistry, type FrameFilter } from '../messaging';
+import { createInjectFrameOperation, type InjectFrameFrame } from './operations/InjectFrame';
+
+export interface EvaluationPlayerOptions extends IOPlayerOptions {
+  readonly injectFrameType?: string;
+}
+
+type EvaluationSnapshotMetadata = SnapshotFrame['metadata'] & {
+  readonly historical?: boolean;
+};
+
+const DEFAULT_FRAME_TYPE = 'evaluation/frame';
+const DEFAULT_INJECT_TYPE = 'simulation/frame';
+
+export class EvaluationPlayer extends IOPlayer {
+  private readonly registry: InboundHandlerRegistry;
+
+  constructor(
+    entities: EntityManager,
+    components: ComponentManager,
+    systems: SystemManager,
+    inboundBus: Bus,
+    outboundBus: Bus,
+    options: EvaluationPlayerOptions = {},
+  ) {
+    const registry = new InboundHandlerRegistry();
+    const { injectFrameType, frameFilter, frameType, ...playerOptions } = options;
+    const resolvedFrameType = frameType ?? DEFAULT_FRAME_TYPE;
+    let suppressHistorical = false;
+    const userFilter = frameFilter;
+    const resolvedFilter: FrameFilter<SnapshotFrame> = (frame) =>
+      !suppressHistorical && (!userFilter || userFilter(frame));
+
+    super(entities, components, systems, inboundBus, outboundBus, registry, {
+      ...playerOptions,
+      frameType: resolvedFrameType,
+      frameFilter: resolvedFilter,
+    });
+
+    this.registry = registry;
+
+    registry.register(
+      createInjectFrameOperation(entities, components, {
+        messageType: injectFrameType ?? DEFAULT_INJECT_TYPE,
+        onInjected: (frame: InjectFrameFrame) => {
+          const metadata = frame.metadata as EvaluationSnapshotMetadata | undefined;
+          suppressHistorical = metadata?.historical === true;
+        },
+      }),
+    );
+  }
+
+  get handlerRegistry(): InboundHandlerRegistry {
+    return this.registry;
+  }
+}

--- a/workspaces/Describing_Simulation_0/project/src/core/evalplayer/operations/InjectFrame.ts
+++ b/workspaces/Describing_Simulation_0/project/src/core/evalplayer/operations/InjectFrame.ts
@@ -1,0 +1,136 @@
+import { ComponentType } from '../../components/ComponentType';
+import type { ComponentManager } from '../../components/ComponentManager';
+import type { EntityManager } from '../../entity/EntityManager';
+import { acknowledge, noAcknowledgement } from '../../messaging/outbound/Acknowledgement';
+import type { Frame } from '../../messaging/outbound/Frame';
+import { matchType } from '../../messaging/outbound/FrameFilter';
+import type { Operation } from '../../messaging/inbound/Operation';
+
+export interface InjectFrameEntityPayload {
+  readonly id: string;
+  readonly components?: Record<string, unknown>;
+}
+
+export interface InjectFramePayload {
+  readonly entities: InjectFrameEntityPayload[];
+}
+
+export type InjectFrameFrame = Frame<InjectFramePayload>;
+
+export interface InjectFrameOperationOptions {
+  readonly messageType?: string;
+  readonly onInjected?: (frame: InjectFrameFrame) => void;
+}
+
+const DEFAULT_MESSAGE_TYPE = 'simulation/frame';
+const OPERATION_ID = 'evaluation.inject-frame';
+
+export function createInjectFrameOperation(
+  entities: EntityManager,
+  components: ComponentManager,
+  options: InjectFrameOperationOptions = {},
+): Operation {
+  const messageType = options.messageType ?? DEFAULT_MESSAGE_TYPE;
+  const componentCache = new Map<string, ComponentType<unknown>>();
+
+  const resolveComponentType = (name: string): ComponentType<unknown> => {
+    const cached = componentCache.get(name);
+    if (cached) {
+      return cached;
+    }
+
+    for (const registered of components.registeredTypes()) {
+      if (registered.name === name) {
+        componentCache.set(name, registered);
+        return registered;
+      }
+    }
+
+    if (components.isRegistered(name)) {
+      throw new Error(`Component type "${name}" could not be resolved.`);
+    }
+
+    const created = new ComponentType<unknown>(name);
+    components.register(created);
+    componentCache.set(name, created);
+    return created;
+  };
+
+  return {
+    id: OPERATION_ID,
+    filter: matchType(messageType),
+    handle: (incomingFrame) => {
+      const frame = incomingFrame as InjectFrameFrame;
+      const payload = frame.payload;
+
+      if (!payload || !Array.isArray(payload.entities)) {
+        return noAcknowledgement();
+      }
+
+      const normalizedEntities = new Map<string, Map<string, unknown>>();
+
+      for (const entity of payload.entities) {
+        if (!entity || typeof entity.id !== 'string' || entity.id.trim() === '') {
+          return noAcknowledgement();
+        }
+
+        if (normalizedEntities.has(entity.id)) {
+          return noAcknowledgement();
+        }
+
+        const componentRecord = entity.components ?? {};
+        if (
+          componentRecord === null ||
+          typeof componentRecord !== 'object' ||
+          Array.isArray(componentRecord)
+        ) {
+          return noAcknowledgement();
+        }
+
+        const componentMap = new Map<string, unknown>();
+        for (const [componentName, value] of Object.entries(componentRecord)) {
+          if (!componentName) {
+            return noAcknowledgement();
+          }
+
+          componentMap.set(componentName, value);
+        }
+
+        normalizedEntities.set(entity.id, componentMap);
+      }
+
+      const nextEntityIds = new Set(normalizedEntities.keys());
+
+      for (const existing of entities.list()) {
+        if (!nextEntityIds.has(existing.id)) {
+          entities.remove(existing.id);
+        }
+      }
+
+      for (const [entityId, componentMap] of normalizedEntities) {
+        if (!entities.has(entityId)) {
+          entities.create(entityId);
+        }
+
+        const seenComponentNames = new Set<string>();
+
+        for (const [componentName, value] of componentMap) {
+          const type = resolveComponentType(componentName);
+          components.setComponent(entityId, type, value);
+          seenComponentNames.add(componentName);
+        }
+
+        const existingComponents = components.getComponentsForEntity(entityId);
+        for (const type of existingComponents.keys()) {
+          if (!seenComponentNames.has(type.name)) {
+            components.removeComponent(entityId, type);
+          }
+        }
+      }
+
+      options.onInjected?.(frame);
+
+      return acknowledge();
+    },
+  };
+}

--- a/workspaces/Describing_Simulation_0/project/tests/EvaluationPlayer.spec.ts
+++ b/workspaces/Describing_Simulation_0/project/tests/EvaluationPlayer.spec.ts
@@ -1,0 +1,218 @@
+import { EvaluationPlayer } from '../src/core/evalplayer/EvaluationPlayer';
+import { ComponentManager } from '../src/core/components/ComponentManager';
+import { EntityManager } from '../src/core/entity/EntityManager';
+import { SystemManager } from '../src/core/systems/SystemManager';
+import { Bus, acknowledge, noAcknowledgement } from 'src/core/messaging';
+import type { SnapshotFrame } from '../src/core/IOPlayer';
+
+describe('EvaluationPlayer', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllTimers();
+  });
+
+  it('materializes injected frame entities and components', () => {
+    const components = new ComponentManager();
+    const entities = new EntityManager(components);
+    const systems = new SystemManager();
+    const inboundBus = new Bus();
+    const outboundBus = new Bus();
+
+    const player = new EvaluationPlayer(
+      entities,
+      components,
+      systems,
+      inboundBus,
+      outboundBus,
+    );
+
+    const acknowledgement = inboundBus.send(
+      'simulation/frame',
+      {
+        entities: [
+          {
+            id: 'entity-1',
+            components: { sample: { value: 5 } },
+          },
+        ],
+      },
+      { tick: 0, timestamp: 0, deltaSeconds: 0 },
+    );
+
+    expect(acknowledgement).toEqual(acknowledge());
+    expect(entities.list().map((entity) => entity.id)).toEqual(['entity-1']);
+
+    const registeredType = components
+      .registeredTypes()
+      .find((type) => type.name === 'sample');
+    expect(registeredType).toBeDefined();
+    expect(components.getComponent('entity-1', registeredType!)).toEqual({ value: 5 });
+
+    player.stop();
+  });
+
+  it('removes redundant entity and component data when omitted', () => {
+    const components = new ComponentManager();
+    const entities = new EntityManager(components);
+    const systems = new SystemManager();
+    const inboundBus = new Bus();
+    const outboundBus = new Bus();
+
+    const player = new EvaluationPlayer(
+      entities,
+      components,
+      systems,
+      inboundBus,
+      outboundBus,
+    );
+
+    inboundBus.send(
+      'simulation/frame',
+      {
+        entities: [
+          {
+            id: 'entity-1',
+            components: { alpha: 1, beta: 2 },
+          },
+          {
+            id: 'entity-2',
+            components: { gamma: 3 },
+          },
+        ],
+      },
+      { tick: 1, timestamp: 0, deltaSeconds: 0 },
+    );
+
+    const ack = inboundBus.send(
+      'simulation/frame',
+      {
+        entities: [
+          {
+            id: 'entity-1',
+            components: { beta: 2 },
+          },
+        ],
+      },
+      { tick: 2, timestamp: 0, deltaSeconds: 0 },
+    );
+
+    expect(ack).toEqual(acknowledge());
+
+    const remainingEntities = entities.list().map((entity) => entity.id);
+    expect(remainingEntities).toEqual(['entity-1']);
+
+    const remainingComponents = Array.from(
+      components.getComponentsForEntity('entity-1').keys(),
+    ).map((type) => type.name);
+    expect(remainingComponents).toEqual(['beta']);
+
+    player.stop();
+  });
+
+  it('returns a negative acknowledgement when payload validation fails', () => {
+    const components = new ComponentManager();
+    const entities = new EntityManager(components);
+    const systems = new SystemManager();
+    const inboundBus = new Bus();
+    const outboundBus = new Bus();
+
+    const player = new EvaluationPlayer(
+      entities,
+      components,
+      systems,
+      inboundBus,
+      outboundBus,
+    );
+
+    inboundBus.send(
+      'simulation/frame',
+      {
+        entities: [
+          {
+            id: 'entity-1',
+            components: { value: 1 },
+          },
+        ],
+      },
+      { tick: 1, timestamp: 0, deltaSeconds: 0 },
+    );
+
+    const acknowledgement = inboundBus.send(
+      'simulation/frame',
+      {
+        entities: [
+          {
+            id: '',
+            components: { value: 2 },
+          },
+        ],
+      },
+      { tick: 2, timestamp: 0, deltaSeconds: 0 },
+    );
+
+    expect(acknowledgement).toEqual(noAcknowledgement());
+
+    const registeredType = components
+      .registeredTypes()
+      .find((type) => type.name === 'value');
+    expect(registeredType).toBeDefined();
+    expect(components.getComponent('entity-1', registeredType!)).toEqual(1);
+
+    player.stop();
+  });
+
+  it('suppresses outbound frames when the latest injection is historical', () => {
+    jest.useFakeTimers();
+
+    const components = new ComponentManager();
+    const entities = new EntityManager(components);
+    const systems = new SystemManager();
+    const inboundBus = new Bus();
+    const outboundBus = new Bus();
+
+    const time = { now: 0 };
+    const timeProvider = jest.fn(() => time.now);
+
+    const frames: SnapshotFrame[] = [];
+    outboundBus.subscribe((frame) => {
+      frames.push(frame as SnapshotFrame);
+      return acknowledge();
+    });
+
+    const player = new EvaluationPlayer(
+      entities,
+      components,
+      systems,
+      inboundBus,
+      outboundBus,
+      { tickIntervalMs: 5, timeProvider },
+    );
+
+    player.start();
+
+    inboundBus.send(
+      'simulation/frame',
+      { entities: [] },
+      { tick: 1, timestamp: 0, deltaSeconds: 0, historical: true },
+    );
+
+    time.now += 5;
+    jest.advanceTimersByTime(5);
+
+    expect(frames).toHaveLength(0);
+
+    inboundBus.send(
+      'simulation/frame',
+      { entities: [] },
+      { tick: 2, timestamp: 5, deltaSeconds: 0, historical: false },
+    );
+
+    time.now += 5;
+    jest.advanceTimersByTime(5);
+
+    expect(frames).toHaveLength(1);
+    expect(frames[0].metadata.tick).toBe(2);
+
+    player.stop();
+  });
+});


### PR DESCRIPTION
## Summary
- add an evaluation player that wires a frame injection operation and filters historical snapshots before publishing
- implement the inject-frame operation to materialize inbound frames into entities and components
- add Jest coverage validating frame ingestion, redundancy cleanup, acknowledgements, and historical filtering

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d629163aec832a95a04dacd422d525