### PR TITLE
Add plugin scaffolding for simulation and evaluation

### DIFF
--- a/Describing_Simulation_0.md
+++ b/Describing_Simulation_0.md
@@ -242,6 +242,15 @@ project/
 ├── package.json
 └── README.md
 ```
+
+Within this repository the tree above lives under
+`workspaces/Describing_Simulation_0/project/`. To make it easier for
+future simulation work, the `plugins/simulation` and
+`plugins/evaluation` branches of that tree now include committed
+directory scaffolding. Each subdirectory (`components/`, `systems/`, and
+`operations/`) contains a README that describes the type of plugin code
+expected there so that new contributors can drop in their generated ECS
+artifacts without needing to recreate the folder layout.
 ### Summary of Scope
 
 This service is only responsible for managing the simulator. To give some idea of where we’re going with this:

--- a/workspaces/Describing_Simulation_0/project/plugins/evaluation/components/README.md
+++ b/workspaces/Describing_Simulation_0/project/plugins/evaluation/components/README.md
@@ -1,0 +1,3 @@
+# Evaluation Components
+
+Keep evaluation-focused component definitions here. Use these to describe metrics, scoring frames, or other evaluation data produced by the simulation.

--- a/workspaces/Describing_Simulation_0/project/plugins/evaluation/operations/README.md
+++ b/workspaces/Describing_Simulation_0/project/plugins/evaluation/operations/README.md
@@ -1,0 +1,3 @@
+# Evaluation Operations
+
+Place message handlers and operations that orchestrate evaluation workflows here. Handlers should translate inbound requests into evaluation system activity.

--- a/workspaces/Describing_Simulation_0/project/plugins/evaluation/systems/README.md
+++ b/workspaces/Describing_Simulation_0/project/plugins/evaluation/systems/README.md
@@ -1,0 +1,3 @@
+# Evaluation Systems
+
+Implement systems that score or analyze simulation output in this directory. Systems should consume evaluation components and emit results for downstream reporting.

--- a/workspaces/Describing_Simulation_0/project/plugins/simulation/components/README.md
+++ b/workspaces/Describing_Simulation_0/project/plugins/simulation/components/README.md
@@ -1,0 +1,3 @@
+# Simulation Components
+
+Store agent-defined ECS component definitions for simulation-specific behavior here. Each file should export interfaces and component types that extend the engine scaffolding.

--- a/workspaces/Describing_Simulation_0/project/plugins/simulation/operations/README.md
+++ b/workspaces/Describing_Simulation_0/project/plugins/simulation/operations/README.md
@@ -1,0 +1,3 @@
+# Simulation Operations
+
+Define inbound operation handlers that expose control or configuration entry points for simulation plugins. Operations should integrate with the messaging bus to trigger systems safely.

--- a/workspaces/Describing_Simulation_0/project/plugins/simulation/systems/README.md
+++ b/workspaces/Describing_Simulation_0/project/plugins/simulation/systems/README.md
@@ -1,0 +1,3 @@
+# Simulation Systems
+
+Add systems that operate over simulation components and entities. Implement update hooks that orchestrate simulation logic using the provided managers.


### PR DESCRIPTION
## Summary
- add simulation and evaluation plugin directory scaffolding with README placeholders for components, systems, and operations
- update the Describing_Simulation_0 documentation to note the committed plugin directories for contributors

## Testing
- ./tools/run_project_tests.sh

------
https://chatgpt.com/codex/tasks/task_e_68d62b1e28c0832a92f3eb58365e4956