### PR TITLE
Add war-time food price simulation plugin and output records

### DIFF
--- a/workspaces/Describing_Simulation_0/project/plugins/simulation/components/FoodDemandComponent.ts
+++ b/workspaces/Describing_Simulation_0/project/plugins/simulation/components/FoodDemandComponent.ts
@@ -1,0 +1,22 @@
+import { ComponentType } from '../../../src/core/components/ComponentType';
+
+export interface FoodDemandComponent {
+  /** Baseline daily consumption requirement in index units. */
+  baselineDemand: number;
+  /** Effective demand after behavioral and policy adjustments. */
+  currentDemand: number;
+  /** Responsiveness of demand to price changes (absolute value). */
+  priceElasticity: number;
+  /** Panic-induced hoarding component 0 to 1. */
+  panicFactor: number;
+  /** Effectiveness of rationing programs reducing demand 0 to 1. */
+  rationingEffectiveness: number;
+  /** Substitution towards alternative calories 0 to 1. */
+  substitutionRate: number;
+  /** Aggregate income or access shock reducing demand 0 to 1. */
+  incomeShock: number;
+}
+
+export const FOOD_DEMAND_COMPONENT = new ComponentType<FoodDemandComponent>(
+  'foodDemand',
+);

--- a/workspaces/Describing_Simulation_0/project/plugins/simulation/components/FoodPriceComponent.ts
+++ b/workspaces/Describing_Simulation_0/project/plugins/simulation/components/FoodPriceComponent.ts
@@ -1,0 +1,22 @@
+import { ComponentType } from '../../../src/core/components/ComponentType';
+
+export interface FoodPriceComponent {
+  /** Baseline consumer price index for staple foods. */
+  baselinePrice: number;
+  /** Current simulated price level. */
+  currentPrice: number;
+  /** Short-run inflation rate per day. */
+  inflationRate: number;
+  /** Rolling volatility indicator capturing price swings. */
+  volatility: number;
+  /** Momentum term capturing the persistence of price pressure. */
+  priceMomentum: number;
+  /** Scarcity index derived from supply-demand gaps. */
+  scarcityIndex: number;
+  /** Affordability index comparing availability to price growth. */
+  affordabilityIndex: number;
+}
+
+export const FOOD_PRICE_COMPONENT = new ComponentType<FoodPriceComponent>(
+  'foodPrice',
+);

--- a/workspaces/Describing_Simulation_0/project/plugins/simulation/components/FoodSupplyComponent.ts
+++ b/workspaces/Describing_Simulation_0/project/plugins/simulation/components/FoodSupplyComponent.ts
@@ -1,0 +1,26 @@
+import { ComponentType } from '../../../src/core/components/ComponentType';
+
+export interface FoodSupplyComponent {
+  /** Baseline daily production volume in index units. */
+  baselineProduction: number;
+  /** Current effective production after disruptions. */
+  currentProduction: number;
+  /** Share of production relying on imports 0 (self-sufficient) to 1 (fully import reliant). */
+  importDependency: number;
+  /** Capacity to adapt and recover supply shocks 0 to 1. */
+  resilience: number;
+  /** Available strategic reserves in daily production equivalents. */
+  stockpile: number;
+  /** Desired buffer of reserves to stabilize prices. */
+  targetStockpile: number;
+  /** Logistics efficiency 0 (paralyzed) to 1 (fully efficient). */
+  logisticsEfficiency: number;
+  /** Share of production lost to spoilage or wastage. */
+  wastageRate: number;
+}
+
+export const FOOD_SUPPLY_COMPONENT = new ComponentType<FoodSupplyComponent>(
+  'foodSupply',
+);
+
+export const FOOD_MARKET_ENTITY_ID = 'food-market';

--- a/workspaces/Describing_Simulation_0/project/plugins/simulation/components/WarImpactComponent.ts
+++ b/workspaces/Describing_Simulation_0/project/plugins/simulation/components/WarImpactComponent.ts
@@ -1,0 +1,26 @@
+import { ComponentType } from '../../../src/core/components/ComponentType';
+
+export interface WarImpactComponent {
+  /** Intensity of the conflict scaled 0 (no conflict) to 1 (max intensity). */
+  intensity: number;
+  /** Aggregate supply disruption factor 0 (no disruption) to 1 (total loss). */
+  supplyDisruption: number;
+  /** Demand-side pressure where positive values indicate upward pressure. */
+  demandPressure: number;
+  /** Effectiveness of relief logistics counteracting disruptions. */
+  reliefEffort: number;
+  /** Severity of trade blockades restricting imports 0 to 1. */
+  blockadeSeverity: number;
+  /** Policy driven rationing dampening demand 0 to 1. */
+  policyRationing: number;
+  /** Accumulated infrastructure damage limiting supply resilience 0 to 1. */
+  infrastructureDamage: number;
+  /** Elapsed time in days since hostilities began. */
+  elapsedDays: number;
+}
+
+export const WAR_IMPACT_COMPONENT = new ComponentType<WarImpactComponent>(
+  'warImpact',
+);
+
+export const WAR_ENTITY_ID = 'war';

--- a/workspaces/Describing_Simulation_0/project/plugins/simulation/scenarios/foodPricesWar/runSimulation.ts
+++ b/workspaces/Describing_Simulation_0/project/plugins/simulation/scenarios/foodPricesWar/runSimulation.ts
@@ -1,0 +1,152 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { ComponentManager } from '../../../../src/core/components/ComponentManager';
+import { EntityManager } from '../../../../src/core/entity/EntityManager';
+import { SystemManager } from '../../../../src/core/systems/SystemManager';
+import { SimulationPlayer, type SimulationPlayerOptions } from '../../../../src/core/simplayer/SimulationPlayer';
+import { EvaluationPlayer } from '../../../../src/core/evalplayer/EvaluationPlayer';
+import { Bus, acknowledge } from '../../../../src/core/messaging';
+import { TimeSystem } from '../../../../src/core/systems/TimeSystem';
+import { FoodSupplySystem } from '../../systems/FoodSupplySystem';
+import { FoodDemandSystem } from '../../systems/FoodDemandSystem';
+import { FoodPriceSystem } from '../../systems/FoodPriceSystem';
+import { WarImpactSystem } from '../../systems/WarImpactSystem';
+import { FOOD_MARKET_ENTITY_ID } from '../../components/FoodSupplyComponent';
+import { WAR_ENTITY_ID } from '../../components/WarImpactComponent';
+import type { SnapshotFrame } from '../../../../src/core/IOPlayer';
+
+const SECONDS_PER_DAY = 86_400;
+const SIMULATION_DAYS = 180;
+
+class ManualSimulationPlayer extends SimulationPlayer {
+  constructor(
+    entities: EntityManager,
+    components: ComponentManager,
+    systems: SystemManager,
+    inbound: Bus,
+    outbound: Bus,
+    options: SimulationPlayerOptions = {},
+  ) {
+    super(entities, components, systems, inbound, outbound, options);
+  }
+
+  manualStep(deltaSeconds: number, timestamp: number): void {
+    this.systems.tick(deltaSeconds);
+    this.onTick(deltaSeconds, timestamp);
+  }
+}
+
+class ManualEvaluationPlayer extends EvaluationPlayer {
+  manualStep(deltaSeconds: number, timestamp: number): void {
+    this.systems.tick(deltaSeconds);
+    this.onTick(deltaSeconds, timestamp);
+  }
+}
+
+async function main(): Promise<void> {
+  const simulationComponents = new ComponentManager();
+  const simulationEntities = new EntityManager(simulationComponents);
+  const simulationSystems = new SystemManager();
+
+  const evaluationComponents = new ComponentManager();
+  const evaluationEntities = new EntityManager(evaluationComponents);
+  const evaluationSystems = new SystemManager();
+
+  const simulationInbound = new Bus();
+  const simulationOutbound = new Bus();
+  const evaluationOutbound = new Bus();
+
+  const simulationPlayer = new ManualSimulationPlayer(
+    simulationEntities,
+    simulationComponents,
+    simulationSystems,
+    simulationInbound,
+    simulationOutbound,
+    { frameType: 'simulation/frame' },
+  );
+
+  const evaluationPlayer = new ManualEvaluationPlayer(
+    evaluationEntities,
+    evaluationComponents,
+    evaluationSystems,
+    simulationOutbound,
+    evaluationOutbound,
+    { frameType: 'evaluation/frame' },
+  );
+
+  // Register core systems for the scenario.
+  simulationSystems.register(new TimeSystem(simulationEntities, simulationComponents), -10);
+  simulationSystems.register(new WarImpactSystem(simulationEntities, simulationComponents), -5);
+  simulationSystems.register(new FoodSupplySystem(simulationEntities, simulationComponents), 0);
+  simulationSystems.register(new FoodDemandSystem(simulationEntities, simulationComponents), 1);
+  simulationSystems.register(new FoodPriceSystem(simulationEntities, simulationComponents), 2);
+
+  // Subscribe to evaluation frames for capture.
+  const frames: SnapshotFrame[] = [];
+  evaluationOutbound.subscribe((frame) => {
+    frames.push(frame as SnapshotFrame);
+    return acknowledge();
+  });
+
+  // Warm-up initial state by executing a zero-duration tick to initialize systems.
+  simulationPlayer.manualStep(0, 0);
+  evaluationPlayer.manualStep(0, 0);
+
+  let currentTimestamp = 0;
+  for (let day = 0; day < SIMULATION_DAYS; day += 1) {
+    currentTimestamp += SECONDS_PER_DAY;
+    simulationPlayer.manualStep(SECONDS_PER_DAY, currentTimestamp);
+    evaluationPlayer.manualStep(SECONDS_PER_DAY, currentTimestamp);
+  }
+
+  simulationPlayer.stop();
+  evaluationPlayer.stop();
+
+  const outputDirectory = path.resolve(
+    __dirname,
+    '../../../../../../verifications/food_prices_war',
+  );
+  await fs.mkdir(outputDirectory, { recursive: true });
+
+  const outputPath = path.join(outputDirectory, 'raw_output.json');
+  const finalState = frames[frames.length - 1];
+
+  const summary = {
+    daysSimulated: SIMULATION_DAYS,
+    finalPrice: finalState?.payload.entities.find(
+      (entity) => entity.id === FOOD_MARKET_ENTITY_ID,
+    )?.components?.foodPrice,
+    finalSupply: finalState?.payload.entities.find(
+      (entity) => entity.id === FOOD_MARKET_ENTITY_ID,
+    )?.components?.foodSupply,
+    finalDemand: finalState?.payload.entities.find(
+      (entity) => entity.id === FOOD_MARKET_ENTITY_ID,
+    )?.components?.foodDemand,
+    finalWarState: finalState?.payload.entities.find(
+      (entity) => entity.id === WAR_ENTITY_ID,
+    )?.components?.warImpact,
+  };
+
+  await fs.writeFile(
+    outputPath,
+    JSON.stringify(
+      {
+        metadata: {
+          scenario: 'food_prices_war',
+          secondsPerDay: SECONDS_PER_DAY,
+          daysSimulated: SIMULATION_DAYS,
+        },
+        summary,
+        frames,
+      },
+      null,
+      2,
+    ),
+    'utf-8',
+  );
+}
+
+main().catch((error) => {
+  console.error('Failed to run food prices war simulation:', error);
+  process.exitCode = 1;
+});

--- a/workspaces/Describing_Simulation_0/project/plugins/simulation/systems/FoodDemandSystem.ts
+++ b/workspaces/Describing_Simulation_0/project/plugins/simulation/systems/FoodDemandSystem.ts
@@ -1,0 +1,162 @@
+import { ComponentManager } from '../../../src/core/components/ComponentManager';
+import { EntityManager } from '../../../src/core/entity/EntityManager';
+import { System } from '../../../src/core/systems/System';
+import { approach, clamp, exponentialSmoothing } from '../utils/math';
+import { FOOD_MARKET_ENTITY_ID } from '../components/FoodSupplyComponent';
+import {
+  FOOD_DEMAND_COMPONENT,
+  type FoodDemandComponent,
+} from '../components/FoodDemandComponent';
+import { FOOD_PRICE_COMPONENT, type FoodPriceComponent } from '../components/FoodPriceComponent';
+import {
+  WAR_ENTITY_ID,
+  WAR_IMPACT_COMPONENT,
+  type WarImpactComponent,
+} from '../components/WarImpactComponent';
+
+const SECONDS_PER_DAY = 86_400;
+
+function ensureDemandComponent(
+  entities: EntityManager,
+  components: ComponentManager,
+): { id: string; component: FoodDemandComponent } {
+  if (!components.isRegistered(FOOD_DEMAND_COMPONENT)) {
+    components.register(FOOD_DEMAND_COMPONENT);
+  }
+
+  const entity =
+    entities.get(FOOD_MARKET_ENTITY_ID) ??
+    entities.create(FOOD_MARKET_ENTITY_ID);
+  const existing = components.getComponent(entity.id, FOOD_DEMAND_COMPONENT);
+
+  if (existing) {
+    return { id: entity.id, component: existing };
+  }
+
+  const initial: FoodDemandComponent = {
+    baselineDemand: 100,
+    currentDemand: 100,
+    priceElasticity: 0.3,
+    panicFactor: 0.1,
+    rationingEffectiveness: 0,
+    substitutionRate: 0.05,
+    incomeShock: 0.05,
+  };
+
+  components.setComponent(entity.id, FOOD_DEMAND_COMPONENT, initial);
+  return { id: entity.id, component: initial };
+}
+
+export class FoodDemandSystem extends System {
+  private marketEntityId: string | null = null;
+
+  constructor(
+    private readonly entities: EntityManager,
+    private readonly components: ComponentManager,
+  ) {
+    super();
+  }
+
+  protected override onInit(): void {
+    const { id } = ensureDemandComponent(this.entities, this.components);
+    this.marketEntityId = id;
+  }
+
+  protected override update(deltaTime: number): void {
+    if (!this.marketEntityId) {
+      throw new Error('Food demand entity not initialized.');
+    }
+
+    const demand =
+      this.components.getComponent(this.marketEntityId, FOOD_DEMAND_COMPONENT) ??
+      ensureDemandComponent(this.entities, this.components).component;
+    const price = this.components.isRegistered(FOOD_PRICE_COMPONENT)
+      ? this.components.getComponent(this.marketEntityId, FOOD_PRICE_COMPONENT)
+      : undefined;
+    const war = this.components.getComponent(WAR_ENTITY_ID, WAR_IMPACT_COMPONENT);
+
+    if (!war) {
+      return;
+    }
+
+    const next = this.calculateDemand(
+      demand,
+      price,
+      war,
+      deltaTime / SECONDS_PER_DAY,
+    );
+
+    this.components.setComponent(this.marketEntityId, FOOD_DEMAND_COMPONENT, next);
+  }
+
+  private calculateDemand(
+    demand: FoodDemandComponent,
+    price: FoodPriceComponent | undefined,
+    war: WarImpactComponent,
+    deltaDays: number,
+  ): FoodDemandComponent {
+    const panicTarget = clamp(
+      0,
+      0.6,
+      Math.exp(-war.elapsedDays / 35) * 0.25 + war.intensity * 0.05,
+    );
+    const panicFactor = approach(demand.panicFactor, panicTarget, deltaDays * 0.6);
+
+    const rationingEffectiveness = approach(
+      demand.rationingEffectiveness,
+      war.policyRationing,
+      deltaDays * 0.6,
+    );
+
+    const substitutionTarget = clamp(
+      0,
+      0.5,
+      war.reliefEffort * 0.5 + war.policyRationing * 0.3,
+    );
+    const substitutionRate = approach(
+      demand.substitutionRate,
+      substitutionTarget,
+      deltaDays * 0.4,
+    );
+
+    const incomeShockTarget = clamp(
+      0,
+      0.6,
+      war.intensity * 0.35 + war.blockadeSeverity * 0.25,
+    );
+    const incomeShock = approach(
+      demand.incomeShock,
+      incomeShockTarget,
+      deltaDays * 0.3,
+    );
+
+    const priceSignal = price
+      ? clamp(-0.5, 2, price.currentPrice / price.baselinePrice - 1)
+      : 0;
+    const priceResponse = -demand.priceElasticity * priceSignal;
+
+    const demandPressure = war.demandPressure;
+
+    const demandTarget = clamp(
+      40,
+      140,
+      demand.baselineDemand *
+        (1 + panicFactor + demandPressure - rationingEffectiveness - substitutionRate - incomeShock + priceResponse),
+    );
+
+    const currentDemand = exponentialSmoothing(
+      demand.currentDemand,
+      demandTarget,
+      clamp(0, 1, deltaDays * 0.6),
+    );
+
+    return {
+      ...demand,
+      currentDemand,
+      panicFactor,
+      rationingEffectiveness,
+      substitutionRate,
+      incomeShock,
+    };
+  }
+}

--- a/workspaces/Describing_Simulation_0/project/plugins/simulation/systems/FoodPriceSystem.ts
+++ b/workspaces/Describing_Simulation_0/project/plugins/simulation/systems/FoodPriceSystem.ts
@@ -1,0 +1,198 @@
+import { ComponentManager } from '../../../src/core/components/ComponentManager';
+import { EntityManager } from '../../../src/core/entity/EntityManager';
+import { System } from '../../../src/core/systems/System';
+import { approach, clamp, exponentialSmoothing } from '../utils/math';
+import {
+  FOOD_MARKET_ENTITY_ID,
+  FOOD_SUPPLY_COMPONENT,
+  type FoodSupplyComponent,
+} from '../components/FoodSupplyComponent';
+import {
+  FOOD_DEMAND_COMPONENT,
+  type FoodDemandComponent,
+} from '../components/FoodDemandComponent';
+import {
+  FOOD_PRICE_COMPONENT,
+  type FoodPriceComponent,
+} from '../components/FoodPriceComponent';
+import {
+  WAR_ENTITY_ID,
+  WAR_IMPACT_COMPONENT,
+  type WarImpactComponent,
+} from '../components/WarImpactComponent';
+
+const SECONDS_PER_DAY = 86_400;
+
+function ensurePriceComponent(
+  entities: EntityManager,
+  components: ComponentManager,
+): { id: string; component: FoodPriceComponent } {
+  if (!components.isRegistered(FOOD_PRICE_COMPONENT)) {
+    components.register(FOOD_PRICE_COMPONENT);
+  }
+
+  const entity =
+    entities.get(FOOD_MARKET_ENTITY_ID) ??
+    entities.create(FOOD_MARKET_ENTITY_ID);
+  const existing = components.getComponent(entity.id, FOOD_PRICE_COMPONENT);
+
+  if (existing) {
+    return { id: entity.id, component: existing };
+  }
+
+  const initial: FoodPriceComponent = {
+    baselinePrice: 100,
+    currentPrice: 100,
+    inflationRate: 0,
+    volatility: 0.02,
+    priceMomentum: 0,
+    scarcityIndex: 0,
+    affordabilityIndex: 1,
+  };
+
+  components.setComponent(entity.id, FOOD_PRICE_COMPONENT, initial);
+  return { id: entity.id, component: initial };
+}
+
+export class FoodPriceSystem extends System {
+  private marketEntityId: string | null = null;
+
+  constructor(
+    private readonly entities: EntityManager,
+    private readonly components: ComponentManager,
+  ) {
+    super();
+  }
+
+  protected override onInit(): void {
+    const { id } = ensurePriceComponent(this.entities, this.components);
+    this.marketEntityId = id;
+  }
+
+  protected override update(deltaTime: number): void {
+    if (!this.marketEntityId) {
+      throw new Error('Food price entity not initialized.');
+    }
+
+    const supply = this.components.getComponent(
+      this.marketEntityId,
+      FOOD_SUPPLY_COMPONENT,
+    );
+    const demand = this.components.getComponent(
+      this.marketEntityId,
+      FOOD_DEMAND_COMPONENT,
+    );
+    const price =
+      this.components.getComponent(this.marketEntityId, FOOD_PRICE_COMPONENT) ??
+      ensurePriceComponent(this.entities, this.components).component;
+    const war = this.components.getComponent(WAR_ENTITY_ID, WAR_IMPACT_COMPONENT);
+
+    if (!supply || !demand || !war) {
+      return;
+    }
+
+    const { priceState, supplyState } = this.calculatePrice(
+      price,
+      supply,
+      demand,
+      war,
+      deltaTime / SECONDS_PER_DAY,
+    );
+
+    this.components.setComponent(this.marketEntityId, FOOD_PRICE_COMPONENT, priceState);
+    this.components.setComponent(this.marketEntityId, FOOD_SUPPLY_COMPONENT, supplyState);
+  }
+
+  private calculatePrice(
+    price: FoodPriceComponent,
+    supply: FoodSupplyComponent,
+    demand: FoodDemandComponent,
+    war: WarImpactComponent,
+    deltaDays: number,
+  ): { priceState: FoodPriceComponent; supplyState: FoodSupplyComponent } {
+    const effectiveSupply = supply.currentProduction * (1 - supply.wastageRate);
+    const baselineDemand = demand.baselineDemand;
+    const demandGap = demand.currentDemand - effectiveSupply;
+
+    const stockpileBuffer = clamp(
+      0,
+      1.5,
+      supply.stockpile / Math.max(1, supply.targetStockpile),
+    );
+
+    const scarcity = clamp(
+      -1,
+      1.5,
+      demandGap / Math.max(1, baselineDemand) +
+        war.supplyDisruption * 0.3 -
+        stockpileBuffer * 0.4 +
+        (1 - supply.logisticsEfficiency) * 0.2,
+    );
+
+    const inflationPressure =
+      Math.max(0, scarcity) * (0.9 + war.intensity * 0.6 + war.blockadeSeverity * 0.4) +
+      demand.panicFactor * 0.3 +
+      war.demandPressure * 0.4;
+
+    const deflationPressure =
+      Math.max(0, -scarcity) * (0.6 + supply.logisticsEfficiency * 0.5) +
+      war.reliefEffort * 0.6 +
+      demand.rationingEffectiveness * 0.35 +
+      stockpileBuffer * 0.5;
+
+    const netPressure = clamp(
+      -1.5,
+      1.5,
+      (inflationPressure - deflationPressure) * 0.6,
+    );
+    const momentumTarget = clamp(-0.2, 0.2, netPressure * 0.4);
+    const priceMomentum = approach(
+      price.priceMomentum,
+      momentumTarget,
+      clamp(0, 1, deltaDays * 0.7),
+    );
+
+    const priceChange = clamp(-0.4, 0.4, priceMomentum * deltaDays * 0.25);
+    const nextPrice = clamp(20, 320, price.currentPrice * (1 + priceChange));
+    const inflationRate = clamp(-0.3, 0.5, priceChange);
+
+    const volatility = exponentialSmoothing(
+      price.volatility,
+      Math.abs(inflationRate),
+      clamp(0, 1, deltaDays * 0.4),
+    );
+
+    const affordabilityIndex = clamp(
+      0.2,
+      1.6,
+      (effectiveSupply + supply.stockpile * 0.05) /
+        Math.max(1, demand.currentDemand) /
+        (nextPrice / price.baselinePrice),
+    );
+
+    const stockpileDelta =
+      (effectiveSupply - demand.currentDemand) * deltaDays;
+    const nextStockpile = clamp(
+      0,
+      400,
+      supply.stockpile + stockpileDelta,
+    );
+
+    const adjustedSupply: FoodSupplyComponent = {
+      ...supply,
+      stockpile: nextStockpile,
+    };
+
+    const priceState: FoodPriceComponent = {
+      ...price,
+      currentPrice: nextPrice,
+      inflationRate,
+      volatility,
+      priceMomentum,
+      scarcityIndex: scarcity,
+      affordabilityIndex,
+    };
+
+    return { priceState, supplyState: adjustedSupply };
+  }
+}

--- a/workspaces/Describing_Simulation_0/project/plugins/simulation/systems/FoodSupplySystem.ts
+++ b/workspaces/Describing_Simulation_0/project/plugins/simulation/systems/FoodSupplySystem.ts
@@ -1,0 +1,138 @@
+import { ComponentManager } from '../../../src/core/components/ComponentManager';
+import { EntityManager } from '../../../src/core/entity/EntityManager';
+import { System } from '../../../src/core/systems/System';
+import { approach, clamp } from '../utils/math';
+import {
+  FOOD_MARKET_ENTITY_ID,
+  FOOD_SUPPLY_COMPONENT,
+  type FoodSupplyComponent,
+} from '../components/FoodSupplyComponent';
+import {
+  WAR_ENTITY_ID,
+  WAR_IMPACT_COMPONENT,
+  type WarImpactComponent,
+} from '../components/WarImpactComponent';
+
+const SECONDS_PER_DAY = 86_400;
+
+function ensureSupplyComponent(
+  entities: EntityManager,
+  components: ComponentManager,
+): { id: string; component: FoodSupplyComponent } {
+  if (!components.isRegistered(FOOD_SUPPLY_COMPONENT)) {
+    components.register(FOOD_SUPPLY_COMPONENT);
+  }
+
+  const entity =
+    entities.get(FOOD_MARKET_ENTITY_ID) ??
+    entities.create(FOOD_MARKET_ENTITY_ID);
+  const existing = components.getComponent(entity.id, FOOD_SUPPLY_COMPONENT);
+
+  if (existing) {
+    return { id: entity.id, component: existing };
+  }
+
+  const initial: FoodSupplyComponent = {
+    baselineProduction: 100,
+    currentProduction: 100,
+    importDependency: 0.4,
+    resilience: 0.55,
+    stockpile: 220,
+    targetStockpile: 250,
+    logisticsEfficiency: 0.92,
+    wastageRate: 0.05,
+  };
+
+  components.setComponent(entity.id, FOOD_SUPPLY_COMPONENT, initial);
+  return { id: entity.id, component: initial };
+}
+
+export class FoodSupplySystem extends System {
+  private marketEntityId: string | null = null;
+
+  constructor(
+    private readonly entities: EntityManager,
+    private readonly components: ComponentManager,
+  ) {
+    super();
+  }
+
+  protected override onInit(): void {
+    const { id } = ensureSupplyComponent(this.entities, this.components);
+    this.marketEntityId = id;
+  }
+
+  protected override update(deltaTime: number): void {
+    if (!this.marketEntityId) {
+      throw new Error('Food market entity not initialized.');
+    }
+
+    const supply =
+      this.components.getComponent(this.marketEntityId, FOOD_SUPPLY_COMPONENT) ??
+      ensureSupplyComponent(this.entities, this.components).component;
+    const war = this.components.getComponent(WAR_ENTITY_ID, WAR_IMPACT_COMPONENT);
+
+    if (!war) {
+      return;
+    }
+
+    const updated = this.calculateSupply(supply, war, deltaTime / SECONDS_PER_DAY);
+    this.components.setComponent(this.marketEntityId, FOOD_SUPPLY_COMPONENT, updated);
+  }
+
+  private calculateSupply(
+    supply: FoodSupplyComponent,
+    war: WarImpactComponent,
+    deltaDays: number,
+  ): FoodSupplyComponent {
+    const disruptionImpact =
+      war.supplyDisruption * (1 - supply.resilience) +
+      war.blockadeSeverity * supply.importDependency;
+    const reliefBoost = war.reliefEffort * (0.3 + 0.4 * (1 - supply.importDependency));
+
+    const logisticsTarget = clamp(
+      0.25,
+      1,
+      1 - disruptionImpact * 0.6 - war.infrastructureDamage * 0.4 + reliefBoost * 0.5,
+    );
+    const logisticsEfficiency = approach(
+      supply.logisticsEfficiency,
+      logisticsTarget,
+      deltaDays * 0.6,
+    );
+
+    const productionTarget =
+      supply.baselineProduction *
+        (0.65 + 0.35 * logisticsEfficiency) *
+        (1 - war.supplyDisruption * (1 - supply.resilience * 0.6)) +
+      supply.baselineProduction * reliefBoost * 0.4;
+
+    const currentProduction = approach(
+      supply.currentProduction,
+      productionTarget,
+      deltaDays * 0.5,
+    );
+
+    const wastageTarget = clamp(
+      0.02,
+      0.2,
+      0.03 + (1 - logisticsEfficiency) * 0.1 + war.infrastructureDamage * 0.05,
+    );
+    const wastageRate = approach(supply.wastageRate, wastageTarget, deltaDays * 0.5);
+
+    const targetStockpile = clamp(
+      80,
+      320,
+      supply.targetStockpile * (1 - war.supplyDisruption * 0.25) +
+        supply.baselineProduction * (0.5 + reliefBoost * 0.8),
+    );
+
+    return {
+      ...supply,
+      currentProduction,
+      logisticsEfficiency,
+      wastageRate,
+      targetStockpile,
+    };
+  }
+}

--- a/workspaces/Describing_Simulation_0/project/plugins/simulation/systems/WarImpactSystem.ts
+++ b/workspaces/Describing_Simulation_0/project/plugins/simulation/systems/WarImpactSystem.ts
@@ -1,0 +1,140 @@
+import { ComponentManager } from '../../../src/core/components/ComponentManager';
+import { TIME_COMPONENT } from '../../../src/core/components/TimeComponent';
+import { EntityManager } from '../../../src/core/entity/EntityManager';
+import { System } from '../../../src/core/systems/System';
+import { approach, clamp } from '../utils/math';
+import {
+  WAR_ENTITY_ID,
+  WAR_IMPACT_COMPONENT,
+  type WarImpactComponent,
+} from '../components/WarImpactComponent';
+
+const SECONDS_PER_DAY = 86_400;
+
+function ensureWarComponent(
+  entities: EntityManager,
+  components: ComponentManager,
+): { id: string; state: WarImpactComponent } {
+  if (!components.isRegistered(WAR_IMPACT_COMPONENT)) {
+    components.register(WAR_IMPACT_COMPONENT);
+  }
+
+  const entity = entities.get(WAR_ENTITY_ID) ?? entities.create(WAR_ENTITY_ID);
+  const existing = components.getComponent(entity.id, WAR_IMPACT_COMPONENT);
+
+  if (existing) {
+    return { id: entity.id, state: existing };
+  }
+
+  const initial: WarImpactComponent = {
+    intensity: 0.15,
+    supplyDisruption: 0.1,
+    demandPressure: 0.05,
+    reliefEffort: 0.05,
+    blockadeSeverity: 0.1,
+    policyRationing: 0.0,
+    infrastructureDamage: 0.05,
+    elapsedDays: 0,
+  };
+
+  components.setComponent(entity.id, WAR_IMPACT_COMPONENT, initial);
+  return { id: entity.id, state: initial };
+}
+
+export class WarImpactSystem extends System {
+  private warEntityId: string | null = null;
+
+  constructor(
+    private readonly entities: EntityManager,
+    private readonly components: ComponentManager,
+  ) {
+    super();
+  }
+
+  protected override onInit(): void {
+    const { id } = ensureWarComponent(this.entities, this.components);
+    this.warEntityId = id;
+  }
+
+  protected override update(deltaTime: number): void {
+    if (!this.warEntityId) {
+      throw new Error('War entity not initialized.');
+    }
+
+    const current =
+      this.components.getComponent(this.warEntityId, WAR_IMPACT_COMPONENT) ??
+      ensureWarComponent(this.entities, this.components).state;
+
+    const deltaDays = deltaTime / SECONDS_PER_DAY;
+    const timeState = this.components.getComponent('time', TIME_COMPONENT);
+    const elapsedDays = timeState?.elapsed ? timeState.elapsed / SECONDS_PER_DAY : current.elapsedDays + deltaDays;
+
+    const intensityTarget = clamp(
+      0,
+      1,
+      0.2 + 0.7 * (1 - Math.exp(-elapsedDays / 40)) - 0.2 * Math.max(0, (elapsedDays - 180) / 180),
+    );
+    const intensity = approach(current.intensity, intensityTarget, deltaDays * 0.6);
+
+    const blockadeTarget = clamp(
+      0,
+      1,
+      0.15 + 0.7 * (1 - Math.exp(-elapsedDays / 35)) - 0.2 * Math.max(0, elapsedDays - 200) / 200,
+    );
+    const blockadeSeverity = approach(
+      current.blockadeSeverity,
+      blockadeTarget,
+      deltaDays * 0.5,
+    );
+
+    const reliefTarget = clamp(
+      0,
+      0.7,
+      (elapsedDays < 50 ? elapsedDays / 50 : 1) * 0.2 + Math.max(0, elapsedDays - 60) / 300,
+    );
+    const reliefEffort = approach(current.reliefEffort, reliefTarget, deltaDays * 0.4);
+
+    const infrastructureDamage = clamp(
+      0,
+      1,
+      current.infrastructureDamage + intensity * deltaDays * 0.02 - reliefEffort * deltaDays * 0.01,
+    );
+
+    const supplyDisruptionBase = clamp(
+      0,
+      1,
+      0.15 + intensity * 0.55 + blockadeSeverity * 0.35 + infrastructureDamage * 0.3 - reliefEffort * 0.45,
+    );
+
+    const rationingTarget = clamp(
+      0,
+      0.6,
+      supplyDisruptionBase * 0.6 + Math.max(0, elapsedDays - 30) / 250,
+    );
+    const policyRationing = approach(
+      current.policyRationing,
+      rationingTarget,
+      deltaDays * 0.7,
+    );
+
+    const panicPulse = Math.exp(-elapsedDays / 35) * 0.25;
+    const demandPressure = clamp(
+      -0.4,
+      0.4,
+      panicPulse + intensity * 0.08 + blockadeSeverity * 0.05 - policyRationing * 0.5 - reliefEffort * 0.25,
+    );
+
+    const nextState: WarImpactComponent = {
+      intensity,
+      supplyDisruption: supplyDisruptionBase,
+      demandPressure,
+      reliefEffort,
+      blockadeSeverity,
+      policyRationing,
+      infrastructureDamage,
+      elapsedDays,
+    };
+
+    this.components.setComponent(this.warEntityId, WAR_IMPACT_COMPONENT, nextState);
+  }
+}

--- a/workspaces/Describing_Simulation_0/project/plugins/simulation/utils/math.ts
+++ b/workspaces/Describing_Simulation_0/project/plugins/simulation/utils/math.ts
@@ -1,0 +1,41 @@
+export function clamp(min: number, max: number, value: number): number {
+  if (min > max) {
+    throw new Error('Minimum cannot exceed maximum.');
+  }
+
+  if (value < min) {
+    return min;
+  }
+
+  if (value > max) {
+    return max;
+  }
+
+  return value;
+}
+
+export function approach(
+  current: number,
+  target: number,
+  rate: number,
+): number {
+  if (!Number.isFinite(current) || !Number.isFinite(target)) {
+    return target;
+  }
+
+  if (rate <= 0) {
+    return current;
+  }
+
+  const clampedRate = rate > 1 ? 1 : rate;
+  return current + (target - current) * clampedRate;
+}
+
+export function exponentialSmoothing(
+  previous: number,
+  observation: number,
+  weight: number,
+): number {
+  const alpha = clamp(0, 1, weight);
+  return previous * (1 - alpha) + observation * alpha;
+}

--- a/workspaces/verifications/food_prices_war/raw_output.json
+++ b/workspaces/verifications/food_prices_war/raw_output.json
@@ -1,0 +1,12358 @@
+{
+  "metadata": {
+    "scenario": "food_prices_war",
+    "secondsPerDay": 86400,
+    "daysSimulated": 180
+  },
+  "summary": {
+    "daysSimulated": 180,
+    "finalPrice": {
+      "baselinePrice": 100,
+      "currentPrice": 320,
+      "inflationRate": 0.012084973230963254,
+      "volatility": 0.012608440688529862,
+      "priceMomentum": 0.04833989292385302,
+      "scarcityIndex": 0.4993000692493762,
+      "affordabilityIndex": 0.25963436562750286
+    },
+    "finalSupply": {
+      "baselineProduction": 100,
+      "currentProduction": 39.12551088116872,
+      "importDependency": 0.4,
+      "resilience": 0.55,
+      "stockpile": 0,
+      "targetStockpile": 309.3719990996898,
+      "logisticsEfficiency": 0.29522850672790707,
+      "wastageRate": 0.1506002592207518
+    },
+    "finalDemand": {
+      "baselineDemand": 100,
+      "currentDemand": 40,
+      "priceElasticity": 0.3,
+      "panicFactor": 0.0460867369898978,
+      "rationingEffectiveness": 0.6,
+      "substitutionRate": 0.47500000000000003,
+      "incomeShock": 0.52342874492652
+    },
+    "finalWarState": {
+      "intensity": 0.8920902109138716,
+      "supplyDisruption": 0.9689258619938709,
+      "demandPressure": -0.33363307507805695,
+      "reliefEffort": 0.5950000000000001,
+      "blockadeSeverity": 0.8457892742606901,
+      "policyRationing": 0.6,
+      "infrastructureDamage": 1,
+      "elapsedDays": 180
+    }
+  },
+  "frames": [
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 100,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.1,
+                "rationingEffectiveness": 0,
+                "substitutionRate": 0.05,
+                "incomeShock": 0.05
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 100,
+                "inflationRate": 0,
+                "volatility": 0.02,
+                "priceMomentum": 0,
+                "scarcityIndex": -0.1637891644223707,
+                "affordabilityIndex": 1.06
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 100,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 220,
+                "targetStockpile": 285.90999999999997,
+                "logisticsEfficiency": 0.92,
+                "wastageRate": 0.05
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 0
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.15,
+                "supplyDisruption": 0.25999999999999995,
+                "demandPressure": 0.2545,
+                "reliefEffort": 0.05,
+                "blockadeSeverity": 0.1,
+                "policyRationing": 0,
+                "infrastructureDamage": 0.05,
+                "elapsedDays": 0
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 1,
+        "timestamp": 0,
+        "deltaSeconds": 0
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 111.48769705791938,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.19148602636339018,
+                "rationingEffectiveness": 0.0765402881422041,
+                "substitutionRate": 0.05162805762844082,
+                "incomeShock": 0.06510321990993478
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 99.37492381211007,
+                "inflationRate": -0.006250761878899226,
+                "volatility": 0.014500304751559692,
+                "priceMomentum": -0.025003047515596902,
+                "scarcityIndex": 0.10368966265829502,
+                "affordabilityIndex": 0.8620845747704744
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 88.65611771426347,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 193.02335472738645,
+                "targetStockpile": 315.5651658504587,
+                "logisticsEfficiency": 0.8916571707357516,
+                "wastageRate": 0.046754426381686476
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 86400
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.1903698369481003,
+                "supplyDisruption": 0.30373130215160354,
+                "demandPressure": 0.19324715694917938,
+                "reliefEffort": 0.0316,
+                "blockadeSeverity": 0.1348584937384566,
+                "policyRationing": 0.1275671469036735,
+                "infrastructureDamage": 0.05349139673896201,
+                "elapsedDays": 1
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 2,
+        "timestamp": 86400,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 111.72171979950781,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.22476222838925475,
+                "rationingEffectiveness": 0.1375219437928611,
+                "substitutionRate": 0.05679000028426037,
+                "incomeShock": 0.08045871063736987
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 99.25507480135418,
+                "inflationRate": -0.0012060287058181214,
+                "volatility": 0.009182594333263062,
+                "priceMomentum": -0.004824114823272486,
+                "scarcityIndex": 0.22358839824870208,
+                "affordabilityIndex": 0.7890408333790178
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 81.62945888294084,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 159.14679218650332,
+                "targetStockpile": 320,
+                "logisticsEfficiency": 0.869155300262328,
+                "wastageRate": 0.04635950888444536
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 172800
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.21663157648894024,
+                "supplyDisruption": 0.3331100876718977,
+                "demandPressure": 0.16691054736723435,
+                "reliefEffort": 0.02216,
+                "blockadeSeverity": 0.16186854892102387,
+                "policyRationing": 0.17817638089329907,
+                "infrastructureDamage": 0.05760242826874082,
+                "elapsedDays": 2
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 3,
+        "timestamp": 172800,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 107.98477886065619,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.2346933681143633,
+                "rationingEffectiveness": 0.17666527275959948,
+                "substitutionRate": 0.062024499219047236,
+                "incomeShock": 0.09505747498665018
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 99.74007353355019,
+                "inflationRate": 0.004886387251902951,
+                "volatility": 0.007464111500719017,
+                "priceMomentum": 0.019545549007611802,
+                "scarcityIndex": 0.2824228082750303,
+                "affordabilityIndex": 0.7561600532807611
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 77.1211761791326,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 124.64621007827178,
+                "targetStockpile": 320,
+                "logisticsEfficiency": 0.851490152642573,
+                "wastageRate": 0.04715928369998134
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 259200
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.2370003663375839,
+                "supplyDisruption": 0.3554950265145287,
+                "demandPressure": 0.15175395226921393,
+                "reliefEffort": 0.018096,
+                "blockadeSeverity": 0.1846845210005995,
+                "policyRationing": 0.20276082540409177,
+                "infrastructureDamage": 0.062161475595492496,
+                "elapsedDays": 3
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 4,
+        "timestamp": 259200,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 103.15937818928171,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.2353208593925074,
+                "rationingEffectiveness": 0.20148197391372275,
+                "substitutionRate": 0.06682939249340493,
+                "incomeShock": 0.10867650691582659
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 100.76373228689911,
+                "inflationRate": 0.010263264474179325,
+                "volatility": 0.008583772690103141,
+                "priceMomentum": 0.0410530578967173,
+                "scarcityIndex": 0.31576981396370357,
+                "affordabilityIndex": 0.7380669341333815
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 74.0729026365974,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 91.9745418780795,
+                "targetStockpile": 320,
+                "logisticsEfficiency": 0.837117647661102,
+                "wastageRate": 0.04840086617230285
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 345600
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.25476843095993057,
+                "supplyDisruption": 0.37428141363947,
+                "demandPressure": 0.14031167861475144,
+                "reliefEffort": 0.0172576,
+                "blockadeSeverity": 0.2051411889917167,
+                "policyRationing": 0.21802644134980492,
+                "infrastructureDamage": 0.06708426821469111,
+                "elapsedDays": 4
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 5,
+        "timestamp": 345600,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 98.21131093668237,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.23229778891848346,
+                "rationingEffectiveness": 0.21839163743656254,
+                "substitutionRate": 0.07132831707025765,
+                "incomeShock": 0.12136796525616214
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 102.25251360898886,
+                "inflationRate": 0.014774971989433906,
+                "volatility": 0.011060252409835446,
+                "priceMomentum": 0.059099887957735624,
+                "scarcityIndex": 0.33656444730525875,
+                "affordabilityIndex": 0.725854497512349
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 71.87096734034333,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 62.057377716342444,
+                "targetStockpile": 320,
+                "logisticsEfficiency": 0.8248265635613039,
+                "wastageRate": 0.04976725231010273
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 432000
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.27125867329844217,
+                "supplyDisruption": 0.39108765249249433,
+                "demandPressure": 0.130207322054691,
+                "reliefEffort": 0.018354560000000002,
+                "blockadeSeverity": 0.2241633295832948,
+                "policyRationing": 0.22966474645178908,
+                "infrastructureDamage": 0.07232589608065995,
+                "elapsedDays": 5
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 6,
+        "timestamp": 432000,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 93.38540785349156,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.22789836538653468,
+                "rationingEffectiveness": 0.2311879299670146,
+                "substitutionRate": 0.0756857924406325,
+                "incomeShock": 0.13325975646443633
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 104.14582263580674,
+                "inflationRate": 0.018516014521245315,
+                "volatility": 0.014042557254399395,
+                "priceMomentum": 0.07406405808498126,
+                "scarcityIndex": 0.34978509800763014,
+                "affordabilityIndex": 0.7164281381536097
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 70.16286379225429,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 35.24675329123495,
+                "targetStockpile": 320,
+                "logisticsEfficiency": 0.8138162909131049,
+                "wastageRate": 0.05113930888702305
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 518400
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.28700611922085256,
+                "supplyDisruption": 0.40671278028201413,
+                "demandPressure": 0.1206740456261586,
+                "reliefEffort": 0.020612736000000003,
+                "blockadeSeverity": 0.2422205102257774,
+                "policyRationing": 0.23971879165398263,
+                "infrastructureDamage": 0.077859891105077,
+                "elapsedDays": 6
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 7,
+        "timestamp": 518400,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 88.69706491649015,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.22303587408526937,
+                "rationingEffectiveness": 0.24185920038203887,
+                "substitutionRate": 0.08000180946342611,
+                "incomeShock": 0.14448261878162882
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 106.39110790626236,
+                "inflationRate": 0.021559052620932162,
+                "volatility": 0.0170491554010125,
+                "priceMomentum": 0.08623621048372865,
+                "scarcityIndex": 0.3572707397186341,
+                "affordabilityIndex": 0.7089600786151213
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 68.74720746293849,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 11.688928639057636,
+                "targetStockpile": 320,
+                "logisticsEfficiency": 0.803594408668787,
+                "wastageRate": 0.05248165462678174
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 604800
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.30223049896527393,
+                "supplyDisruption": 0.42156605514887363,
+                "demandPressure": 0.11146025203413626,
+                "reliefEffort": 0.023567641600000005,
+                "blockadeSeverity": 0.25955449153559507,
+                "policyRationing": 0.2489733806587217,
+                "infrastructureDamage": 0.08366882466838248,
+                "elapsedDays": 7
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 8,
+        "timestamp": 604800,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 84.10997753668909,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.2180755273791624,
+                "rationingEffectiveness": 0.25139690568826095,
+                "substitutionRate": 0.08431984777714474,
+                "incomeShock": 0.15514745795743307
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 108.93761956293692,
+                "inflationRate": 0.023935380566938086,
+                "volatility": 0.019803645467382735,
+                "priceMomentum": 0.09574152226775234,
+                "scarcityIndex": 0.3596961998129591,
+                "affordabilityIndex": 0.7035261586302901
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 67.50921382528864,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 320,
+                "logisticsEfficiency": 0.7938682200343345,
+                "wastageRate": 0.05379091442379039
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 691200
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.3170252832933572,
+                "supplyDisruption": 0.43586514689236305,
+                "demandPressure": 0.10248120059734754,
+                "reliefEffort": 0.026940584960000003,
+                "blockadeSeverity": 0.27629293419320505,
+                "policyRationing": 0.257755375892409,
+                "infrastructureDamage": 0.08973992448464962,
+                "elapsedDays": 8
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 9,
+        "timestamp": 691200,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 79.59059709552022,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.2131618710672957,
+                "rationingEffectiveness": 0.2602867988573032,
+                "substitutionRate": 0.0886503861778866,
+                "incomeShock": 0.16534168656579706
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 111.61168659012101,
+                "inflationRate": 0.024546773079057425,
+                "volatility": 0.021700896512052613,
+                "priceMomentum": 0.0981870923162297,
+                "scarcityIndex": 0.3466574201678179,
+                "affordabilityIndex": 0.7061323915534524
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 66.383422034701,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 320,
+                "logisticsEfficiency": 0.7844663744285324,
+                "wastageRate": 0.05507371216556002
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 777600
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.3314333014384045,
+                "supplyDisruption": 0.4497304322276398,
+                "demandPressure": 0.09370662723657859,
+                "reliefEffort": 0.030564350976,
+                "blockadeSeverity": 0.2925062579274858,
+                "policyRationing": 0.2662133943033314,
+                "infrastructureDamage": 0.09606294700365771,
+                "elapsedDays": 9
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 10,
+        "timestamp": 777600,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 75.14134370257537,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.20835065213877232,
+                "rationingEffectiveness": 0.26876742507737655,
+                "substitutionRate": 0.09298849493074302,
+                "incomeShock": 0.17513197045207643
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 114.18774421827776,
+                "inflationRate": 0.023080536696994596,
+                "volatility": 0.022252752586029406,
+                "priceMomentum": 0.09232214678797838,
+                "scarcityIndex": 0.3188084044275056,
+                "affordabilityIndex": 0.7185323946940496
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 65.33236791353536,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 320,
+                "logisticsEfficiency": 0.7752889504367405,
+                "wastageRate": 0.056338136079230716
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 864000
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.34547699168537177,
+                "supplyDisruption": 0.46323132761847463,
+                "demandPressure": 0.08512404583124149,
+                "reliefEffort": 0.034338610585600005,
+                "blockadeSeverity": 0.3082360763873928,
+                "policyRationing": 0.27442117589075876,
+                "infrastructureDamage": 0.10262910073150915,
+                "elapsedDays": 10
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 11,
+        "timestamp": 864000,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 70.79503032819711,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.20366192674080238,
+                "rationingEffectiveness": 0.2769580496607517,
+                "substitutionRate": 0.09732394615467803,
+                "incomeShock": 0.18456848881844712
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 116.58311643422887,
+                "inflationRate": 0.02097748959268514,
+                "volatility": 0.0217426473886917,
+                "priceMomentum": 0.08390995837074056,
+                "scarcityIndex": 0.29132401281934234,
+                "affordabilityIndex": 0.734589392173597
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 64.33445718855937,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 320,
+                "logisticsEfficiency": 0.7662774351198607,
+                "wastageRate": 0.057590958262782044
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 950400
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.35917050491966196,
+                "supplyDisruption": 0.47640979352962126,
+                "demandPressure": 0.07672667133402408,
+                "reliefEffort": 0.03820316635136001,
+                "blockadeSeverity": 0.32350941980572134,
+                "policyRationing": 0.2824184660496685,
+                "infrastructureDamage": 0.10943047916638879,
+                "elapsedDays": 11
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 12,
+        "timestamp": 950400,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 66.57438138037725,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.19910144652813608,
+                "rationingEffectiveness": 0.2849202841268611,
+                "substitutionRate": 0.1016461605074821,
+                "incomeShock": 0.19368895870335
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 118.76221911716199,
+                "inflationRate": 0.018691408752677087,
+                "volatility": 0.020522151934285856,
+                "priceMomentum": 0.07476563501070835,
+                "scarcityIndex": 0.2645704725378605,
+                "affordabilityIndex": 0.754417362886208
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 63.377094606656776,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 320,
+                "logisticsEfficiency": 0.757397174411179,
+                "wastageRate": 0.05883711418967986
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 1036800
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.37252454928154327,
+                "supplyDisruption": 0.4892926205302384,
+                "demandPressure": 0.06850946026388384,
+                "reliefEffort": 0.042121899810816,
+                "blockadeSeverity": 0.33834585141166673,
+                "policyRationing": 0.29022844043760065,
+                "infrastructureDamage": 0.11645975115391148,
+                "elapsedDays": 12
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 13,
+        "timestamp": 1036800,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 62.491440207008736,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.1946692693172391,
+                "rationingEffectiveness": 0.2926875354352576,
+                "substitutionRate": 0.10594620863868981,
+                "incomeShock": 0.2025219231596551
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 120.70659392538288,
+                "inflationRate": 0.016371997952502996,
+                "volatility": 0.018862090341572713,
+                "priceMomentum": 0.06548799181001198,
+                "scarcityIndex": 0.23875199335500216,
+                "affordabilityIndex": 0.7782000995380083
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 62.452797145089036,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 320,
+                "logisticsEfficiency": 0.7486272531101756,
+                "wastageRate": 0.060079944098798785
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 1123200
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.38554833118294696,
+                "supplyDisruption": 0.5018980258164485,
+                "demandPressure": 0.06046784951547991,
+                "reliefEffort": 0.0460731398864896,
+                "blockadeSeverity": 0.35276103057467545,
+                "policyRationing": 0.2978657029741886,
+                "infrastructureDamage": 0.12370998637870553,
+                "elapsedDays": 13
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 14,
+        "timestamp": 1123200,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 58.55188191598408,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.1903632246759811,
+                "rationingEffectiveness": 0.3002791386010622,
+                "substitutionRate": 0.11021732685498446,
+                "incomeShock": 0.21108926880296186
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 122.40528279853793,
+                "inflationRate": 0.01407287553988253,
+                "volatility": 0.01694640442089664,
+                "priceMomentum": 0.05629150215953012,
+                "scarcityIndex": 0.21397744518916315,
+                "affordabilityIndex": 0.8062193509139274
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 61.556995441519696,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 320,
+                "logisticsEfficiency": 0.7399546906130879,
+                "wastageRate": 0.06132160137462532
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 1209600
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.39825033479131916,
+                "supplyDisruption": 0.5142392773476396,
+                "demandPressure": 0.05259738857885248,
+                "reliefEffort": 0.05004388393189377,
+                "blockadeSeverity": 0.366768499174864,
+                "policyRationing": 0.3053402073782652,
+                "infrastructureDamage": 0.131174554235213,
+                "elapsedDays": 14
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 15,
+        "timestamp": 1209600,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 54.758034313551434,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.18618030760478035,
+                "rationingEffectiveness": 0.30770722709057396,
+                "substitutionRate": 0.11445477651484774,
+                "incomeShock": 0.21940808848749402
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 123.8516333532004,
+                "inflationRate": 0.01181607951548113,
+                "volatility": 0.014894274458730436,
+                "priceMomentum": 0.04726431806192452,
+                "scarcityIndex": 0.1903039811589577,
+                "affordabilityIndex": 0.8388541647307279
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 60.68678877699534,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 2.1319813124114404,
+                "targetStockpile": 320,
+                "logisticsEfficiency": 0.7313711138350049,
+                "wastageRate": 0.06256342158726512
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 1296000
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.41063863682431934,
+                "supplyDisruption": 0.5263267235002436,
+                "demandPressure": 0.04489365866971257,
+                "reliefEffort": 0.05402633035913626,
+                "blockadeSeverity": 0.38038057945156256,
+                "policyRationing": 0.31265928608358184,
+                "infrastructureDamage": 0.138847063668108,
+                "elapsedDays": 15
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 16,
+        "timestamp": 1296000,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 51.11043185979495,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.1821172379321321,
+                "rationingEffectiveness": 0.3149801371766611,
+                "substitutionRate": 0.1186554748200913,
+                "incomeShock": 0.22749203271716312
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 125.00666189834335,
+                "inflationRate": 0.009325904825567012,
+                "volatility": 0.012666926605465067,
+                "priceMomentum": 0.03730361930226805,
+                "scarcityIndex": 0.16509525454979723,
+                "affordabilityIndex": 0.8785003930329424
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 59.84023858947617,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 7.043609711099997,
+                "targetStockpile": 320,
+                "logisticsEfficiency": 0.7228708458127457,
+                "wastageRate": 0.06380620166284148
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 1382400
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.4227210353947592,
+                "supplyDisruption": 0.538168947799154,
+                "demandPressure": 0.0373522757476244,
+                "reliefEffort": 0.05801579821548176,
+                "blockadeSeverity": 0.3936088274595678,
+                "policyRationing": 0.31982874390071925,
+                "infrastructureDamage": 0.14672132639384836,
+                "elapsedDays": 16
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 17,
+        "timestamp": 1382400,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 47.61490875278896,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.1781706838170337,
+                "rationingEffectiveness": 0.32210413426226253,
+                "substitutionRate": 0.1228175965562322,
+                "incomeShock": 0.23535227867948763
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 125.81106652263504,
+                "inflationRate": 0.006434894045453663,
+                "volatility": 0.010174113581460505,
+                "priceMomentum": 0.025739576181814654,
+                "scarcityIndex": 0.1376170993193217,
+                "affordabilityIndex": 0.9269559755627055
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 59.01596644320233,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 14.605655531854943,
+                "targetStockpile": 320,
+                "logisticsEfficiency": 0.7144498033942966,
+                "wastageRate": 0.06505039400402149
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 1468800
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.4345051044033678,
+                "supplyDisruption": 0.5497734344820183,
+                "demandPressure": 0.029968911523828367,
+                "reliefEffort": 0.062009478929289055,
+                "blockadeSeverity": 0.40646426420159765,
+                "policyRationing": 0.32685346565266343,
+                "infrastructureDamage": 0.15479133369262282,
+                "elapsedDays": 17
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 18,
+        "timestamp": 1468800,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 44.28320586315843,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.17433735005179496,
+                "rationingEffectiveness": 0.3290843105360853,
+                "substitutionRate": 0.12694022677149006,
+                "incomeShock": 0.24299822013467182
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 126.20299581544448,
+                "inflationRate": 0.0031152211299227297,
+                "volatility": 0.0073505566008453945,
+                "priceMomentum": 0.012460884519690919,
+                "scarcityIndex": 0.10816183718946375,
+                "affordabilityIndex": 0.9856348205249935
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 58.212924449447705,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 24.67607639272314,
+                "targetStockpile": 320,
+                "logisticsEfficiency": 0.7061048585405404,
+                "wastageRate": 0.0662962351045
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 1555200
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.4459982180802024,
+                "supplyDisruption": 0.5611469564035749,
+                "demandPressure": 0.02273931299240441,
+                "reliefEffort": 0.06600568735757344,
+                "blockadeSeverity": 0.4189574954747895,
+                "policyRationing": 0.3337377613853005,
+                "infrastructureDamage": 0.16305124118065115,
+                "elapsedDays": 18
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 19,
+        "timestamp": 1555200,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 41.71328234526337,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.17061401197639417,
+                "rationingEffectiveness": 0.3359250637280254,
+                "substitutionRate": 0.1310230864485211,
+                "incomeShock": 0.25043795646005573
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 126.16701061923999,
+                "inflationRate": -0.00028513741668310076,
+                "volatility": 0.004524388927180477,
+                "priceMomentum": -0.001140549666732403,
+                "scarcityIndex": 0.082897738124659,
+                "affordabilityIndex": 1.0409779920602331
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 57.43026361885849,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 36.513997807331776,
+                "targetStockpile": 320,
+                "logisticsEfficiency": 0.6978334663360226,
+                "wastageRate": 0.0675438281936199
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 1641600
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.4572075635167725,
+                "supplyDisruption": 0.5722958034295127,
+                "demandPressure": 0.015659316264350947,
+                "reliefEffort": 0.07000341241454407,
+                "blockadeSeverity": 0.43109877595365775,
+                "policyRationing": 0.3404855658559855,
+                "infrastructureDamage": 0.17149535832684115,
+                "elapsedDays": 19
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 20,
+        "timestamp": 1641600,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40.685312938105355,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.16699752754154365,
+                "rationingEffectiveness": 0.3426303587618658,
+                "substitutionRate": 0.13506632801298907,
+                "incomeShock": 0.2576786384919748
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 125.77490614353769,
+                "inflationRate": -0.003107820925436878,
+                "volatility": 0.0039577617264830375,
+                "priceMomentum": -0.012431283701747512,
+                "scarcityIndex": 0.07056235566409452,
+                "affordabilityIndex": 1.0668867295064124
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 56.6672579968779,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 48.597621121852626,
+                "targetStockpile": 320,
+                "logisticsEfficiency": 0.6896334471372937,
+                "wastageRate": 0.06879319526041781
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 1728000
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.46814014832740297,
+                "supplyDisruption": 0.583225918319755,
+                "demandPressure": 0.008724855044109737,
+                "reliefEffort": 0.07400204744872645,
+                "blockadeSeverity": 0.44289804527411314,
+                "policyRationing": 0.34710055545109275,
+                "infrastructureDamage": 0.18011814081890196,
+                "elapsedDays": 20
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 21,
+        "timestamp": 1728000,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40.27412517524215,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.1634848406196284,
+                "rationingEffectiveness": 0.34920387408095477,
+                "substitutionRate": 0.1390703886168823,
+                "incomeShock": 0.2647267128558678
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 125.088323831283,
+                "inflationRate": -0.00545881792566107,
+                "volatility": 0.004558184206154251,
+                "priceMomentum": -0.02183527170264428,
+                "scarcityIndex": 0.0638150021527755,
+                "affordabilityIndex": 1.0805468473182822
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 55.92326068210315,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 60.32965045844179,
+                "targetStockpile": 320,
+                "logisticsEfficiency": 0.6815028582225363,
+                "wastageRate": 0.07004430933558578
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 1814400
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.4788028062968988,
+                "supplyDisruption": 0.593942978551634,
+                "demandPressure": 0.0019319650966498868,
+                "reliefEffort": 0.07800122846923586,
+                "blockadeSeverity": 0.4543649500041473,
+                "policyRationing": 0.3535862176270141,
+                "infrastructureDamage": 0.1889141846601476,
+                "elapsedDays": 21
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 22,
+        "timestamp": 1814400,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40.10965007009686,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.1600729808361418,
+                "rationingEffectiveness": 0.35564908528720873,
+                "substitutionRate": 0.14303588771740305,
+                "incomeShock": 0.27158809460933697
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 124.15096426349116,
+                "inflationRate": -0.007493581647605635,
+                "volatility": 0.005732343182734805,
+                "priceMomentum": -0.02997432659042254,
+                "scarcityIndex": 0.05970975834374814,
+                "affordabilityIndex": 1.090010474730151
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 55.19767813417647,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 71.48224335446795,
+                "targetStockpile": 320,
+                "logisticsEfficiency": 0.6734399176501921,
+                "wastageRate": 0.07129711431859607
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 1900800
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.4892022021589551,
+                "supplyDisruption": 0.6044524463570012,
+                "demandPressure": -0.00472321401512887,
+                "reliefEffort": 0.08200073708154153,
+                "blockadeSeverity": 0.4655088584471895,
+                "policyRationing": 0.3599458927580447,
+                "infrastructureDamage": 0.19787822133251126,
+                "elapsedDays": 22
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 23,
+        "timestamp": 1900800,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40.04386002803875,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.15675906204311255,
+                "rationingEffectiveness": 0.36196931400410715,
+                "substitutionRate": 0.14696355705807154,
+                "incomeShock": 0.2782682893843946
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 122.99517303338573,
+                "inflationRate": -0.009309563054640896,
+                "volatility": 0.007163231131497241,
+                "priceMomentum": -0.03723825221856358,
+                "scarcityIndex": 0.05705883410499368,
+                "affordabilityIndex": 1.0986502230839985
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 54.48995501412751,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 81.97500834969208,
+                "targetStockpile": 320,
+                "logisticsEfficiency": 0.6654429587053982,
+                "wastageRate": 0.07255153706476102
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 1987200
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.49934483596466067,
+                "supplyDisruption": 0.6147595999713318,
+                "demandPressure": -0.011244438955505233,
+                "reliefEffort": 0.08600044224892492,
+                "blockadeSeverity": 0.4763388717542574,
+                "policyRationing": 0.3661827998153728,
+                "infrastructureDamage": 0.20700511362931523,
+                "elapsedDays": 23
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 24,
+        "timestamp": 1987200,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40.017544011215506,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.1535402802873807,
+                "rationingEffectiveness": 0.3681677571067313,
+                "substitutionRate": 0.1508541936057316,
+                "incomeShock": 0.2847724800092947
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 121.64747472428398,
+                "inflationRate": -0.010957326827256197,
+                "volatility": 0.008680869409800823,
+                "priceMomentum": -0.04382930730902479,
+                "scarcityIndex": 0.055377925351853985,
+                "affordabilityIndex": 1.1077883508847317
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 53.79956511502712,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 91.78621833569446,
+                "targetStockpile": 320,
+                "logisticsEfficiency": 0.6575104023402817,
+                "wastageRate": 0.07380749471337515
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 2073600
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.5092370472263731,
+                "supplyDisruption": 0.6248695537234973,
+                "demandPressure": -0.017635363736928852,
+                "reliefEffort": 0.09000026534935496,
+                "blockadeSeverity": 0.4868638330859915,
+                "policyRationing": 0.3723000525084807,
+                "infrastructureDamage": 0.21628985192034914,
+                "elapsedDays": 24
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 25,
+        "timestamp": 2073600,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40.00701760448621,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.15041391161587245,
+                "rationingEffectiveness": 0.3742475047031124,
+                "substitutionRate": 0.15470862837744553,
+                "incomeShock": 0.2911055881696812
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 120.13157148888966,
+                "inflationRate": -0.012461444340132287,
+                "volatility": 0.010193099381933409,
+                "priceMomentum": -0.04984577736052915,
+                "scarcityIndex": 0.05446436089519027,
+                "affordabilityIndex": 1.1178991817511548
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 53.12600582997108,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 100.91730829331266,
+                "targetStockpile": 320,
+                "logisticsEfficiency": 0.6496407402408422,
+                "wastageRate": 0.07506489911230808
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 2160000
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.5188850189125733,
+                "supplyDisruption": 0.6347872714638627,
+                "demandPressure": -0.023899541498939265,
+                "reliefEffort": 0.09400015920961298,
+                "blockadeSeverity": 0.4970923356980622,
+                "policyRationing": 0.37830066976736654,
+                "infrastructureDamage": 0.2257275507065045,
+                "elapsedDays": 25
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 26,
+        "timestamp": 2160000,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40.00280704179448,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.14737730985445865,
+                "rationingEffectiveness": 0.38021155158936654,
+                "substitutionRate": 0.15852770607324518,
+                "incomeShock": 0.2972723185371606
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 118.46968719709498,
+                "inflationRate": -0.013833867909972158,
+                "volatility": 0.011649406793148909,
+                "priceMomentum": -0.05533547163988863,
+                "scarcityIndex": 0.054228360350745505,
+                "affordabilityIndex": 1.129113617296871
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 52.468794684834734,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 109.37868551745456,
+                "targetStockpile": 320,
+                "logisticsEfficiency": 0.6418325241940429,
+                "wastageRate": 0.07632365948089578
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 2246400
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.5282947813254025,
+                "supplyDisruption": 0.6445175759920461,
+                "demandPressure": -0.03004042666545405,
+                "reliefEffort": 0.09800009552576779,
+                "blockadeSeverity": 0.5070327303895534,
+                "policyRationing": 0.38418758284686927,
+                "infrastructureDamage": 0.23531344537775487,
+                "elapsedDays": 26
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 27,
+        "timestamp": 2246400,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40.001122816717796,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.14442790441426262,
+                "rationingEffectiveness": 0.3860628048762696,
+                "substitutionRate": 0.16231227195514383,
+                "incomeShock": 0.3032771905831545
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 116.68306750936443,
+                "inflationRate": -0.015080817127154119,
+                "volatility": 0.013021970926750993,
+                "priceMomentum": -0.060323268508616475,
+                "scarcityIndex": 0.054625533706071275,
+                "affordabilityIndex": 1.1414239710500726
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 51.82746708337095,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 117.18406395496544,
+                "targetStockpile": 320,
+                "logisticsEfficiency": 0.6340843592057617,
+                "wastageRate": 0.0775836840082123
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 2332800
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.5374722158749904,
+                "supplyDisruption": 0.6540651560638353,
+                "demandPressure": -0.03606137730540729,
+                "reliefEffort": 0.10200005731546068,
+                "blockadeSeverity": 0.516693132536908,
+                "policyRationing": 0.3899636404008716,
+                "infrastructureDamage": 0.24504288912210007,
+                "elapsedDays": 27
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 28,
+        "timestamp": 2332800,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40.000449126687116,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.1415631981460164,
+                "rationingEffectiveness": 0.3918040893457777,
+                "substitutionRate": 0.16606316352999556,
+                "incomeShock": 0.30912456173981356
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 114.79210102925587,
+                "inflationRate": -0.01620600589675787,
+                "volatility": 0.014295584914753742,
+                "priceMomentum": -0.06482402358703147,
+                "scarcityIndex": 0.05562987603103055,
+                "affordabilityIndex": 1.1547658784541437
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 51.201574769440555,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 124.34820753774838,
+                "targetStockpile": 320,
+                "logisticsEfficiency": 0.6263948988628392,
+                "wastageRate": 0.07884488080979818
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 2419200
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.5464230587576042,
+                "supplyDisruption": 0.6634345719171151,
+                "demandPressure": -0.04196565758875895,
+                "reliefEffort": 0.10600003438927641,
+                "blockadeSeverity": 0.5260814288274265,
+                "policyRationing": 0.3956316123254498,
+                "infrastructureDamage": 0.2549113499533594,
+                "elapsedDays": 28
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 29,
+        "timestamp": 2419200,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40.00017965067485,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.13878076524970484,
+                "rationingEffectiveness": 0.3974381514460012,
+                "substitutionRate": 0.16978120538624852,
+                "incomeShock": 0.3148186444761531
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 112.81629033938859,
+                "inflationRate": -0.017212078811622594,
+                "volatility": 0.015462182473501281,
+                "priceMomentum": -0.06884831524649038,
+                "scarcityIndex": 0.05722295945422157,
+                "affordabilityIndex": 1.1690506308754676
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 50.590684717658064,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 130.88603660550487,
+                "targetStockpile": 320,
+                "logisticsEfficiency": 0.6187628420462656,
+                "wastageRate": 0.0801071584985323
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 2505600
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.5551529045417894,
+                "supplyDisruption": 0.6726302598774173,
+                "demandPressure": -0.047756440272118617,
+                "reliefEffort": 0.11000002063356584,
+                "blockadeSeverity": 0.5352052837519425,
+                "policyRationing": 0.4011941928461502,
+                "infrastructureDamage": 0.2649144078378595,
+                "elapsedDays": 29
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 30,
+        "timestamp": 2505600,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40.00007186026994,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.13607824924138914,
+                "rationingEffectiveness": 0.40296766245804677,
+                "substitutionRate": 0.17346720608370628,
+                "incomeShock": 0.3203635190898615
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 110.77417669401628,
+                "inflationRate": -0.01810123023216736,
+                "volatility": 0.016517801576967715,
+                "priceMomentum": -0.07240492092866944,
+                "scarcityIndex": 0.05938960367841725,
+                "affordabilityIndex": 1.1841776560965538
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 49.99437828350591,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 136.81227914402476,
+                "targetStockpile": 320,
+                "logisticsEfficiency": 0.6111869304650094,
+                "wastageRate": 0.08137042652369988
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 2592000
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.5636672096654897,
+                "supplyDisruption": 0.6816565363783305,
+                "demandPressure": -0.053436809174478225,
+                "reliefEffort": 0.1140000123801395,
+                "blockadeSeverity": 0.5440721458890387,
+                "policyRationing": 0.40665400313274386,
+                "infrastructureDamage": 0.2750477519073679,
+                "elapsedDays": 30
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 31,
+        "timestamp": 2592000,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40.00002874410798,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.13345336097697824,
+                "rationingEffectiveness": 0.4100752211497651,
+                "substitutionRate": 0.17745795636914977,
+                "incomeShock": 0.32576314347675905
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 108.67695054432716,
+                "inflationRate": -0.018932446281971882,
+                "volatility": 0.017483659458969382,
+                "priceMomentum": -0.07572978512788753,
+                "scarcityIndex": 0.062039249042041944,
+                "affordabilityIndex": 1.200108794752319
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 49.41225051366622,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 142.14133958602204,
+                "targetStockpile": 319.85619219306705,
+                "logisticsEfficiency": 0.6036659466945777,
+                "wastageRate": 0.08263459537087155
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 2678400
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.5719712958466303,
+                "supplyDisruption": 0.6905176015978274,
+                "demandPressure": -0.06040976161973313,
+                "reliefEffort": 0.1180000074280837,
+                "blockadeSeverity": 0.5526892539994641,
+                "policyRationing": 0.41481359361091064,
+                "infrastructureDamage": 0.2853071777500197,
+                "elapsedDays": 31
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 32,
+        "timestamp": 2678400,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40.00001149764319,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.13090387673189027,
+                "rationingEffectiveness": 0.41825935610342374,
+                "substitutionRate": 0.18172062824156346,
+                "incomeShock": 0.33102136076240735
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 106.53334338504806,
+                "inflationRate": -0.01972457957775294,
+                "volatility": 0.018380027506482804,
+                "priceMomentum": -0.07889831831101175,
+                "scarcityIndex": 0.06495238825245174,
+                "affordabilityIndex": 1.2168250955474735
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 48.84390955800015,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 146.88725431115498,
+                "targetStockpile": 319.21432719442885,
+                "logisticsEfficiency": 0.5961987125317352,
+                "wastageRate": 0.08389957667819001
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 2764800
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.580070353409419,
+                "supplyDisruption": 0.6992175428315627,
+                "demandPressure": -0.0676982108325718,
+                "reliefEffort": 0.12200000445685022,
+                "blockadeSeverity": 0.5610636429424938,
+                "policyRationing": 0.42371544607252953,
+                "infrastructureDamage": 0.2956885847736396,
+                "elapsedDays": 32
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 33,
+        "timestamp": 2764800,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40.00000459905728,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.12842763633524004,
+                "rationingEffectiveness": 0.42696812782888155,
+                "substitutionRate": 0.18616525455726252,
+                "incomeShock": 0.33614190541585987
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 104.35276388481665,
+                "inflationRate": -0.020468516531486614,
+                "volatility": 0.019215423116484328,
+                "priceMomentum": -0.08187406612594646,
+                "scarcityIndex": 0.06814520833934189,
+                "affordabilityIndex": 1.2342938195462412
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 48.28897614842111,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 151.06368152645535,
+                "targetStockpile": 318.1757173083807,
+                "logisticsEfficiency": 0.5887840875524961,
+                "wastageRate": 0.08516528330240691
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 2851200
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.5879694445284889,
+                "supplyDisruption": 0.7077603376764157,
+                "demandPressure": -0.07501098828033745,
+                "reliefEffort": 0.12600000267411013,
+                "blockadeSeverity": 0.5692021494224453,
+                "policyRationing": 0.43277397564585346,
+                "infrastructureDamage": 0.30618797363746825,
+                "elapsedDays": 33
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 34,
+        "timestamp": 2851200,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40.00000183962291,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.12602254135709406,
+                "rationingEffectiveness": 0.43587633072919246,
+                "substitutionRate": 0.1907169689747787,
+                "incomeShock": 0.3411284082802395
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 102.14537698848011,
+                "inflationRate": -0.021153123445518226,
+                "volatility": 0.01999050324809789,
+                "priceMomentum": -0.0846124937820729,
+                "scarcityIndex": 0.07163742057370993,
+                "affordabilityIndex": 1.2524650690055406
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 47.747083123891116,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 154.68390461939345,
+                "targetStockpile": 316.82634375938835,
+                "logisticsEfficiency": 0.5814209678055879,
+                "wastageRate": 0.08643162935465612
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 2937600
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.5956735063929303,
+                "supplyDisruption": 0.7161498570689928,
+                "demandPressure": -0.08226264595711177,
+                "reliefEffort": 0.1300000016044661,
+                "blockadeSeverity": 0.5771114175717323,
+                "policyRationing": 0.44181513266273303,
+                "infrastructureDamage": 0.3168014437492822,
+                "elapsedDays": 34
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 35,
+        "timestamp": 2937600,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40.00000073584917,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.12368655334731993,
+                "rationingEffectiveness": 0.44482350295905854,
+                "substitutionRate": 0.19532477571087944,
+                "incomeShock": 0.34598440082503806
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 99.9216848768633,
+                "inflationRate": -0.02176987522271915,
+                "volatility": 0.020702252037946393,
+                "priceMomentum": -0.0870795008908766,
+                "scarcityIndex": 0.0754506677176916,
+                "affordabilityIndex": 1.2712738759185473
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 47.21787498900227,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 157.7608406359965,
+                "targetStockpile": 315.23869545090724,
+                "logisticsEfficiency": 0.5741082846004593,
+                "wastageRate": 0.08769853021794258
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 3024000
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.6031873542921985,
+                "supplyDisruption": 0.7243898682067047,
+                "demandPressure": -0.08942939860845833,
+                "reliefEffort": 0.13400000096267964,
+                "blockadeSeverity": 0.5847979043758613,
+                "policyRationing": 0.4507882844456359,
+                "infrastructureDamage": 0.32752519082549936,
+                "elapsedDays": 35
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 36,
+        "timestamp": 3024000,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40.00000029433967,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.12141769212457819,
+                "rationingEffectiveness": 0.4537372698007708,
+                "substitutionRate": 0.19995643926547868,
+                "incomeShock": 0.35071331883413015
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 97.69217958966402,
+                "inflationRate": -0.022312526954952432,
+                "volatility": 0.02134636200474881,
+                "priceMomentum": -0.08925010781980973,
+                "scarcityIndex": 0.07960732519257191,
+                "affordabilityIndex": 1.2906419963380518
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 46.70100749846834,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 160.30705055786478,
+                "targetStockpile": 313.47346738117284,
+                "logisticsEfficiency": 0.5668450033649641,
+                "wastageRate": 0.08896590255352908
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 3110400
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.6105156846258277,
+                "supplyDisruption": 0.7324840373687813,
+                "demandPressure": -0.09650590789657182,
+                "reliefEffort": 0.13800000057760778,
+                "blockadeSeverity": 0.5922678849452214,
+                "policyRationing": 0.4596797810285789,
+                "infrastructureDamage": 0.33835550451223984,
+                "elapsedDays": 36
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 37,
+        "timestamp": 3110400,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40.000000117735866,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.11921403411403661,
+                "rationingEffectiveness": 0.4625871235328579,
+                "substitutionRate": 0.20459230675111006,
+                "incomeShock": 0.3553185056798324
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 95.4671207489132,
+                "inflationRate": -0.02277622272424183,
+                "volatility": 0.021918306292546017,
+                "priceMomentum": -0.09110489089696731,
+                "scarcityIndex": 0.08412959847943631,
+                "affordabilityIndex": 1.3104787178735307
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 46.19614726273186,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 162.33475005877756,
+                "targetStockpile": 311.58111260091516,
+                "logisticsEfficiency": 0.5596301225574523,
+                "wastageRate": 0.0902336643005307
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 3196800
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.6176630778388341,
+                "supplyDisruption": 0.7404359326484341,
+                "demandPressure": -0.10349231910634943,
+                "reliefEffort": 0.14200000034656465,
+                "blockadeSeverity": 0.5995274576381833,
+                "policyRationing": 0.468487026020916,
+                "infrastructureDamage": 0.34928876606555087,
+                "elapsedDays": 37
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 38,
+        "timestamp": 3196800,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40.000000047094346,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.11707371073242374,
+                "rationingEffectiveness": 0.47136126880103013,
+                "substitutionRate": 0.2092206679698312,
+                "incomeShock": 0.35980321528875486
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 93.256397981274,
+                "inflationRate": -0.023156902086254316,
+                "volatility": 0.02241374461002934,
+                "priceMomentum": -0.09262760834501726,
+                "scarcityIndex": 0.08903885193332806,
+                "affordabilityIndex": 1.3306810237817999
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 45.70297137160769,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 163.85582022315572,
+                "targetStockpile": 309.60324655696814,
+                "logisticsEfficiency": 0.5524626726237443,
+                "wastageRate": 0.09150173467130725
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 3283200
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.6246340012846431,
+                "supplyDisruption": 0.748249026603659,
+                "demandPressure": -0.1103903735733463,
+                "reliefEffort": 0.1460000002079388,
+                "blockadeSeverity": 0.6065825490397954,
+                "policyRationing": 0.4772106989798116,
+                "infrastructureDamage": 0.36032144608916433,
+                "elapsedDays": 38
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 39,
+        "timestamp": 3283200,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40.00000001883774,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.11499490681907644,
+                "rationingEffectiveness": 0.48005596144242596,
+                "substitutionRate": 0.21383469159125415,
+                "incomeShock": 0.36417061487396274
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 91.06944173979022,
+                "inflationRate": -0.023451004851408976,
+                "volatility": 0.022828648706581193,
+                "priceMomentum": -0.0938040194056359,
+                "scarcityIndex": 0.09435512271610778,
+                "affordabilityIndex": 1.3511334831924677
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 45.22116703390893,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 164.88181802844997,
+                "targetStockpile": 307.5739065329932,
+                "logisticsEfficiency": 0.5453417149929245,
+                "wastageRate": 0.09277003414421398
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 3369600
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.6314328120173313,
+                "supplyDisruption": 0.755926698831936,
+                "demandPressure": -0.11720224378882783,
+                "reliefEffort": 0.15000000012476328,
+                "blockadeSeverity": 0.6134389188001946,
+                "policyRationing": 0.48585242320335653,
+                "infrastructureDamage": 0.37145010232826337,
+                "elapsedDays": 39
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 40,
+        "timestamp": 3369600,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40.00000000753509,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.11297585911167395,
+                "rationingEffectiveness": 0.4886708248486988,
+                "substitutionRate": 0.21843050302406977,
+                "incomeShock": 0.3684237874860943
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 88.915162208538,
+                "inflationRate": -0.023655350138277586,
+                "volatility": 0.02315932927925975,
+                "priceMomentum": -0.09462140055311034,
+                "scarcityIndex": 0.10009678455117593,
+                "affordabilityIndex": 1.3717081029925198
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 44.75043123161983,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 165.42398652082093,
+                "targetStockpile": 305.5206718070915,
+                "logisticsEfficiency": 0.5382663411079558,
+                "wastageRate": 0.09403848445465454
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 3456000
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.6380637595149267,
+                "supplyDisruption": 0.7634722384727153,
+                "demandPressure": -0.12393018526946604,
+                "reliefEffort": 0.15400000007485798,
+                "blockadeSeverity": 0.6201021643367076,
+                "policyRationing": 0.49441406711954733,
+                "infrastructureDamage": 0.3826713775178133,
+                "elapsedDays": 40
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 41,
+        "timestamp": 3456000,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40.00000000301404,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.11101485476538736,
+                "rationingEffectiveness": 0.4972068513744652,
+                "substitutionRate": 0.22300600611042196,
+                "incomeShock": 0.3725657344207526
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 86.80190688535941,
+                "inflationRate": -0.023767097429595315,
+                "volatility": 0.02340243653939398,
+                "priceMomentum": -0.09506838971838126,
+                "scarcityIndex": 0.10628033293916347,
+                "affordabilityIndex": 1.3922642716921547
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 44.2904703875565,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 165.4932646639024,
+                "targetStockpile": 303.46565223046343,
+                "logisticsEfficiency": 0.5312356714883771,
+                "wastageRate": 0.09530700858501026
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 3542400
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.644530988335471,
+                "supplyDisruption": 0.7708888466407428,
+                "demandPressure": -0.1305764334189482,
+                "reliefEffort": 0.1580000000449148,
+                "blockadeSeverity": 0.6265777254034952,
+                "policyRationing": 0.5028975357249761,
+                "infrastructureDamage": 0.39398199728407357,
+                "elapsedDays": 41
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 42,
+        "timestamp": 3542400,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40.00000000120562,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.10911022991421035,
+                "rationingEffectiveness": 0.5056655659560555,
+                "substitutionRate": 0.22756016875289684,
+                "incomeShock": 0.3765993775087504
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 84.73743297135744,
+                "inflationRate": -0.02378373918361686,
+                "volatility": 0.023554957597083134,
+                "priceMomentum": -0.09513495673446744,
+                "scarcityIndex": 0.11292026818646629,
+                "affordabilityIndex": 1.4126488657449745
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 43.841000045689384,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 165.1002968601964,
+                "targetStockpile": 301.4263543219503,
+                "logisticsEfficiency": 0.5242488548231049,
+                "wastageRate": 0.09657553075379874
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 3628800
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.6508385407075031,
+                "supplyDisruption": 0.7781796387927528,
+                "demandPressure": -0.1371431738506871,
+                "reliefEffort": 0.1620000000269489,
+                "blockadeSeverity": 0.6328708885324769,
+                "policyRationing": 0.511304709010449,
+                "infrastructureDamage": 0.4053787680979542,
+                "elapsedDays": 42
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 43,
+        "timestamp": 3628800,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40.000000000482245,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.1072603682732709,
+                "rationingEffectiveness": 0.5140486810557948,
+                "substitutionRate": 0.2320925921896465,
+                "incomeShock": 0.3805275613082538
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 82.7288930127231,
+                "inflationRate": -0.023703101311946192,
+                "volatility": 0.023614215083028356,
+                "priceMomentum": -0.09481240524778477,
+                "scarcityIndex": 0.12002905609179945,
+                "affordabilityIndex": 1.4326965588559502
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 43.40174456344865,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 164.2554421521921,
+                "targetStockpile": 299.4164347927756,
+                "logisticsEfficiency": 0.5173050670918239,
+                "wastageRate": 0.09784397640428127
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 3715200
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.6569903590565839,
+                "supplyDisruption": 0.7853476470297294,
+                "demandPressure": -0.1436325347133859,
+                "reliefEffort": 0.16600000001616935,
+                "blockadeSeverity": 0.6389867913491635,
+                "policyRationing": 0.5196374244556211,
+                "infrastructureDamage": 0.41685857527892417,
+                "elapsedDays": 43
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 44,
+        "timestamp": 3715200,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40.0000000001929,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.10546369978095882,
+                "rationingEffectiveness": 0.5223579560531818,
+                "substitutionRate": 0.236603252041901,
+                "incomeShock": 0.3843530552125883
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 80.78283298211485,
+                "inflationRate": -0.023523341842721902,
+                "volatility": 0.023577865786905773,
+                "priceMomentum": -0.09409336737088761,
+                "scarcityIndex": 0.12761714895962833,
+                "affordabilityIndex": 1.4522303605881723
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 42.97243681542969,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 162.9687831129962,
+                "targetStockpile": 297.44635177600753,
+                "logisticsEfficiency": 0.5104035107137445,
+                "wastageRate": 0.0991122721926588
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 3801600
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.6629902884694402,
+                "supplyDisruption": 0.7923958223367148,
+                "demandPressure": -0.1500465855829651,
+                "reliefEffort": 0.1700000000097016,
+                "blockadeSeverity": 0.6449304267669249,
+                "policyRationing": 0.5278974727181065,
+                "infrastructureDamage": 0.42841838104821595,
+                "elapsedDays": 44
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 45,
+        "timestamp": 3801600,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40.000000000077165,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.10371869927973625,
+                "rationingEffectiveness": 0.5305951407745558,
+                "substitutionRate": 0.24109234289696144,
+                "incomeShock": 0.3880785554837587
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 78.90520206392497,
+                "inflationRate": -0.02324294468115005,
+                "volatility": 0.023443897344603483,
+                "priceMomentum": -0.0929717787246002,
+                "scarcityIndex": 0.13569305205599516,
+                "affordabilityIndex": 1.4710624035304831
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 42.55281790798073,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 161.25013443704515,
+                "targetStockpile": 295.52392403606314,
+                "logisticsEfficiency": 0.5035434137226835,
+                "wastageRate": 0.1003803459759478
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 3888000
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.6688420790972691,
+                "supplyDisruption": 0.7993270367619998,
+                "demandPressure": -0.15638733829086282,
+                "reliefEffort": 0.17400000000582097,
+                "blockadeSeverity": 0.650706647063115,
+                "policyRationing": 0.5360865972554719,
+                "infrastructureDamage": 0.44005522263010316,
+                "elapsedDays": 45
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 46,
+        "timestamp": 3888000,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40.000000000030866,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.10202388523453111,
+                "rationingEffectiveness": 0.538761953371237,
+                "substitutionRate": 0.24556018515115832,
+                "incomeShock": 0.391706687219129
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 77.10137326205773,
+                "inflationRate": -0.02286070822562336,
+                "volatility": 0.023210621697011435,
+                "priceMomentum": -0.09144283290249344,
+                "scarcityIndex": 0.14426342283596413,
+                "affordabilityIndex": 1.4889949939746665
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 42.142636904201325,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 159.10905124150793,
+                "targetStockpile": 293.65480816209356,
+                "logisticsEfficiency": 0.49672402896754697,
+                "wastageRate": 0.10164812679959812
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 3974400
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.6745493884997052,
+                "supplyDisruption": 0.8061440855374195,
+                "demandPressure": -0.16265674830064727,
+                "reliefEffort": 0.1780000000034926,
+                "blockadeSeverity": 0.6563201678403847,
+                "policyRationing": 0.5442064951023577,
+                "infrastructureDamage": 0.4517662104000623,
+                "elapsedDays": 46
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 47,
+        "timestamp": 3974400,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40.00000000001235,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.10037781848764399,
+                "rationingEffectiveness": 0.5468600721305528,
+                "substitutionRate": 0.2500071692475257,
+                "incomeShock": 0.39524000625686745
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 75.37617377533924,
+                "inflationRate": -0.022375729688429342,
+                "volatility": 0.022876664893578598,
+                "priceMomentum": -0.08950291875371737,
+                "scarcityIndex": 0.153333192312351,
+                "affordabilityIndex": 1.5058219373349333
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 41.74165055891467,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 156.5548370887446,
+                "targetStockpile": 291.84290327982507,
+                "logisticsEfficiency": 0.48994463333736876,
+                "wastageRate": 0.10291554488489711
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 4060800
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.6801157839309138,
+                "supplyDisruption": 0.8128496891414031,
+                "demandPressure": -0.16885671621743803,
+                "reliefEffort": 0.18200000000209554,
+                "blockadeSeverity": 0.661775571876416,
+                "policyRationing": 0.5522588179700966,
+                "infrastructureDamage": 0.46354852607865965,
+                "elapsedDays": 47
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 48,
+        "timestamp": 4060800,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40.000000000004945,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.0987791010491302,
+                "rationingEffectiveness": 0.5548911329040394,
+                "substitutionRate": 0.25443372235913053,
+                "incomeShock": 0.3986810010244689
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 73.73392396098245,
+                "inflationRate": -0.02178738628006729,
+                "volatility": 0.022440953448174074,
+                "priceMomentum": -0.08714954512026916,
+                "scarcityIndex": 0.1629056998171487,
+                "affordabilityIndex": 1.5213301454456714
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 41.349623063204945,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 153.59655173984459,
+                "targetStockpile": 290.09069221170853,
+                "logisticsEfficiency": 0.4832045270101229,
+                "wastageRate": 0.1041825316161932
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 4147200
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.6855447445692406,
+                "supplyDisruption": 0.8194464953063527,
+                "demandPressure": -0.17498908930637042,
+                "reliefEffort": 0.18600000000125733,
+                "blockadeSeverity": 0.6670773128652188,
+                "policyRationing": 0.5602451734196972,
+                "infrastructureDamage": 0.4753994209700319,
+                "elapsedDays": 48
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 49,
+        "timestamp": 4147200,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40.000000000001975,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.09722637492164743,
+                "rationingEffectiveness": 0.5628567287820755,
+                "substitutionRate": 0.25884028853972113,
+                "incomeShock": 0.4020320943337471
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 72.17848365332934,
+                "inflationRate": -0.021095314396616202,
+                "volatility": 0.021902697827550926,
+                "priceMomentum": -0.08438125758646481,
+                "scarcityIndex": 0.17298283412393417,
+                "affordabilityIndex": 1.5353015279783555
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 40.9663257981332,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 150.24301864889947,
+                "targetStockpile": 288.3995273261283,
+                "logisticsEfficiency": 0.4765030327245611,
+                "wastageRate": 0.10544901952796507
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 4233600
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.6908396636918125,
+                "supplyDisruption": 0.825937080971882,
+                "demandPressure": -0.1810556629838394,
+                "reliefEffort": 0.1900000000007544,
+                "blockadeSeverity": 0.6722297190530471,
+                "policyRationing": 0.5681671260340996,
+                "infrastructureDamage": 0.48731621424386057,
+                "elapsedDays": 49
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 50,
+        "timestamp": 4233600,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40.000000000000796,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.0957183209587887,
+                "rationingEffectiveness": 0.5707584106536855,
+                "substitutionRate": 0.2632273169520943,
+                "incomeShock": 0.40529564512503735
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 70.71330462263602,
+                "inflationRate": -0.020299387802749144,
+                "volatility": 0.021261373817630214,
+                "priceMomentum": -0.08119755121099657,
+                "scarcityIndex": 0.1835651754391903,
+                "affordabilityIndex": 1.5475151643821388
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 40.59153709726549,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 146.5028322072957,
+                "targetStockpile": 286.76986858382793,
+                "logisticsEfficiency": 0.4698394950743678,
+                "wastageRate": 0.10671494229175826
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 4320000
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.6960038507954451,
+                "supplyDisruption": 0.8323239541853863,
+                "demandPressure": -0.18705818227148457,
+                "reliefEffort": 0.19400000000045264,
+                "blockadeSeverity": 0.6772369967719021,
+                "policyRationing": 0.5760261985680921,
+                "infrastructureDamage": 0.4992962912597649,
+                "elapsedDays": 50
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 51,
+        "timestamp": 4320000,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40.00000000000032,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.0942536577559478,
+                "rationingEffectiveness": 0.5787803377034777,
+                "substitutionRate": 0.2673117848597116,
+                "incomeShock": 0.4084739501628837
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 69.34681771804334,
+                "inflationRate": -0.01932432534280473,
+                "volatility": 0.02048655442770002,
+                "priceMomentum": -0.07729730137121892,
+                "scarcityIndex": 0.1952222307853368,
+                "affordabilityIndex": 1.5563183710488713
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 40.185129131067065,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 142.34798115227824,
+                "targetStockpile": 285.08039784532264,
+                "logisticsEfficiency": 0.4628328222239475,
+                "wastageRate": 0.1079996575830084
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 4406400
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.7010405336651869,
+                "supplyDisruption": 0.8393343559513771,
+                "demandPressure": -0.19275055121071943,
+                "reliefEffort": 0.19640000000027158,
+                "blockadeSeverity": 0.6821032338735054,
+                "policyRationing": 0.5841282890700059,
+                "infrastructureDamage": 0.5113531019330658,
+                "elapsedDays": 51
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 52,
+        "timestamp": 4406400,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40.00000000000013,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.09283114057279165,
+                "rationingEffectiveness": 0.5869799837057973,
+                "substitutionRate": 0.2710486406407408,
+                "incomeShock": 0.41156924568514763
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 68.08702009921619,
+                "inflationRate": -0.018166624803885745,
+                "volatility": 0.01955858257817431,
+                "priceMomentum": -0.07266649921554298,
+                "scarcityIndex": 0.20793798589650958,
+                "affordabilityIndex": 1.5610503321910805
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 39.74181542088465,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 137.74548823217722,
+                "targetStockpile": 283.2837230523116,
+                "logisticsEfficiency": 0.4554777828451888,
+                "wastageRate": 0.10931328362776727
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 4492800
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.7059528603917895,
+                "supplyDisruption": 0.8466855420309729,
+                "demandPressure": -0.1982802054379439,
+                "reliefEffort": 0.19784000000016294,
+                "blockadeSeverity": 0.6868324030665487,
+                "policyRationing": 0.5924464143740104,
+                "infrastructureDamage": 0.5234937591409,
+                "elapsedDays": 52
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 53,
+        "timestamp": 4492800,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40.00000000000006,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.09144956028644036,
+                "rationingEffectiveness": 0.5934323480696407,
+                "substitutionRate": 0.2740980553019284,
+                "incomeShock": 0.4145837090072324
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 66.94435285135512,
+                "inflationRate": -0.016782453486670026,
+                "volatility": 0.018448130941572594,
+                "priceMomentum": -0.0671298139466801,
+                "scarcityIndex": 0.22163905100634018,
+                "affordabilityIndex": 1.5613878104546632
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 39.26848332540368,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 132.66865242892106,
+                "targetStockpile": 281.3718769206373,
+                "logisticsEfficiency": 0.4478604752985665,
+                "wastageRate": 0.11065665797814747
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 4579200
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.7107439013393666,
+                "supplyDisruption": 0.854208752692893,
+                "demandPressure": -0.20212072009574175,
+                "reliefEffort": 0.19870400000009777,
+                "blockadeSeverity": 0.6914283651599413,
+                "policyRationing": 0.5977339243122031,
+                "infrastructureDamage": 0.5357215971676864,
+                "elapsedDays": 53
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 54,
+        "timestamp": 4579200,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40.00000000000003,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.09010774237448096,
+                "rationingEffectiveness": 0.5969650456040528,
+                "substitutionRate": 0.2762217344564081,
+                "incomeShock": 0.41751946008293517
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 65.93058525280865,
+                "inflationRate": -0.015143437129005725,
+                "volatility": 0.017126253416545847,
+                "priceMomentum": -0.0605737485160229,
+                "scarcityIndex": 0.23625641277672205,
+                "affordabilityIndex": 1.5571002296768595
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 38.774529360564934,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 127.09943158342625,
+                "targetStockpile": 279.35646081983055,
+                "logisticsEfficiency": 0.44006812540996626,
+                "wastageRate": 0.1120258653732998
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 4665600
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.7154166510644722,
+                "supplyDisruption": 0.8618035952172729,
+                "demandPressure": -0.2039952484043343,
+                "reliefEffort": 0.19922240000005867,
+                "blockadeSeverity": 0.6958948722147058,
+                "policyRationing": 0.5993201772936609,
+                "infrastructureDamage": 0.5480377061889753,
+                "elapsedDays": 54
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 55,
+        "timestamp": 4665600,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40.000000000000014,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.08880454592696638,
+                "rationingEffectiveness": 0.5986636501544801,
+                "substitutionRate": 0.2776152550564237,
+                "incomeShock": 0.42037856302330506
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 65.0548566582949,
+                "inflationRate": -0.013282584875529382,
+                "volatility": 0.01558878600013926,
+                "priceMomentum": -0.05313033950211753,
+                "scarcityIndex": 0.25174240763222144,
+                "affordabilityIndex": 1.5480412432328412
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 38.26829084085266,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 121.02750047611138,
+                "targetStockpile": 277.2574332035815,
+                "logisticsEfficiency": 0.4321671715088766,
+                "wastageRate": 0.11341562042102435
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 4752000
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.7199740301877953,
+                "supplyDisruption": 0.8694106740335732,
+                "demandPressure": -0.20523463886277943,
+                "reliefEffort": 0.1995334400000352,
+                "blockadeSeverity": 0.7002355706070926,
+                "policyRationing": 0.5997960531880983,
+                "infrastructureDamage": 0.5604418523927309,
+                "elapsedDays": 55
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 56,
+        "timestamp": 4752000,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40.00000000000001,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.08753886268657415,
+                "rationingEffectiveness": 0.5994287496356497,
+                "substitutionRate": 0.27850582374863,
+                "incomeShock": 0.42316302757478236
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 64.3242392545741,
+                "inflationRate": -0.011230789540562877,
+                "volatility": 0.013845587416308706,
+                "priceMomentum": -0.04492315816225151,
+                "scarcityIndex": 0.268070729082222,
+                "affordabilityIndex": 1.5341146562837003
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 37.75612359484622,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 114.4484287302024,
+                "targetStockpile": 275.0969825669235,
+                "logisticsEfficiency": 0.42420299786912835,
+                "wastageRate": 0.11482098605448385
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 4838400
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.7244188872196433,
+                "supplyDisruption": 0.8769951694218273,
+                "demandPressure": -0.20624908330171388,
+                "reliefEffort": 0.19972006400002112,
+                "blockadeSeverity": 0.7044540040054169,
+                "policyRationing": 0.5999388159564295,
+                "infrastructureDamage": 0.5729330294971235,
+                "elapsedDays": 56
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 57,
+        "timestamp": 4838400,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.08630961611612437,
+                "rationingEffectiveness": 0.5997604867264172,
+                "substitutionRate": 0.27906769930361197,
+                "incomeShock": 0.4258748105578132
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 63.744918093524255,
+                "inflationRate": -0.00900626525495426,
+                "volatility": 0.011909858551766928,
+                "priceMomentum": -0.03602506101981704,
+                "scarcityIndex": 0.2852313707713125,
+                "affordabilityIndex": 1.515255162597719
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 37.242498245556746,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 107.36193378592483,
+                "targetStockpile": 272.89636271716256,
+                "logisticsEfficiency": 0.4162049276134837,
+                "wastageRate": 0.116237991374566
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 4924800
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.7287540003403536,
+                "supplyDisruption": 0.884536985335234,
+                "demandPressure": -0.2071684127676135,
+                "reliefEffort": 0.19983203840001268,
+                "blockadeSeverity": 0.7085536162630455,
+                "policyRationing": 0.5999816447869288,
+                "infrastructureDamage": 0.5855097891199305,
+                "elapsedDays": 57
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 58,
+        "timestamp": 4924800,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.08511576049267736,
+                "rationingEffectiveness": 0.5999008907522141,
+                "substitutionRate": 0.27941980340249817,
+                "incomeShock": 0.4285158172670699
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 63.3230944805249,
+                "inflationRate": -0.006617368499563652,
+                "volatility": 0.009792862530885618,
+                "priceMomentum": -0.026469473998254608,
+                "scarcityIndex": 0.3032251479668936,
+                "affordabilityIndex": 1.491425085688821
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 36.730398246514014,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 99.77049774130785,
+                "targetStockpile": 270.67442567025125,
+                "logisticsEfficiency": 0.40819127946937106,
+                "wastageRate": 0.11766369267562107
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 5011200
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.7329820791367464,
+                "supplyDisruption": 0.8920248386793507,
+                "demandPressure": -0.20803584564873126,
+                "reliefEffort": 0.19989922304000762,
+                "blockadeSeverity": 0.7125377542298972,
+                "policyRationing": 0.5999944934360786,
+                "infrastructureDamage": 0.5981704384722653,
+                "elapsedDays": 58
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 59,
+        "timestamp": 5011200,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.08395628002745545,
+                "rationingEffectiveness": 0.5999593651193798,
+                "substitutionRate": 0.27963959056999865,
+                "incomeShock": 0.4310879028343543
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 63.065577953068306,
+                "inflationRate": -0.004066707882316045,
+                "volatility": 0.007502400671457789,
+                "priceMomentum": -0.01626683152926418,
+                "scarcityIndex": 0.32205928740135575,
+                "affordabilityIndex": 1.4626202001817723
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 36.22173462708334,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 91.67836815436084,
+                "targetStockpile": 268.44710187382645,
+                "logisticsEfficiency": 0.4001732261082318,
+                "wastageRate": 0.11909601399389742
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 5097600
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.7371057662957051,
+                "supplyDisruption": 0.8994527134494804,
+                "demandPressure": -0.20886710790766339,
+                "reliefEffort": 0.1999395338240046,
+                "blockadeSeverity": 0.7164096704847508,
+                "policyRationing": 0.5999983480308235,
+                "infrastructureDamage": 0.6109131584599393,
+                "elapsedDays": 59
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 60,
+        "timestamp": 5097600,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.08283018801085329,
+                "rationingEffectiveness": 0.5999834486933001,
+                "substitutionRate": 0.2797764389299894,
+                "incomeShock": 0.43359287355521625
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 62.98018779889329,
+                "inflationRate": -0.0013539898776248572,
+                "volatility": 0.005043036353924616,
+                "priceMomentum": -0.005415959510499429,
+                "scarcityIndex": 0.3417443135705974,
+                "affordabilityIndex": 1.428878893021398
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 35.71768489236187,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 83.09087415638776,
+                "targetStockpile": 266.2273864511169,
+                "logisticsEfficiency": 0.3921574387478776,
+                "wastageRate": 0.12053353691060768
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 5184000
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.7411276392559415,
+                "supplyDisruption": 0.9068177337676281,
+                "demandPressure": -0.20966876680123117,
+                "reliefEffort": 0.19996372029440276,
+                "blockadeSeverity": 0.720172525990592,
+                "policyRationing": 0.599999504409247,
+                "infrastructureDamage": 0.6237360740421141,
+                "elapsedDays": 60
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 61,
+        "timestamp": 5184000,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.08173652598182293,
+                "rationingEffectiveness": 0.5999932902709845,
+                "substitutionRate": 0.28012815861872153,
+                "incomeShock": 0.43603248818028173
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 63.071637855306946,
+                "inflationRate": 0.0014520448352055336,
+                "volatility": 0.003606639746436983,
+                "priceMomentum": 0.0058081793408221345,
+                "scarcityIndex": 0.3618036268124199,
+                "affordabilityIndex": 1.3915400865733625
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 35.251367138344065,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 74.04301540916741,
+                "targetStockpile": 264.12337578578337,
+                "logisticsEfficiency": 0.38446485364135563,
+                "wastageRate": 0.1219591248388209
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 5270400
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.7450502118189788,
+                "supplyDisruption": 0.9135148882442764,
+                "demandPressure": -0.2107774230880837,
+                "reliefEffort": 0.201311565509975,
+                "blockadeSeverity": 0.7238293926751674,
+                "policyRationing": 0.5999998513227741,
+                "infrastructureDamage": 0.6366239626233938,
+                "elapsedDays": 61
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 62,
+        "timestamp": 5270400,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.08067436292093982,
+                "rationingEffectiveness": 0.5999972893464931,
+                "substitutionRate": 0.2807676110133831,
+                "incomeShock": 0.43840845917224874
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 63.345684274088896,
+                "inflationRate": 0.004345002414724755,
+                "volatility": 0.0039019848137520916,
+                "priceMomentum": 0.01738000965889902,
+                "scarcityIndex": 0.38224078248188914,
+                "affordabilityIndex": 1.3510360706303197
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 34.827179308901364,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 64.5737863879306,
+                "targetStockpile": 262.1785987632577,
+                "logisticsEfficiency": 0.3771015077526545,
+                "wastageRate": 0.12336366066372959
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 5356800
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.7488759357203594,
+                "supplyDisruption": 0.9197818651205245,
+                "demandPressure": -0.2120616841093413,
+                "reliefEffort": 0.20345360597265166,
+                "blockadeSeverity": 0.7273832559388507,
+                "policyRationing": 0.5999999553968323,
+                "infrastructureDamage": 0.6495669452780746,
+                "elapsedDays": 62
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 63,
+        "timestamp": 5356800,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.0796427944664757,
+                "rationingEffectiveness": 0.5999989077100271,
+                "substitutionRate": 0.28167499771903404,
+                "incomeShock": 0.4407224539294806
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 63.810169870940534,
+                "inflationRate": 0.007332553151401251,
+                "volatility": 0.005274212148811756,
+                "priceMomentum": 0.029330212605605005,
+                "scarcityIndex": 0.40310543264596466,
+                "affordabilityIndex": 1.307471549533375
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 34.43949121334979,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 54.71708973939267,
+                "targetStockpile": 260.4021732669484,
+                "logisticsEfficiency": 0.36999631836984004,
+                "wastageRate": 0.12474597360550979
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 5443200
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.7526072021620596,
+                "supplyDisruption": 0.9257619538643153,
+                "demandPressure": -0.21344288512246765,
+                "reliefEffort": 0.206072163583591,
+                "blockadeSeverity": 0.7308370170918701,
+                "policyRationing": 0.5999999866190496,
+                "infrastructureDamage": 0.6625583676854798,
+                "elapsedDays": 63
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 64,
+        "timestamp": 5443200,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.07864094215282331,
+                "rationingEffectiveness": 0.5999995606754397,
+                "substitutionRate": 0.2828003244464038,
+                "incomeShock": 0.4429760959770951
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 64.47523227517438,
+                "inflationRate": 0.010422514241522504,
+                "volatility": 0.007333532985896056,
+                "priceMomentum": 0.04169005696609002,
+                "scarcityIndex": 0.42444515504575564,
+                "affordabilityIndex": 1.2608934160813998
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 34.0805702171276,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 44.49979360285758,
+                "targetStockpile": 258.7860873154799,
+                "logisticsEfficiency": 0.36307666205402783,
+                "wastageRate": 0.12610899190597316
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 5529600
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.7562463433070685,
+                "supplyDisruption": 0.9315417866253641,
+                "demandPressure": -0.21487405016798466,
+                "reliefEffort": 0.20897663148348794,
+                "blockadeSeverity": 0.7341934957228862,
+                "policyRationing": 0.5999999959857149,
+                "infrastructureDamage": 0.6755935282367863,
+                "elapsedDays": 64
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 65,
+        "timestamp": 5529600,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.07766795267063696,
+                "rationingEffectiveness": 0.5999998235476045,
+                "substitutionRate": 0.2840907236346799,
+                "incomeShock": 0.4451709661264225
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 65.35337315008447,
+                "inflationRate": 0.0136198171595919,
+                "volatility": 0.009848046655374393,
+                "priceMomentum": 0.0544792686383676,
+                "scarcityIndex": 0.4462925967174267,
+                "affordabilityIndex": 1.2114007060917893
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 33.74350036237198,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 33.9424528745117,
+                "targetStockpile": 257.3148645166275,
+                "logisticsEfficiency": 0.3562868863823601,
+                "wastageRate": 0.12745687449526757
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 5616000
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.7597956337370658,
+                "supplyDisruption": 0.9371739835919312,
+                "demandPressure": -0.21632722715904637,
+                "reliefEffort": 0.21205264555675943,
+                "blockadeSeverity": 0.7374554320008533,
+                "policyRationing": 0.5999999987957144,
+                "infrastructureDamage": 0.68866891445596,
+                "elapsedDays": 65
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 66,
+        "timestamp": 5616000,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.07672299714807049,
+                "rationingEffectiveness": 0.5999999292022704,
+                "substitutionRate": 0.2855007516042648,
+                "incomeShock": 0.4473086036036806
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 66.45958624192484,
+                "inflationRate": 0.016926641097773924,
+                "volatility": 0.012679484432334204,
+                "priceMomentum": 0.0677065643910957,
+                "scarcityIndex": 0.4686655258576903,
+                "affordabilityIndex": 1.1591783358469312
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 33.42294157628865,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 23.06073526318213,
+                "targetStockpile": 255.97078403494817,
+                "logisticsEfficiency": 0.349588682647442,
+                "wastageRate": 0.12879354672576424
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 5702400
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.7632572918741096,
+                "supplyDisruption": 0.9426907406756813,
+                "demandPressure": -0.21778587665135274,
+                "reliefEffort": 0.21523158733405565,
+                "blockadeSeverity": 0.7406254889120443,
+                "policyRationing": 0.5999999996387143,
+                "infrastructureDamage": 0.7017817444201017,
+                "elapsedDays": 66
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 67,
+        "timestamp": 5702400,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.07580527045251205,
+                "rationingEffectiveness": 0.5999999716158767,
+                "substitutionRate": 0.2869949080963059,
+                "incomeShock": 0.4493905071486896
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 67.81158859009038,
+                "inflationRate": 0.02034322547907544,
+                "volatility": 0.015744980851030696,
+                "priceMomentum": 0.08137290191630175,
+                "scarcityIndex": 0.49157050689527915,
+                "affordabilityIndex": 1.1044975662005825
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 33.115060410059165,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 11.866792323203029,
+                "targetStockpile": 254.7365448951171,
+                "logisticsEfficiency": 0.3429570156456369,
+                "wastageRate": 0.130122164860353
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 5788800
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.7666334813672219,
+                "supplyDisruption": 0.9481119825807324,
+                "demandPressure": -0.21924030156105578,
+                "reliefEffort": 0.21847228573376673,
+                "blockadeSeverity": 0.7437062544340654,
+                "policyRationing": 0.5999999998916142,
+                "infrastructureDamage": 0.7149296911901085,
+                "elapsedDays": 67
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 68,
+        "timestamp": 5788800,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.07491399051223238,
+                "rationingEffectiveness": 0.5999999886268412,
+                "substitutionRate": 0.28854695247526696,
+                "incomeShock": 0.45141813608442793
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 69.43015812312689,
+                "inflationRate": 0.023868627275796285,
+                "volatility": 0.018994439420936933,
+                "priceMomentum": 0.09547450910318514,
+                "scarcityIndex": 0.5150067413681736,
+                "affordabilityIndex": 1.0477037260620883
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 32.81721507822293,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0.3703468537148815,
+                "targetStockpile": 253.5964906135309,
+                "logisticsEfficiency": 0.33637596392754493,
+                "wastageRate": 0.1314450521602476
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 5875200
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.7699263124447402,
+                "supplyDisruption": 0.9534502550908919,
+                "demandPressure": -0.22068490406932065,
+                "reliefEffort": 0.2217500381069267,
+                "blockadeSeverity": 0.7467002436486335,
+                "policyRationing": 0.5999999999674842,
+                "infrastructureDamage": 0.7281107170579341,
+                "elapsedDays": 68
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 69,
+        "timestamp": 5875200,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.07404839765737918,
+                "rationingEffectiveness": 0.5999999954448836,
+                "substitutionRate": 0.2901381760568208,
+                "incomeShock": 0.4533929113582072
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 71.33957528463867,
+                "inflationRate": 0.027501264769203698,
+                "volatility": 0.022397169560243638,
+                "priceMomentum": 0.11000505907681479,
+                "scarcityIndex": 0.5389690523523867,
+                "affordabilityIndex": 0.9892002749851107
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 32.527625599497135,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 252.537046625923,
+                "logisticsEfficiency": 0.3298355368121214,
+                "wastageRate": 0.13276382358186667
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 5961600
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.7731378432332787,
+                "supplyDisruption": 0.9587136608758163,
+                "demandPressure": -0.22211653962027728,
+                "reliefEffort": 0.225050022864156,
+                "blockadeSeverity": 0.7496099007948451,
+                "policyRationing": 0.5999999999902452,
+                "infrastructureDamage": 0.741322973693958,
+                "elapsedDays": 69
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 70,
+        "timestamp": 5961600,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.07320775397976732,
+                "rationingEffectiveness": 0.5999999981761975,
+                "substitutionRate": 0.2917555750441067,
+                "incomeShock": 0.4553162165552237
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 73.40946104897627,
+                "inflationRate": 0.02901455126525392,
+                "volatility": 0.02504412224224775,
+                "priceMomentum": 0.11605820506101568,
+                "scarcityIndex": 0.5452894417274923,
+                "affordabilityIndex": 0.9508888322107351
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 32.245103883159786,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 251.54674723661685,
+                "logisticsEfficiency": 0.32332948965621294,
+                "wastageRate": 0.13407955585423076
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 6048000
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.7762700810441245,
+                "supplyDisruption": 0.9639076213968558,
+                "demandPressure": -0.22353352940557994,
+                "reliefEffort": 0.22836334705182695,
+                "blockadeSeverity": 0.7524376012646081,
+                "policyRationing": 0.5999999999970735,
+                "infrastructureDamage": 0.7545647418443222,
+                "elapsedDays": 70
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 71,
+        "timestamp": 6048000,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.07239134271092912,
+                "rationingEffectiveness": 0.5999999992699522,
+                "substitutionRate": 0.2933902800059112,
+                "incomeShock": 0.4571893988852234
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 75.59809530733972,
+                "inflationRate": 0.029814062480356167,
+                "volatility": 0.02695209833749112,
+                "priceMomentum": 0.11925624992142467,
+                "scarcityIndex": 0.5509350213686738,
+                "affordabilityIndex": 0.9140606560729301
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 31.968855218995895,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 250.61606587491247,
+                "logisticsEfficiency": 0.31685390295885635,
+                "wastageRate": 0.1353929426483701
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 6134400
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.7793249836278723,
+                "supplyDisruption": 0.9690359344613616,
+                "demandPressure": -0.22493506800636842,
+                "reliefEffort": 0.23168467489776284,
+                "blockadeSeverity": 0.75518565354187,
+                "policyRationing": 0.599999999999122,
+                "infrastructureDamage": 0.767834394767902,
+                "elapsedDays": 71
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 72,
+        "timestamp": 6134400,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.07159846761790525,
+                "rationingEffectiveness": 0.5999999997078228,
+                "substitutionRate": 0.29503632899124665,
+                "incomeShock": 0.4590137701429967
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 77.89580438874675,
+                "inflationRate": 0.03039374301780793,
+                "volatility": 0.028328756209617844,
+                "priceMomentum": 0.12157497207123172,
+                "scarcityIndex": 0.5564987903216858,
+                "affordabilityIndex": 0.8782577490143928
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 31.69834069472021,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 249.7371669168526,
+                "logisticsEfficiency": 0.3104062857215773,
+                "wastageRate": 0.13670441643626813
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 6220800
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.7823044603980825,
+                "supplyDisruption": 0.9741014091550203,
+                "demandPressure": -0.22632086814567315,
+                "reliefEffort": 0.23501080493865772,
+                "blockadeSeverity": 0.7578563010872224,
+                "policyRationing": 0.5999999999997366,
+                "infrastructureDamage": 0.781130375926477,
+                "elapsedDays": 72
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 73,
+        "timestamp": 6220800,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.07082845241627073,
+                "rationingEffectiveness": 0.5999999998830817,
+                "substitutionRate": 0.29668976065404407,
+                "incomeShock": 0.46079060764340063
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 80.3029482715292,
+                "inflationRate": 0.03090209930652178,
+                "volatility": 0.02935809344837942,
+                "priceMomentum": 0.12360839722608712,
+                "scarcityIndex": 0.5619852876545222,
+                "affordabilityIndex": 0.8435231469865532
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 31.433185342496287,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 248.90364190989072,
+                "logisticsEfficiency": 0.30398501974680775,
+                "wastageRate": 0.13801423686169384
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 6307200
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.7852103736247268,
+                "supplyDisruption": 0.9791062471902618,
+                "demandPressure": -0.2276909477083652,
+                "reliefEffort": 0.23833981629652798,
+                "blockadeSeverity": 0.760451724169422,
+                "policyRationing": 0.5999999999999209,
+                "infrastructureDamage": 0.7944511852360063,
+                "elapsedDays": 73
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 74,
+        "timestamp": 6307200,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.07008064019990533,
+                "rationingEffectiveness": 0.5999999999532184,
+                "substitutionRate": 0.2983479676813403,
+                "incomeShock": 0.4625211551315872
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 82.82316842527757,
+                "inflationRate": 0.031383905672139445,
+                "volatility": 0.03016841833788343,
+                "priceMomentum": 0.12553562268855778,
+                "scarcityIndex": 0.5673978782453362,
+                "affordabilityIndex": 0.8098579318835254
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 31.17311835160234,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 248.11026135983124,
+                "logisticsEfficiency": 0.2975890190553697,
+                "wastageRate": 0.13932255173966654
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 6393600
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.7880445395981671,
+                "supplyDisruption": 0.9840522720938496,
+                "demandPressure": -0.22904550211859442,
+                "reliefEffort": 0.24167055644458346,
+                "blockadeSeverity": 0.7629740416453229,
+                "policyRationing": 0.5999999999999762,
+                "infrastructureDamage": 0.8077953704635238,
+                "elapsedDays": 74
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 75,
+        "timestamp": 6393600,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.06935439288703166,
+                "rationingEffectiveness": 0.5999999999812831,
+                "substitutionRate": 0.30000924738215334,
+                "incomeShock": 0.46420662366909826
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 85.46131450212266,
+                "inflationRate": 0.03185275481491881,
+                "volatility": 0.030842152928697582,
+                "priceMomentum": 0.12741101925967524,
+                "scarcityIndex": 0.5727391850887347,
+                "affordabilityIndex": 0.7772511810328262
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 30.917934846647128,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 247.35275552671814,
+                "logisticsEfficiency": 0.2912175226001886,
+                "wastageRate": 0.14062943778282744
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 6480000
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.7908087297643969,
+                "supplyDisruption": 0.9889410670878098,
+                "demandPressure": -0.23038482792748582,
+                "reliefEffort": 0.24500233386675008,
+                "blockadeSeverity": 0.7654253126896737,
+                "policyRationing": 0.5999999999999929,
+                "infrastructureDamage": 0.8211615217201442,
+                "elapsedDays": 75
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 76,
+        "timestamp": 6480000,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.06864909068205736,
+                "rationingEffectiveness": 0.599999999992512,
+                "substitutionRate": 0.3016724951599684,
+                "incomeShock": 0.4658481924964695
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 88.2228128731318,
+                "inflationRate": 0.03231284689566243,
+                "volatility": 0.031430430515483526,
+                "priceMomentum": 0.12925138758264973,
+                "scarcityIndex": 0.5780113597431855,
+                "affordabilityIndex": 0.7456882619413526
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 30.66747176960664,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 246.62762810531524,
+                "logisticsEfficiency": 0.2848699686499045,
+                "wastageRate": 0.14193492715442488
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 6566400
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.793504671832252,
+                "supplyDisruption": 0.9937740581764594,
+                "demandPressure": -0.23170927712249323,
+                "reliefEffort": 0.24833473365338338,
+                "blockadeSeverity": 0.7678075384761902,
+                "policyRationing": 0.5999999999999979,
+                "infrastructureDamage": 0.8345482678202554,
+                "elapsedDays": 76
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 77,
+        "timestamp": 6566400,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.06796413155277159,
+                "rationingEffectiveness": 0.5999999999970044,
+                "substitutionRate": 0.30333699846772033,
+                "incomeShock": 0.4674470098729695
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 91.11348106433182,
+                "inflationRate": 0.03276554098719254,
+                "volatility": 0.031964474704167134,
+                "priceMomentum": 0.13106216394877016,
+                "scarcityIndex": 0.5832162502452432,
+                "affordabilityIndex": 0.7151530493722283
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 30.421592805360042,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 245.93200178073732,
+                "logisticsEfficiency": 0.27854591885346175,
+                "wastageRate": 0.1432390244787577
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 6652800
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.7961340508532853,
+                "supplyDisruption": 0.9985525643474609,
+                "demandPressure": -0.23301922986526363,
+                "reliefEffort": 0.2516675068586967,
+                "blockadeSeverity": 0.7701226638112783,
+                "policyRationing": 0.5999999999999993,
+                "infrastructureDamage": 0.8479542737687341,
+                "elapsedDays": 77
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 78,
+        "timestamp": 6652800,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.06729893072245824,
+                "rationingEffectiveness": 0.5999999999988016,
+                "substitutionRate": 0.3050022999036758,
+                "incomeShock": 0.46900419389408177
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 94.12769805933274,
+                "inflationRate": 0.033082008938641064,
+                "volatility": 0.03241148839795671,
+                "priceMomentum": 0.13232803575456425,
+                "scarcityIndex": 0.5865315980625946,
+                "affordabilityIndex": 0.6876647447294559
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 30.26508336567462,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 245.4650231133304,
+                "logisticsEfficiency": 0.2727760205281801,
+                "wastageRate": 0.14451516718629687
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 6739200
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.7986985102749784,
+                "supplyDisruption": 1,
+                "demandPressure": -0.23431507828221879,
+                "reliefEffort": 0.255000504115218,
+                "blockadeSeverity": 0.7723725787217386,
+                "policyRationing": 0.5999999999999998,
+                "infrastructureDamage": 0.8613782389330815,
+                "elapsedDays": 78
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 79,
+        "timestamp": 6739200,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.06665292017650117,
+                "rationingEffectiveness": 0.5999999999995206,
+                "substitutionRate": 0.30666810710269826,
+                "incomeShock": 0.4705208332873233
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 97.25914164087472,
+                "inflationRate": 0.033268035297836514,
+                "volatility": 0.032754107157908635,
+                "priceMomentum": 0.13307214119134606,
+                "scarcityIndex": 0.5885913271672006,
+                "affordabilityIndex": 0.6629587375685293
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 30.19216923635959,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 245.25878040166424,
+                "logisticsEfficiency": 0.2674674089793354,
+                "wastageRate": 0.14575468553504206
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 6825600
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8011996529679501,
+                "supplyDisruption": 1,
+                "demandPressure": -0.23559721688249347,
+                "reliefEffort": 0.25833363580246416,
+                "blockadeSeverity": 0.7745591199977507,
+                "policyRationing": 0.5999999999999999,
+                "infrastructureDamage": 0.8748188956344158,
+                "elapsedDays": 79
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 80,
+        "timestamp": 6825600,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.06602554818306858,
+                "rationingEffectiveness": 0.5999999999998082,
+                "substitutionRate": 0.308334233891248,
+                "incomeShock": 0.4719979881869753
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 100.50612233658987,
+                "inflationRate": 0.03338483808241373,
+                "volatility": 0.03300639952771067,
+                "priceMomentum": 0.13353935232965491,
+                "scarcityIndex": 0.5902371557317323,
+                "affordabilityIndex": 0.6399937172127681
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 30.16214907677151,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 245.24809314124806,
+                "logisticsEfficiency": 0.2623484846046309,
+                "wastageRate": 0.14696679373722676
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 6912000
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8036390422278028,
+                "supplyDisruption": 1,
+                "demandPressure": -0.23686603694813552,
+                "reliefEffort": 0.26166684814814517,
+                "blockadeSeverity": 0.776684072692396,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 0.8882750079974905,
+                "elapsedDays": 80
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 81,
+        "timestamp": 6912000,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.06541627882747549,
+                "rationingEffectiveness": 0.5999999999999233,
+                "substitutionRate": 0.3100005621125262,
+                "incomeShock": 0.47343669088828777
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 103.86958721351857,
+                "inflationRate": 0.03346527354487548,
+                "volatility": 0.033189949134576596,
+                "priceMomentum": 0.13386109417950193,
+                "scarcityIndex": 0.5916741095564516,
+                "affordabilityIndex": 0.6182362156857493
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 30.15404467045277,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 245.38407455993598,
+                "logisticsEfficiency": 0.2573106417432093,
+                "wastageRate": 0.14816149905554407
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 6998400
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8060182027522325,
+                "supplyDisruption": 1,
+                "demandPressure": -0.23812192330362758,
+                "reliefEffort": 0.2650001088888871,
+                "blockadeSeverity": 0.7787491715789422,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 0.9017453709636463,
+                "elapsedDays": 81
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 82,
+        "timestamp": 6998400,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.06482459155983467,
+                "rationingEffectiveness": 0.5999999999999693,
+                "substitutionRate": 0.3116670170008488,
+                "incomeShock": 0.47483794658170414
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 107.35076981804634,
+                "inflationRate": 0.03351493635352297,
+                "volatility": 0.03331994402215514,
+                "priceMomentum": 0.13405974541409188,
+                "scarcityIndex": 0.592843010328843,
+                "affordabilityIndex": 0.5975088459229868
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 30.160660623253193,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 245.63005874235196,
+                "logisticsEfficiency": 0.2529242566972837,
+                "wastageRate": 0.14931525692812936
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 7084800
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8083386215940151,
+                "supplyDisruption": 1,
+                "demandPressure": -0.23936525250908441,
+                "reliefEffort": 0.26833339866666556,
+                "blockadeSeverity": 0.7807561025670817,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 0.9152288094088599,
+                "elapsedDays": 82
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 83,
+        "timestamp": 7084800,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.0642499807556175,
+                "rationingEffectiveness": 0.5999999999999878,
+                "substitutionRate": 0.3133335513738425,
+                "incomeShock": 0.4762027340676374
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 110.94702831809023,
+                "inflationRate": 0.03350007183124396,
+                "volatility": 0.033391995145790665,
+                "priceMomentum": 0.13400028732497585,
+                "scarcityIndex": 0.5932482320153338,
+                "affordabilityIndex": 0.5780186980615539
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 30.18983576795732,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 245.95854575020397,
+                "logisticsEfficiency": 0.2511697026789135,
+                "wastageRate": 0.15031724776341907
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 7171200
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8106017490904632,
+                "supplyDisruption": 1,
+                "demandPressure": -0.2405963919038493,
+                "reliefEffort": 0.271666705866666,
+                "blockadeSeverity": 0.7827065040792782,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 0.9287241773320024,
+                "elapsedDays": 83
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 84,
+        "timestamp": 7171200,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.06369195528875687,
+                "rationingEffectiveness": 0.5999999999999951,
+                "substitutionRate": 0.3150001355283054,
+                "incomeShock": 0.47753200645231497
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 114.65672429159153,
+                "inflationRate": 0.03343664115874686,
+                "volatility": 0.033409853550973145,
+                "priceMomentum": 0.13374656463498744,
+                "scarcityIndex": 0.5932573892691846,
+                "affordabilityIndex": 0.5596031024395052
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 30.23637015118295,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 246.34891032871698,
+                "logisticsEfficiency": 0.25046788107156537,
+                "wastageRate": 0.1511909887554363
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 7257600
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8128089997699329,
+                "supplyDisruption": 1,
+                "demandPressure": -0.2418156991566349,
+                "reliefEffort": 0.27500002351999964,
+                "blockadeSeverity": 0.7846019683883447,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 0.942230357092201,
+                "elapsedDays": 84
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 85,
+        "timestamp": 7257600,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.0631500381169349,
+                "rationingEffectiveness": 0.599999999999998,
+                "substitutionRate": 0.3166667508060499,
+                "incomeShock": 0.4788266918251964
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 118.4797396438059,
+                "inflationRate": 0.0333431412403846,
+                "volatility": 0.03338316862673773,
+                "priceMomentum": 0.1333725649615384,
+                "scarcityIndex": 0.5930631921079323,
+                "affordabilityIndex": 0.5420744892305583
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 30.294016033276392,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 246.78568335617612,
+                "logisticsEfficiency": 0.25018715242862616,
+                "wastageRate": 0.1519797932233485
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 7344000
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.814961753235951,
+                "supplyDisruption": 1,
+                "demandPressure": -0.24302352211600048,
+                "reliefEffort": 0.2783333474453331,
+                "blockadeSeverity": 0.7864440429173472,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 0.9557462586824667,
+                "elapsedDays": 85
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 86,
+        "timestamp": 7344000,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.06262376587870823,
+                "rationingEffectiveness": 0.5999999999999992,
+                "substitutionRate": 0.31833338551040324,
+                "incomeShock": 0.48008769391845313
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 122.41708783249825,
+                "inflationRate": 0.03323224882608191,
+                "volatility": 0.033322800706475406,
+                "priceMomentum": 0.13292899530432764,
+                "scarcityIndex": 0.5927655217045359,
+                "affordabilityIndex": 0.5252933039322178
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 30.358190430194085,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 247.25726288291511,
+                "logisticsEfficiency": 0.2500748609714505,
+                "wastageRate": 0.15271792403889467
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 7430400
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8170613550295116,
+                "supplyDisruption": 1,
+                "demandPressure": -0.2442201988375462,
+                "reliefEffort": 0.28166667513386656,
+                "blockadeSeverity": 0.7882342315028927,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 0.9692708190317183,
+                "elapsedDays": 86
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 87,
+        "timestamp": 7430400,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.062112688502133646,
+                "rationingEffectiveness": 0.5999999999999996,
+                "substitutionRate": 0.32000003232230595,
+                "incomeShock": 0.4813158927489886
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 126.47049487705449,
+                "inflationRate": 0.03311144805292591,
+                "volatility": 0.033238259645055605,
+                "priceMomentum": 0.13244579221170363,
+                "scarcityIndex": 0.5924157203258553,
+                "affordabilityIndex": 0.5091667646410882
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 30.426018198808553,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 247.75494738165617,
+                "logisticsEfficiency": 0.25002994438858017,
+                "wastageRate": 0.15342753983327626
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 7516800
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8191091174700839,
+                "supplyDisruption": 1,
+                "demandPressure": -0.24540605771375182,
+                "reliefEffort": 0.28500000508032,
+                "blockadeSeverity": 0.7899739956228348,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 0.9828030013303168,
+                "elapsedDays": 87
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 88,
+        "timestamp": 7516800,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.061616368824566274,
+                "rationingEffectiveness": 0.5999999999999999,
+                "substitutionRate": 0.3216666866696886,
+                "incomeShock": 0.4825121452434614
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 130.64210885573917,
+                "inflationRate": 0.03298487906400631,
+                "volatility": 0.03313690741263589,
+                "priceMomentum": 0.13193951625602524,
+                "scarcityIndex": 0.5920400152665424,
+                "affordabilityIndex": 0.49363408062254166
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 30.495828303862375,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 248.272210667924,
+                "logisticsEfficiency": 0.25001197775543205,
+                "wastageRate": 0.154121715888267
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 7603200
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8211063204758533,
+                "supplyDisruption": 1,
+                "demandPressure": -0.2465814176621145,
+                "reliefEffort": 0.2883333363815253,
+                "blockadeSeverity": 0.7916647555893972,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 0.9963417943760186,
+                "elapsedDays": 88
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 89,
+        "timestamp": 7603200,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.06113438222331205,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.32333334570092953,
+                "incomeShock": 0.4836772858467648
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 134.93361468281367,
+                "inflationRate": 0.032849330622895655,
+                "volatility": 0.033021876696739796,
+                "priceMomentum": 0.13139732249158262,
+                "scarcityIndex": 0.5915761913060132,
+                "affordabilityIndex": 0.478796278972113
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 30.566691840298525,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 248.80415807995215,
+                "logisticsEfficiency": 0.25000479110217283,
+                "wastageRate": 0.15456061838902485
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 7689600
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.823054212363713,
+                "supplyDisruption": 1,
+                "demandPressure": -0.24774658834507354,
+                "reliefEffort": 0.29166666849558187,
+                "blockadeSeverity": 0.7933078917086922,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 89
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 90,
+        "timestamp": 7689600,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.0606663162568251,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.32500000764002757,
+                "incomeShock": 0.48481212711440136
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 139.34661802182328,
+                "inflationRate": 0.03270499607813199,
+                "volatility": 0.03289512444929667,
+                "priceMomentum": 0.13081998431252795,
+                "scarcityIndex": 0.5910402741043885,
+                "affordabilityIndex": 0.46459567207953645
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 30.638106999446656,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 249.3471186073696,
+                "logisticsEfficiency": 0.2500019164408691,
+                "wastageRate": 0.15478021337246897
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 7776000
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8249540106295021,
+                "supplyDisruption": 1,
+                "demandPressure": -0.24890187040590622,
+                "reliefEffort": 0.29500000109734914,
+                "blockadeSeverity": 0.7949047454075773,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 90
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 91,
+        "timestamp": 7776000,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.06021177031614954,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.3266666713823651,
+                "incomeShock": 0.4859174602891818
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 143.88298165490662,
+                "inflationRate": 0.032554529829872836,
+                "volatility": 0.032758886601527135,
+                "priceMomentum": 0.13021811931949134,
+                "scarcityIndex": 0.5904682098477185,
+                "affordabilityIndex": 0.45094220638873156
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 30.709807933812563,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 249.8983389839705,
+                "logisticsEfficiency": 0.2500007665763476,
+                "wastageRate": 0.1548900683574171
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 7862400
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8268069027089806,
+                "supplyDisruption": 1,
+                "demandPressure": -0.2500475557111952,
+                "reliefEffort": 0.29833333399174283,
+                "blockadeSeverity": 0.7964566203287717,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 91
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 92,
+        "timestamp": 7862400,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.05977035528631372,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.32833333624176153,
+                "incomeShock": 0.48699405586266337
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 148.54479646322363,
+                "inflationRate": 0.032400043109323845,
+                "volatility": 0.032615349204645816,
+                "priceMomentum": 0.12960017243729538,
+                "scarcityIndex": 0.5898780235451117,
+                "affordabilityIndex": 0.43778362036596297
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 30.781655741964144,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 250.45575425504384,
+                "logisticsEfficiency": 0.25000030663053907,
+                "wastageRate": 0.1549450188471816
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 7948800
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8286140467200146,
+                "supplyDisruption": 1,
+                "demandPressure": -0.25118392759431474,
+                "reliefEffort": 0.30166666706171236,
+                "blockadeSeverity": 0.7979647833951278,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 92
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 93,
+        "timestamp": 7948800,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.05934169321739326,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.33000000179246236,
+                "incomeShock": 0.48804266412173464
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 153.33430263772985,
+                "inflationRate": 0.03224284046659289,
+                "volatility": 0.032466345709424645,
+                "priceMomentum": 0.12897136186637156,
+                "scarcityIndex": 0.5892787527341276,
+                "affordabilityIndex": 0.4250862629078726
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 30.853578581858514,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 251.01781570152247,
+                "logisticsEfficiency": 0.2500001226522156,
+                "wastageRate": 0.15497250329098
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 8035200
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8303765721864387,
+                "supplyDisruption": 1,
+                "demandPressure": -0.2523112610966879,
+                "reliefEffort": 0.3050000002370274,
+                "blockadeSeverity": 0.7994304658439231,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 93
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 94,
+        "timestamp": 8035200,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.05892541700496733,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.33166666777058734,
+                "incomeShock": 0.4890640156807405
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 158.25382842133544,
+                "inflationRate": 0.032083660987643224,
+                "volatility": 0.03231327182071208,
+                "priceMomentum": 0.1283346439505729,
+                "scarcityIndex": 0.5886749282609497,
+                "affordabilityIndex": 0.41282581365286225
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 30.925539575791817,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 251.58336178228558,
+                "logisticsEfficiency": 0.25000004906088624,
+                "wastageRate": 0.1549862491924457
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 8121600
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8320955807440445,
+                "supplyDisruption": 1,
+                "demandPressure": -0.25342982320494833,
+                "reliefEffort": 0.30833333347554975,
+                "blockadeSeverity": 0.8008548642320212,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 94
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 95,
+        "timestamp": 8121600,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.05852117007970036,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.3333333340127517,
+                "incomeShock": 0.4900588219995319
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 163.3057513764688,
+                "inflationRate": 0.03192291147411032,
+                "volatility": 0.03215712768207138,
+                "priceMomentum": 0.12769164589644127,
+                "scarcityIndex": 0.5880688213931702,
+                "affordabilityIndex": 0.40098277689885053
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 30.99751990214812,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 252.15152134040045,
+                "logisticsEfficiency": 0.2500000196243545,
+                "wastageRate": 0.1549931236150051
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 8208000
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8337721468291392,
+                "supplyDisruption": 1,
+                "demandPressure": -0.2545398730829666,
+                "reliefEffort": 0.3116666667519965,
+                "blockadeSeverity": 0.802239141412719,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 95
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 96,
+        "timestamp": 8208000,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.05812860610578911,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.33500000041789063,
+                "incomeShock": 0.491027775887814
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 168.49247548327904,
+                "inflationRate": 0.0317608171365213,
+                "volatility": 0.03199860346385135,
+                "priceMomentum": 0.1270432685460852,
+                "scarcityIndex": 0.5874615706042403,
+                "affordabilityIndex": 0.389540285215682
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 31.069509996959262,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 252.7216410075121,
+                "logisticsEfficiency": 0.2500000078497418,
+                "wastageRate": 0.15499656141501547
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 8294400
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8354073183501025,
+                "supplyDisruption": 1,
+                "demandPressure": -0.2556416622981942,
+                "reliefEffort": 0.3150000000511979,
+                "blockadeSeverity": 0.8035844274850791,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 96
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 97,
+        "timestamp": 8294400,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.05774738868802241,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.3366666669235448,
+                "incomeShock": 0.4919715519961572
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 173.8164177134104,
+                "inflationRate": 0.031597507335926714,
+                "volatility": 0.031838165012681496,
+                "priceMomentum": 0.12639002934370686,
+                "scarcityIndex": 0.586853746516393,
+                "affordabilityIndex": 0.37848302294652164
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 31.1415050169443,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 253.29323075696112,
+                "logisticsEfficiency": 0.25000000313989673,
+                "wastageRate": 0.1549982805505129
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 8380800
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8370021173423643,
+                "supplyDisruption": 1,
+                "demandPressure": -0.25673543504207136,
+                "reliefEffort": 0.31833333336405206,
+                "blockadeSeverity": 0.8048918207165225,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 97
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 98,
+        "timestamp": 8380800,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.057377191087207964,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.33833333349114647,
+                "incomeShock": 0.49289080729402474
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 179.27999988826116,
+                "inflationRate": 0.031433061656230624,
+                "volatility": 0.03167612367010114,
+                "priceMomentum": 0.1257322466249225,
+                "scarcityIndex": 0.5862456351194414,
+                "affordabilityIndex": 0.3677966934317207
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 31.21350251592437,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 253.86592306851708,
+                "logisticsEfficiency": 0.25000000125595867,
+                "wastageRate": 0.15499914021245853
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 8467200
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8385575406072101,
+                "supplyDisruption": 1,
+                "demandPressure": -0.25782142834442145,
+                "reliefEffort": 0.3216666666850979,
+                "blockadeSeverity": 0.806162388439435,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 98
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 99,
+        "timestamp": 8467200,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.057017695943727784,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.3400000000968996,
+                "incomeShock": 0.4937861815351615
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 184.88564337035677,
+                "inflationRate": 0.031267533944608426,
+                "volatility": 0.031512687779904056,
+                "priceMomentum": 0.1250701357784337,
+                "scarcityIndex": 0.5856373797419381,
+                "affordabilityIndex": 0.3574677505219033
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 31.28550126098289,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 254.43944230186554,
+                "logisticsEfficiency": 0.25000000050238347,
+                "wastageRate": 0.1549995700811101
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 8553600
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8400745603348138,
+                "supplyDisruption": 1,
+                "demandPressure": -0.2588998722818534,
+                "reliefEffort": 0.3250000000110588,
+                "blockadeSeverity": 0.8073971679225171,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 99
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 100,
+        "timestamp": 8553600,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.05666859500899035,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.3416666667261335,
+                "incomeShock": 0.4946582977106807
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 190.63576523053692,
+                "inflationRate": 0.03110096465771378,
+                "volatility": 0.031347998531027946,
+                "priceMomentum": 0.12440385863085512,
+                "scarcityIndex": 0.5850290522126849,
+                "affordabilityIndex": 0.3474832587509139
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 31.357500631723614,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 255.0135817266858,
+                "logisticsEfficiency": 0.25000000020095337,
+                "wastageRate": 0.15499978503050738
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 8640000
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.841554124711888,
+                "supplyDisruption": 1,
+                "demandPressure": -0.25997099018025716,
+                "reliefEffort": 0.3283333333399686,
+                "blockadeSeverity": 0.8085971672175924,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 100
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 101,
+        "timestamp": 8640000,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.05632958888455459,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.34333333336980965,
+                "incomeShock": 0.49550776249017364
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 196.5327751606581,
+                "inflationRate": 0.030933387147946308,
+                "volatility": 0.03118215397779529,
+                "priceMomentum": 0.12373354859178523,
+                "scarcityIndex": 0.5844206885274238,
+                "affordabilityIndex": 0.33783081630964473
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 31.42950031636901,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 255.58818629518635,
+                "logisticsEfficiency": 0.25000000008038137,
+                "wastageRate": 0.15499989251123464
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 8726400
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8429971585143325,
+                "supplyDisruption": 1,
+                "demandPressure": -0.2610349988115064,
+                "reliefEffort": 0.3316666666706478,
+                "blockadeSeverity": 0.8097633659825632,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 101
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 102,
+        "timestamp": 8726400,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.05600038676870662,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.34500000002236353,
+                "incomeShock": 0.4963351666511615
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 202.57907274520286,
+                "inflationRate": 0.03076483085125171,
+                "volatility": 0.031015224727177857,
+                "priceMomentum": 0.12305932340500685,
+                "scarcityIndex": 0.5838123067243302,
+                "affordabilityIndex": 0.3284985088317109
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 31.501500158395984,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 256.16313972149294,
+                "logisticsEfficiency": 0.25000000003215256,
+                "wastageRate": 0.1549999462540097
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 8812800
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8444045636852487,
+                "supplyDisruption": 1,
+                "demandPressure": -0.2620921085845058,
+                "reliefEffort": 0.3350000000023887,
+                "blockadeSeverity": 0.8108967162811844,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 102
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 103,
+        "timestamp": 8812800,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.055680706210277035,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.34666666668037144,
+                "incomeShock": 0.49714108549719827
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 208.77704488918837,
+                "inflationRate": 0.030595322902781368,
+                "volatility": 0.03084726399741926,
+                "priceMomentum": 0.12238129161112547,
+                "scarcityIndex": 0.5832039158424982,
+                "affordabilityIndex": 0.31947487844812605
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 31.573500079287747,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 256.7383547911816,
+                "logisticsEfficiency": 0.25000000001286105,
+                "wastageRate": 0.1549999731263618
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 8899200
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8457772198986832,
+                "supplyDisruption": 1,
+                "demandPressure": -0.26314252373072483,
+                "reliefEffort": 0.33833333333476656,
+                "blockadeSeverity": 0.8119981433603132,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 103
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 104,
+        "timestamp": 8899200,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.0553702728694921,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.34833333334172817,
+                "incomeShock": 0.497926079264926
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 215.12906329699894,
+                "inflationRate": 0.030424888958371907,
+                "volatility": 0.03067831398180032,
+                "priceMomentum": 0.12169955583348763,
+                "scarcityIndex": 0.5825955204114208,
+                "affordabilityIndex": 0.31074890055461957
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 31.645500039682876,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 257.3137660934234,
+                "logisticsEfficiency": 0.25000000000514444,
+                "wastageRate": 0.1549999865629237
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 8985600
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.847115985109453,
+                "supplyDisruption": 1,
+                "demandPressure": -0.2641864424843661,
+                "reliefEffort": 0.3416666666675266,
+                "blockadeSeverity": 0.8130685464052619,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 104
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 105,
+        "timestamp": 8985600,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.0550688202856583,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.3500000000051401,
+                "incomeShock": 0.49869069352037565
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 221.63748194777463,
+                "inflationRate": 0.03025355361581443,
+                "volatility": 0.030508409835405963,
+                "priceMomentum": 0.12101421446325772,
+                "scarcityIndex": 0.5819871227007958,
+                "affordabilityIndex": 0.3023099646136858
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 31.717500019858896,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 257.88932457008985,
+                "logisticsEfficiency": 0.2500000000020578,
+                "wastageRate": 0.15499999328135894
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 9072000
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8484216960893955,
+                "supplyDisruption": 1,
+                "demandPressure": -0.2652240572573174,
+                "reliefEffort": 0.34500000000051595,
+                "blockadeSeverity": 0.8141087992738786,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 105
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 106,
+        "timestamp": 9072000,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.05477608965148538,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.3516666666698126,
+                "incomeShock": 0.4994354595447987
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 228.3046345396553,
+                "inflationRate": 0.03008134063466602,
+                "volatility": 0.03033758215510999,
+                "priceMomentum": 0.12032536253866408,
+                "scarcityIndex": 0.5813787238479388,
+                "affordabilityIndex": 0.2941478571969577
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 31.789500009937548,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 258.46499342758074,
+                "logisticsEfficiency": 0.2500000000008231,
+                "wastageRate": 0.15499999664063832
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 9158400
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8496951689503778,
+                "supplyDisruption": 1,
+                "demandPressure": -0.2662555548090319,
+                "reliefEffort": 0.3483333333336429,
+                "blockadeSeverity": 0.8151197512099475,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 106
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 107,
+        "timestamp": 9158400,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.054491829593858544,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.35333333333525807,
+                "incomeShock": 0.5001608947103077
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 235.13283188910864,
+                "inflationRate": 0.029908273054646772,
+                "volatility": 0.030165858514924704,
+                "priceMomentum": 0.11963309221858709,
+                "scarcityIndex": 0.5807703244227382,
+                "affordabilityIndex": 0.28625274638822845
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 31.861500004972683,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 259.04074507069356,
+                "logisticsEfficiency": 0.25000000000032924,
+                "wastageRate": 0.1549999983203027
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 9244800
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8509371996543929,
+                "supplyDisruption": 1,
+                "demandPressure": -0.26728111641148244,
+                "reliefEffort": 0.3516666666668524,
+                "blockadeSeverity": 0.8161022275364977,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 107
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 108,
+        "timestamp": 9244800,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.0542157959608759,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.35500000000117715,
+                "incomeShock": 0.5008675028455954
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 242.124359278865,
+                "inflationRate": 0.029734373262912228,
+                "volatility": 0.029993264414119713,
+                "priceMomentum": 0.11893749305164891,
+                "scarcityIndex": 0.5801619247107523,
+                "affordabilityIndex": 0.2786151671117457
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 31.93350000248831,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 259.616558803025,
+                "logisticsEfficiency": 0.2500000000001317,
+                "wastageRate": 0.15499999916014479
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 9331200
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8521485645110622,
+                "supplyDisruption": 1,
+                "demandPressure": -0.2683009180093295,
+                "reliefEffort": 0.35500000000011145,
+                "blockadeSeverity": 0.8170570303295808,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 108
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 109,
+        "timestamp": 9331200,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.05394775161497237,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.35666666666738633,
+                "incomeShock": 0.501555774591997
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 249.2814737518256,
+                "inflationRate": 0.02955966303546286,
+                "volatility": 0.029819823862656972,
+                "priceMomentum": 0.11823865214185145,
+                "scarcityIndex": 0.579553524855067,
+                "affordabilityIndex": 0.2712260071662686
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 32.00550000124518,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 260.19241910227163,
+                "logisticsEfficiency": 0.2500000000000527,
+                "wastageRate": 0.15499999958006977
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 9417600
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8533300206628546,
+                "supplyDisruption": 1,
+                "demandPressure": -0.26931513037544075,
+                "reliefEffort": 0.35833333333340023,
+                "blockadeSeverity": 0.8179849390730722,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 109
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 110,
+        "timestamp": 9417600,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.053687466231956575,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.35833333333377315,
+                "incomeShock": 0.502226187750149
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 256.60640135036726,
+                "inflationRate": 0.029384163565376133,
+                "volatility": 0.029645559743744637,
+                "priceMomentum": 0.11753665426150453,
+                "scarcityIndex": 0.5789451249273783,
+                "affordabilityIndex": 0.2640764938503253
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 32.07750000062315,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 260.7683143267055,
+                "logisticsEfficiency": 0.2500000000000211,
+                "wastageRate": 0.15499999979003382
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 9504000
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8544823065583247,
+                "supplyDisruption": 1,
+                "demandPressure": -0.2703239192618962,
+                "reliefEffort": 0.3616666666667068,
+                "blockadeSeverity": 0.8188867112950278,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 110
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 111,
+        "timestamp": 9504000,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.053434716105791896,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.3600000000002687,
+                "incomeShock": 0.502879207617498
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 264.1013343015935,
+                "inflationRate": 0.029207895484231524,
+                "volatility": 0.029470494039939392,
+                "priceMomentum": 0.1168315819369261,
+                "scarcityIndex": 0.5783367249636112,
+                "affordabilityIndex": 0.25715818111520616
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 32.14950000031189,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 261.3442357450302,
+                "logisticsEfficiency": 0.25000000000000844,
+                "wastageRate": 0.1549999998950165
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 9590400
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.855606142413667,
+                "supplyDisruption": 1,
+                "demandPressure": -0.2713274455466081,
+                "reliefEffort": 0.3650000000000241,
+                "blockadeSeverity": 0.8197630831861156,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 111
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 112,
+        "timestamp": 9590400,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.053189283958957945,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.3616666666668308,
+                "incomeShock": 0.5035152873168978
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 271.76842814973094,
+                "inflationRate": 0.02903087887992974,
+                "volatility": 0.029294647975935534,
+                "priceMomentum": 0.11612351551971896,
+                "scarcityIndex": 0.5777283249817663,
+                "affordabilityIndex": 0.2504629372071733
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 32.22150000015613,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 261.92017680877325,
+                "logisticsEfficiency": 0.2500000000000034,
+                "wastageRate": 0.15499999994750807
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 9676800
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8567022306628753,
+                "supplyDisruption": 1,
+                "demandPressure": -0.2723258653756839,
+                "reliefEffort": 0.3683333333333478,
+                "blockadeSeverity": 0.8206147702006297,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 112
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 113,
+        "timestamp": 9676800,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.052950958758233226,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.36333333333343354,
+                "incomeShock": 0.504134868116534
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 279.60979883726833,
+                "inflationRate": 0.028853133312517126,
+                "volatility": 0.02911804211056817,
+                "priceMomentum": 0.1154125332500685,
+                "scarcityIndex": 0.5771199249908634,
+                "affordabilityIndex": 0.243982932772638
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 32.29350000007817,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 262.4961326065803,
+                "logisticsEfficiency": 0.25000000000000133,
+                "wastageRate": 0.15499999997375397
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 9763200
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8577712563967859,
+                "supplyDisruption": 1,
+                "demandPressure": -0.27331933030165323,
+                "reliefEffort": 0.37166666666667536,
+                "blockadeSeverity": 0.8214424676405732,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 113
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 114,
+        "timestamp": 9763200,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.052719535535744246,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.36500000000006116,
+                "incomeShock": 0.5047383797414052
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 287.6275197367103,
+                "inflationRate": 0.028674677828827738,
+                "volatility": 0.028940696397871994,
+                "priceMomentum": 0.11469871131531095,
+                "scarcityIndex": 0.5765115249954217,
+                "affordabilityIndex": 0.2377106294061545
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 32.36550000003915,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 263.0720994549355,
+                "logisticsEfficiency": 0.25000000000000056,
+                "wastageRate": 0.15499999998687697
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 9849600
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8588138877912822,
+                "supplyDisruption": 1,
+                "demandPressure": -0.27430798741768003,
+                "reliefEffort": 0.3750000000000052,
+                "blockadeSeverity": 0.8222468512232908,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 114
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 115,
+        "timestamp": 9849600,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.05249481521513098,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.366666666666704,
+                "incomeShock": 0.5053262406765844
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 295.8236186350202,
+                "inflationRate": 0.028495530976355862,
+                "volatility": 0.02876263022926554,
+                "priceMomentum": 0.11398212390542345,
+                "scarcityIndex": 0.5759031249977058,
+                "affordabilityIndex": 0.23163876862420849
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 32.43750000001961,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 263.64807459120175,
+                "logisticsEfficiency": 0.2500000000000002,
+                "wastageRate": 0.15499999999343847
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 9936000
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8598307765249265,
+                "supplyDisruption": 1,
+                "demandPressure": -0.2752919794878752,
+                "reliefEffort": 0.37833333333333646,
+                "blockadeSeverity": 0.8230285776331125,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 115
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 116,
+        "timestamp": 9936000,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.0522766044426825,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.3683333333333561,
+                "incomeShock": 0.5058988584624778
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 304.2000746730008,
+                "inflationRate": 0.028315710816570337,
+                "volatility": 0.02858386246418746,
+                "priceMomentum": 0.11326284326628135,
+                "scarcityIndex": 0.5752947249988504,
+                "affordabilityIndex": 0.2257603612494535
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 32.50950000000983,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 264.22405594340137,
+                "logisticsEfficiency": 0.2500000000000001,
+                "wastageRate": 0.15499999999671923
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 10022400
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8608225581862795,
+                "supplyDisruption": 1,
+                "demandPressure": -0.2762714450738223,
+                "reliefEffort": 0.38166666666666854,
+                "blockadeSeverity": 0.8237882850574589,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 116
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 117,
+        "timestamp": 10022400,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.05206471542330114,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.3700000000000139,
+                "incomeShock": 0.5064566299822952
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 312.7588152420163,
+                "inflationRate": 0.028135234937781358,
+                "volatility": 0.028404411453625017,
+                "priceMomentum": 0.11254093975112543,
+                "scarcityIndex": 0.5746863249994238,
+                "affordabilityIndex": 0.2200686771910292
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 32.58150000000493,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 264.80004195755106,
+                "logisticsEfficiency": 0.25000000000000006,
+                "wastageRate": 0.15499999999835962
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 10108800
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.861789852671165,
+                "supplyDisruption": 1,
+                "demandPressure": -0.2772465186574261,
+                "reliefEffort": 0.3850000000000011,
+                "blockadeSeverity": 0.8245265937078454,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 117
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 118,
+        "timestamp": 10108800,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.05185896576115728,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.37166666666667514,
+                "incomeShock": 0.5069999417419356
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.027954120467619754,
+                "volatility": 0.028224295059222915,
+                "priceMomentum": 0.11181648187047902,
+                "scarcityIndex": 0.5740779249997112,
+                "affordabilityIndex": 0.21556412109397557
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 32.653500000002474,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 265.3760314681633,
+                "logisticsEfficiency": 0.25,
+                "wastageRate": 0.15499999999917982
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 10195200
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8627332645701243,
+                "supplyDisruption": 1,
+                "demandPressure": -0.27821733076019106,
+                "reliefEffort": 0.388333333333334,
+                "blockadeSeverity": 0.8252441063262121,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 118
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 119,
+        "timestamp": 10195200,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.05165917830490098,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.3733333333333385,
+                "incomeShock": 0.5075291701424913
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.027772384085162923,
+                "volatility": 0.02804353066959892,
+                "priceMomentum": 0.11108953634065169,
+                "scarcityIndex": 0.5734695249998553,
+                "affordabilityIndex": 0.21603943359386305
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 32.72550000000125,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 265.9520236011225,
+                "logisticsEfficiency": 0.25,
+                "wastageRate": 0.1549999999995899
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 10281600
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8636533835463049,
+                "supplyDisruption": 1,
+                "demandPressure": -0.2791840080590312,
+                "reliefEffort": 0.39166666666666705,
+                "blockadeSeverity": 0.825941408676992,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 119
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 120,
+        "timestamp": 10281600,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.05146518099730029,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.37500000000000316,
+                "incomeShock": 0.5080446817455647
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.027590042032729033,
+                "volatility": 0.027862135214850963,
+                "priceMomentum": 0.11036016813091613,
+                "scarcityIndex": 0.5728611249999275,
+                "affordabilityIndex": 0.21651474609380666
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 32.79750000000063,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 266.5280177008419,
+                "logisticsEfficiency": 0.25,
+                "wastageRate": 0.15499999999979497
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 10368000
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.864550784704019,
+                "supplyDisruption": 1,
+                "demandPressure": -0.28014667349871375,
+                "reliefEffort": 0.39500000000000024,
+                "blockadeSeverity": 0.8266190700253175,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 120
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 121,
+        "timestamp": 10368000,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.051276806729180176,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.3766666666666686,
+                "incomeShock": 0.5085468335315886
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.02740711012735423,
+                "volatility": 0.027680125179852272,
+                "priceMomentum": 0.10962844050941692,
+                "scarcityIndex": 0.5722527249999636,
+                "affordabilityIndex": 0.21699005859377846
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 32.86950000000032,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 267.1040132756314,
+                "logisticsEfficiency": 0.25,
+                "wastageRate": 0.1549999999998975
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 10454400
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8654260289482034,
+                "supplyDisruption": 1,
+                "demandPressure": -0.2811054464010325,
+                "reliefEffort": 0.3983333333333335,
+                "blockadeSeverity": 0.8272776436017595,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 121
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 122,
+        "timestamp": 10454400,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.05109389319753893,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.3783333333333345,
+                "incomeShock": 0.5090359731513352
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.02722360377196436,
+                "volatility": 0.02749751661669711,
+                "priceMomentum": 0.10889441508785744,
+                "scarcityIndex": 0.5716443249999817,
+                "affordabilityIndex": 0.21746537109376426
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 32.94150000000016,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 267.6800099567236,
+                "logisticsEfficiency": 0.25,
+                "wastageRate": 0.15499999999994876
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 10540800
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8662796633350021,
+                "supplyDisruption": 1,
+                "demandPressure": -0.2820604425708065,
+                "reliefEffort": 0.4016666666666668,
+                "blockadeSeverity": 0.8279176670539738,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 122
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 123,
+        "timestamp": 10540800,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.05091628276772315,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.3800000000000007,
+                "incomeShock": 0.5095124391707947
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.027039537966250676,
+                "volatility": 0.027314325156518535,
+                "priceMomentum": 0.1081581518650027,
+                "scarcityIndex": 0.5710359249999908,
+                "affordabilityIndex": 0.21794068359375715
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 33.013500000000086,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 268.2560074675427,
+                "logisticsEfficiency": 0.25,
+                "wastageRate": 0.15499999999997438
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 10627200
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8671122214136952,
+                "supplyDisruption": 1,
+                "demandPressure": -0.28301177439879516,
+                "reliefEffort": 0.4050000000000001,
+                "blockadeSeverity": 0.8285396628856279,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 123
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 124,
+        "timestamp": 10627200,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.05074382233954527,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.3816666666666671,
+                "incomeShock": 0.5099765613095978
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.026854927317258324,
+                "volatility": 0.02713056602081445,
+                "priceMomentum": 0.1074197092690333,
+                "scarcityIndex": 0.5704275249999954,
+                "affordabilityIndex": 0.21841599609375362
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 33.085500000000046,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 268.832005600657,
+                "logisticsEfficiency": 0.25,
+                "wastageRate": 0.1549999999999872
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 10713600
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8679242235601838,
+                "supplyDisruption": 1,
+                "demandPressure": -0.2839595509616197,
+                "reliefEffort": 0.4083333333333334,
+                "blockadeSeverity": 0.8291441388829628,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 124
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 125,
+        "timestamp": 10713600,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.050576363217231184,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.3833333333333336,
+                "incomeShock": 0.5104286606731545
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.026669786049695342,
+                "volatility": 0.026946254032366806,
+                "priceMomentum": 0.10667914419878137,
+                "scarcityIndex": 0.5698191249999977,
+                "affordabilityIndex": 0.2188913085937518
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 33.15750000000003,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 269.40800420049277,
+                "logisticsEfficiency": 0.25,
+                "wastageRate": 0.15499999999999362
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 10800000
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8687161773022424,
+                "supplyDisruption": 1,
+                "demandPressure": -0.2849038781187772,
+                "reliefEffort": 0.4116666666666667,
+                "blockadeSeverity": 0.8297315885293413,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 125
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 126,
+        "timestamp": 10800000,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.05041376098308856,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.3850000000000002,
+                "incomeShock": 0.5108690499786748
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.02648412801597003,
+                "volatility": 0.026761403625808096,
+                "priceMomentum": 0.10593651206388012,
+                "scarcityIndex": 0.5692107249999988,
+                "affordabilityIndex": 0.21936662109375094
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 33.229500000000016,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 269.9840031503696,
+                "logisticsEfficiency": 0.25,
+                "wastageRate": 0.1549999999999968
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 10886400
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.86948857763674,
+                "supplyDisruption": 1,
+                "demandPressure": -0.28584485860683173,
+                "reliefEffort": 0.41500000000000004,
+                "blockadeSeverity": 0.8303024914081183,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 126
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 127,
+        "timestamp": 10886400,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.05025587537478964,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.38666666666666677,
+                "incomeShock": 0.5112980337752328
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.026297966705963714,
+                "volatility": 0.026576028857870346,
+                "priceMomentum": 0.10519186682385485,
+                "scarcityIndex": 0.5686023249999994,
+                "affordabilityIndex": 0.21984193359375048
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 33.30150000000001,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 270.5600023627772,
+                "logisticsEfficiency": 0.25,
+                "wastageRate": 0.15499999999999842
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 10972800
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8702419073390296,
+                "supplyDisruption": 1,
+                "demandPressure": -0.2867825921308638,
+                "reliefEffort": 0.41833333333333333,
+                "blockadeSeverity": 0.8308573135941647,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 127
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 128,
+        "timestamp": 10972800,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.05010257016616539,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.38833333333333336,
+                "incomeShock": 0.5117159086580334
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.026111315256546107,
+                "volatility": 0.02639014341734065,
+                "priceMomentum": 0.10444526102618443,
+                "scarcityIndex": 0.5679939249999997,
+                "affordabilityIndex": 0.22031724609375025
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 33.37350000000001,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 271.1360017720829,
+                "logisticsEfficiency": 0.25,
+                "wastageRate": 0.15499999999999922
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 11059200
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.870976637264698,
+                "supplyDisruption": 1,
+                "demandPressure": -0.28771717545325837,
+                "reliefEffort": 0.42166666666666663,
+                "blockadeSeverity": 0.8313965080343623,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 128
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 129,
+        "timestamp": 11059200,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.049953713051410636,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.39,
+                "incomeShock": 0.5121229634770329
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.025924186460840087,
+                "volatility": 0.026203760634740426,
+                "priceMomentum": 0.10369674584336035,
+                "scarcityIndex": 0.5673855249999998,
+                "affordabilityIndex": 0.22079255859375013
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 33.44550000000001,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 271.7120013290622,
+                "logisticsEfficiency": 0.25,
+                "wastageRate": 0.15499999999999964
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 11145600
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8716932266438662,
+                "supplyDisruption": 1,
+                "demandPressure": -0.2886487024799075,
+                "reliefEffort": 0.425,
+                "blockadeSeverity": 0.8319205149173814,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 129
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 130,
+        "timestamp": 11145600,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.049809175532602896,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.39166666666666666,
+                "incomeShock": 0.5125194795400647
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.02573659277724244,
+                "volatility": 0.02601689349174123,
+                "priceMomentum": 0.10294637110896976,
+                "scarcityIndex": 0.5667771249999999,
+                "affordabilityIndex": 0.2212678710937501
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 33.51750000000001,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 272.28800099679665,
+                "logisticsEfficiency": 0.25,
+                "wastageRate": 0.15499999999999983
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 11232000
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8723921233682232,
+                "supplyDisruption": 1,
+                "demandPressure": -0.2895772643439034,
+                "reliefEffort": 0.42833333333333334,
+                "blockadeSeverity": 0.8324297620330429,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 130
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 131,
+        "timestamp": 11232000,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.049668832810440225,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.3933333333333333,
+                "incomeShock": 0.5129057308106143
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.025548546338207093,
+                "volatility": 0.025829554630327576,
+                "priceMomentum": 0.10219418535282837,
+                "scarcityIndex": 0.5661687249999999,
+                "affordabilityIndex": 0.22174318359375006
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 33.58950000000001,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 272.8640007475975,
+                "logisticsEfficiency": 0.25,
+                "wastageRate": 0.15499999999999992
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 11318400
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8730737642709727,
+                "supplyDisruption": 1,
+                "demandPressure": -0.29050294948679445,
+                "reliefEffort": 0.43166666666666664,
+                "blockadeSeverity": 0.8329246651215584,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 131
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 132,
+        "timestamp": 11318400,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.04953256367810616,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.39499999999999996,
+                "incomeShock": 0.5132819841003862
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.025360058958797126,
+                "volatility": 0.025641756361715395,
+                "priceMomentum": 0.1014402358351885,
+                "scarcityIndex": 0.565560325,
+                "affordabilityIndex": 0.22221849609375002
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 33.661500000000004,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 273.44000056069814,
+                "logisticsEfficiency": 0.25,
+                "wastageRate": 0.15499999999999997
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 11404800
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8737385753998683,
+                "supplyDisruption": 1,
+                "demandPressure": -0.2914258437374738,
+                "reliefEffort": 0.435,
+                "blockadeSeverity": 0.8334056282129332,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 132
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 133,
+        "timestamp": 11404800,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.04940025041817251,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.39666666666666667,
+                "incomeShock": 0.5136484992567991
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.02517114214501162,
+                "volatility": 0.02545351067503389,
+                "priceMomentum": 0.10068456858004649,
+                "scarcityIndex": 0.5649519249999999,
+                "affordabilityIndex": 0.22269380859375001
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 33.73350000000001,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 274.0160004205236,
+                "logisticsEfficiency": 0.25,
+                "wastageRate": 0.155
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 11491200
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8743869722835068,
+                "supplyDisruption": 1,
+                "demandPressure": -0.29234603038877094,
+                "reliefEffort": 0.43833333333333335,
+                "blockadeSeverity": 0.8338730439568086,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 133
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 134,
+        "timestamp": 11491200,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.049271778702453084,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.3983333333333333,
+                "incomeShock": 0.5140055293455454
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.02498180710189337,
+                "volatility": 0.02526482924577768,
+                "priceMomentum": 0.09992722840757348,
+                "scarcityIndex": 0.564343525,
+                "affordabilityIndex": 0.22316912109375006
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 33.80550000000001,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 274.59200031539274,
+                "logisticsEfficiency": 0.25,
+                "wastageRate": 0.15500000000000003
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 11577600
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8750193601910478,
+                "supplyDisruption": 1,
+                "demandPressure": -0.29326359027181104,
+                "reliefEffort": 0.44166666666666665,
+                "blockadeSeverity": 0.8343272939430149,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 134
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 135,
+        "timestamp": 11577600,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.04914703749472431,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.39999999999999997,
+                "incomeShock": 0.5143533208283434
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.024792064741423165,
+                "volatility": 0.02507572344403587,
+                "priceMomentum": 0.09916825896569266,
+                "scarcityIndex": 0.5637351249999999,
+                "affordabilityIndex": 0.22364443359375005
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 33.87750000000001,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 275.1680002365446,
+                "logisticsEfficiency": 0.25,
+                "wastageRate": 0.15500000000000003
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 11664000
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8756361343855193,
+                "supplyDisruption": 1,
+                "demandPressure": -0.294178601828208,
+                "reliefEffort": 0.445,
+                "blockadeSeverity": 0.8347687490130933,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 135
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 136,
+        "timestamp": 11664000,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.049025918956230624,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.40166666666666667,
+                "incomeShock": 0.5146921137360102
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.02459482394488499,
+                "volatility": 0.02488336364437552,
+                "priceMomentum": 0.09837929577953997,
+                "scarcityIndex": 0.5630306418725015,
+                "affordabilityIndex": 0.22413832335227668
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 33.95158778483138,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 275.74400017740845,
+                "logisticsEfficiency": 0.25036152118292143,
+                "wastageRate": 0.15498192394085394
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 11750400
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8762376803708708,
+                "supplyDisruption": 1,
+                "demandPressure": -0.29509114118015345,
+                "reliefEffort": 0.44833333333333336,
+                "blockadeSeverity": 0.8351977695630455,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 136
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 137,
+        "timestamp": 11750400,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.04890831835389526,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.4033333333333333,
+                "incomeShock": 0.5150221418369808
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.024389010887097134,
+                "volatility": 0.024685622541464166,
+                "priceMomentum": 0.09755604354838854,
+                "scarcityIndex": 0.5622443129932454,
+                "affordabilityIndex": 0.22465505378143938
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 34.028238566973734,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 276.32000013305634,
+                "logisticsEfficiency": 0.25098609083256085,
+                "wastageRate": 0.15494165742879895
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 11836800
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8768243741329248,
+                "supplyDisruption": 1,
+                "demandPressure": -0.2960012821984629,
+                "reliefEffort": 0.45166666666666666,
+                "blockadeSeverity": 0.8356147058375538,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 137
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 138,
+        "timestamp": 11836800,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.04879413397115904,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.40499999999999997,
+                "incomeShock": 0.5153436328013902
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.02417717088958507,
+                "volatility": 0.024482241880712526,
+                "priceMomentum": 0.09670868355834028,
+                "scarcityIndex": 0.561414885235559,
+                "affordabilityIndex": 0.22518875044254252
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 34.10678825595373,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 276.8960000997923,
+                "logisticsEfficiency": 0.25171757098993264,
+                "wastageRate": 0.15488495016490283
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 11923200
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8773965823743813,
+                "supplyDisruption": 1,
+                "demandPressure": -0.2969090965686379,
+                "reliefEffort": 0.455,
+                "blockadeSeverity": 0.8360198982159148,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 138
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 139,
+        "timestamp": 11923200,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.048683267021372156,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.4066666666666667,
+                "incomeShock": 0.5156568083608389
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.023961578625171644,
+                "volatility": 0.024273976578496174,
+                "priceMomentum": 0.09584631450068658,
+                "scarcityIndex": 0.5605627255255584,
+                "affordabilityIndex": 0.22573326773980987
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 34.186543852762995,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 277.47200007484423,
+                "logisticsEfficiency": 0.2524934588374248,
+                "wastageRate": 0.15481780214058016
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 12009600
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8779546627440182,
+                "supplyDisruption": 1,
+                "demandPressure": -0.2978146538550026,
+                "reliefEffort": 0.4583333333333333,
+                "blockadeSeverity": 0.8364136774899187,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 139
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 140,
+        "timestamp": 12009600,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.048575621563665995,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.4083333333333333,
+                "incomeShock": 0.5159618844639544
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.023743705759456148,
+                "volatility": 0.024061868250880164,
+                "priceMomentum": 0.09497482303782459,
+                "scarcityIndex": 0.5596984245752068,
+                "affordabilityIndex": 0.2262842453387934
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 34.2670142090506,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 278.04800005613316,
+                "logisticsEfficiency": 0.25328870695568806,
+                "wastageRate": 0.15474446572250566
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 12096000
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8784989640602335,
+                "supplyDisruption": 1,
+                "demandPressure": -0.29871802156296934,
+                "reliefEffort": 0.46166666666666667,
+                "blockadeSeverity": 0.8367963651339023,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 140
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 141,
+        "timestamp": 12096000,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.04847110442123412,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.41,
+                "incomeShock": 0.5162590714278599
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.02352440451025834,
+                "volatility": 0.023846882754631434,
+                "priceMomentum": 0.09409761804103337,
+                "scarcityIndex": 0.5588274490286298,
+                "affordabilityIndex": 0.22683898491691432
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 34.34789563129446,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 278.6240000420999,
+                "logisticsEfficiency": 0.25409325138859923,
+                "wastageRate": 0.15466757029182288
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 12182400
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8790298265290684,
+                "supplyDisruption": 1,
+                "demandPressure": -0.29961926519948867,
+                "reliefEffort": 0.465,
+                "blockadeSeverity": 0.8371682735671946,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 141
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 142,
+        "timestamp": 12182400,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.04836962510195359,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.4116666666666667,
+                "incomeShock": 0.5165485740856586
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.02330414480307574,
+                "volatility": 0.023629787574009155,
+                "priceMomentum": 0.09321657921230296,
+                "scarcityIndex": 0.5579526082546223,
+                "affordabilityIndex": 0.22739592748349516
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 34.42901277250503,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 279.200000031575,
+                "logisticsEfficiency": 0.2549030228325192,
+                "wastageRate": 0.15458863400428546
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 12268800
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8795475819568468,
+                "supplyDisruption": 1,
+                "demandPressure": -0.3005184483317362,
+                "reliefEffort": 0.4683333333333333,
+                "blockadeSeverity": 0.83752970640917,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 142
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 143,
+        "timestamp": 12268800,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.04827109572127983,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.41333333333333333,
+                "incomeShock": 0.5168305919300392
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.02308318067790736,
+                "volatility": 0.023411144815568437,
+                "priceMomentum": 0.09233272271162944,
+                "scarcityIndex": 0.5570753443746754,
+                "affordabilityIndex": 0.22795420735161254
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 34.51026831371817,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 279.77600002368126,
+                "logisticsEfficiency": 0.25571635107630264,
+                "wastageRate": 0.15450849944832762
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 12355200
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8800525539575657,
+                "supplyDisruption": 1,
+                "demandPressure": -0.30141563264408644,
+                "reliefEffort": 0.4716666666666667,
+                "blockadeSeverity": 0.8378809587271183,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 143
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 144,
+        "timestamp": 12355200,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.04817543092734987,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.415,
+                "incomeShock": 0.5171053192531045
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.022861649545848763,
+                "volatility": 0.02319134670768057,
+                "priceMomentum": 0.09144659818339505,
+                "scarcityIndex": 0.5561964001038168,
+                "affordabilityIndex": 0.2285133551153597
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 34.59160949879769,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 280.35200001776093,
+                "logisticsEfficiency": 0.25653252674261406,
+                "wastageRate": 0.1544276233870331
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 12441600
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8805450581551634,
+                "supplyDisruption": 1,
+                "demandPressure": -0.30231087799342526,
+                "reliefEffort": 0.47500000000000003,
+                "blockadeSeverity": 0.8382223172771321,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 144
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 145,
+        "timestamp": 12441600,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.048082547828231126,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.4166666666666667,
+                "incomeShock": 0.5173729452825224
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.02263962732445546,
+                "volatility": 0.022970658954390523,
+                "priceMomentum": 0.09055850929782185,
+                "scarcityIndex": 0.5553161618870469,
+                "affordabilityIndex": 0.2290731194709409
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 34.67300807926439,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 280.9280000133207,
+                "logisticsEfficiency": 0.25735122595074356,
+                "wastageRate": 0.15434625039597938
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 12528000
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8810254023807961,
+                "supplyDisruption": 1,
+                "demandPressure": -0.303204242462847,
+                "reliefEffort": 0.47833333333333333,
+                "blockadeSeverity": 0.838554060738209,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 145
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 146,
+        "timestamp": 12528000,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.04799236592125413,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.41833333333333333,
+                "incomeShock": 0.517633654314098
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.022417157939196023,
+                "volatility": 0.022749258548312723,
+                "priceMomentum": 0.08966863175678409,
+                "scarcityIndex": 0.5544348351965225,
+                "affordabilityIndex": 0.22963336622943997
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 34.754448957492514,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 281.50400000999053,
+                "logisticsEfficiency": 0.25817228014897187,
+                "wastageRate": 0.1542645111905411
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 12614400
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8814938868652412,
+                "supplyDisruption": 1,
+                "demandPressure": -0.3040957824137852,
+                "reliefEffort": 0.4816666666666667,
+                "blockadeSeverity": 0.8388764599397609,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 146
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 147,
+        "timestamp": 12614400,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.04790480702436987,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.42,
+                "incomeShock": 0.51788762584086
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.022194268770225803,
+                "volatility": 0.022527262637077956,
+                "priceMomentum": 0.08877707508090321,
+                "scarcityIndex": 0.5535525336942674,
+                "affordabilityIndex": 0.2301940230489039
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 34.8359239764368,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 282.0800000074929,
+                "logisticsEfficiency": 0.258995584015678,
+                "wastageRate": 0.15418247639448665
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 12700800
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.881950804426552,
+                "supplyDisruption": 1,
+                "demandPressure": -0.30498555253662074,
+                "reliefEffort": 0.485,
+                "blockadeSeverity": 0.8391897780827132,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 147
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 148,
+        "timestamp": 12700800,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.047819795209473714,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.4216666666666667,
+                "incomeShock": 0.5181350346787537
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.02197097863327442,
+                "volatility": 0.022304749035556543,
+                "priceMomentum": 0.08788391453309768,
+                "scarcityIndex": 0.5526693244323122,
+                "affordabilityIndex": 0.23075504988274967
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 34.91742860156896,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 282.6560000056197,
+                "logisticsEfficiency": 0.25982105858884075,
+                "wastageRate": 0.15410018526780128
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 12787200
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8823964406530783,
+                "supplyDisruption": 1,
+                "demandPressure": -0.30587360589981244,
+                "reliefEffort": 0.48833333333333334,
+                "blockadeSeverity": 0.8394942709543787,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 148
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 149,
+        "timestamp": 12787200,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.04773725673763983,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.42333333333333334,
+                "incomeShock": 0.51837605108903
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.021747301868673824,
+                "volatility": 0.022081770168803454,
+                "priceMomentum": 0.0869892074746953,
+                "scarcityIndex": 0.551785250708933,
+                "affordabilityIndex": 0.23131642343243225
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 34.99896017650134,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 283.2320000042148,
+                "logisticsEfficiency": 0.2606486364877685,
+                "wastageRate": 0.15401766080951224
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 12873600
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8828310740819681,
+                "supplyDisruption": 1,
+                "demandPressure": -0.30675999399759324,
+                "reliefEffort": 0.4916666666666667,
+                "blockadeSeverity": 0.8397901871372763,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 149
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 150,
+        "timestamp": 12873600,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.047657119996211396,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.425,
+                "incomeShock": 0.5186108408974189
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.021523250425602262,
+                "volatility": 0.021858362271522977,
+                "priceMomentum": 0.08609300170240905,
+                "scarcityIndex": 0.5509003436057045,
+                "affordabilityIndex": 0.23187812906232944
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 35.080517016492266,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 283.8080000031611,
+                "logisticsEfficiency": 0.2614782559725693,
+                "wastageRate": 0.15393491760612765
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 12960000
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8832549763732634,
+                "supplyDisruption": 1,
+                "demandPressure": -0.3076447667962728,
+                "reliefEffort": 0.495,
+                "blockadeSeverity": 0.8400777682120705,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 150
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 151,
+        "timestamp": 12960000,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.047579315437693594,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.4266666666666667,
+                "incomeShock": 0.5188395656101707
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.02129883492167535,
+                "volatility": 0.021634551331583925,
+                "priceMomentum": 0.0851953396867014,
+                "scarcityIndex": 0.5500146278049564,
+                "affordabilityIndex": 0.2324401566305751
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 35.16209794131197,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 284.38400000237084,
+                "logisticsEfficiency": 0.26230985853953753,
+                "wastageRate": 0.15385196587608696
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 13046400
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8836684124796952,
+                "supplyDisruption": 1,
+                "demandPressure": -0.30852797277918775,
+                "reliefEffort": 0.49833333333333335,
+                "blockadeSeverity": 0.8403572489547928,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 151
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 152,
+        "timestamp": 13046400,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.04750377552039783,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.42833333333333334,
+                "incomeShock": 0.519062382527048
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.021074065181608016,
+                "volatility": 0.02141035687159356,
+                "priceMomentum": 0.08429626072643207,
+                "scarcityIndex": 0.5491281245228268,
+                "affordabilityIndex": 0.23300249835221193
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 35.24370203596161,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 284.9600000017781,
+                "logisticsEfficiency": 0.2631433879317097,
+                "wastageRate": 0.153768813541458
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 13132800
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8840716408122885,
+                "supplyDisruption": 1,
+                "demandPressure": -0.30940965899033857,
+                "reliefEffort": 0.5016666666666667,
+                "blockadeSeverity": 0.840628857528509,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 152
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 153,
+        "timestamp": 13132800,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.04743043465078713,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.43,
+                "incomeShock": 0.5192794448513497
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.020848950512003566,
+                "volatility": 0.02118579432775756,
+                "priceMomentum": 0.08339580204801426,
+                "scarcityIndex": 0.5482408529899236,
+                "affordabilityIndex": 0.233565147708456
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 35.32532852859224,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 285.5360000013336,
+                "logisticsEfficiency": 0.2639787897162633,
+                "wastageRate": 0.15368546728491583
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 13219200
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8844649134018774,
+                "supplyDisruption": 1,
+                "demandPressure": -0.310289871076751,
+                "reliefEffort": 0.505,
+                "blockadeSeverity": 0.8408928156695872,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 153
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 154,
+        "timestamp": 13219200,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.047359229127474096,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.4316666666666667,
+                "incomeShock": 0.5194909017970452
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.020623499842807973,
+                "volatility": 0.020960876533777727,
+                "priceMomentum": 0.08249399937123189,
+                "scarcityIndex": 0.5473528312014836,
+                "affordabilityIndex": 0.23412809889112068
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 35.40697672833747,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 286.1120000010002,
+                "logisticsEfficiency": 0.2648160110894097,
+                "wastageRate": 0.15360193308798742
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 13305600
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8848484760566325,
+                "supplyDisruption": 1,
+                "demandPressure": -0.31116865332959964,
+                "reliefEffort": 0.5083333333333334,
+                "blockadeSeverity": 0.8411493388687197,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 154
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 155,
+        "timestamp": 13305600,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.04729009708682403,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.43333333333333335,
+                "incomeShock": 0.5196968986930934
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.02039772180148758,
+                "volatility": 0.02073561464086167,
+                "priceMomentum": 0.08159088720595031,
+                "scarcityIndex": 0.5464640763003872,
+                "affordabilityIndex": 0.2346913465195384
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 35.48864599363292,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 286.68800000075015,
+                "logisticsEfficiency": 0.26565500077301824,
+                "wastageRate": 0.1535182165053428
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 13392000
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.885222568515699,
+                "supplyDisruption": 1,
+                "demandPressure": -0.31204604872412944,
+                "reliefEffort": 0.5116666666666667,
+                "blockadeSeverity": 0.8413986365468451,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 155
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 156,
+        "timestamp": 13392000,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.047222978450117574,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.435,
+                "incomeShock": 0.5198975770850236
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.020167404144344002,
+                "volatility": 0.020508330442254603,
+                "priceMomentum": 0.08066961657737601,
+                "scarcityIndex": 0.5455177664343376,
+                "affordabilityIndex": 0.23527264724180966
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 35.57298635619815,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 287.2713533464637,
+                "logisticsEfficiency": 0.266512329693651,
+                "wastageRate": 0.15343349176798887
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 13478400
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8855874245990418,
+                "supplyDisruption": 0.9998974028086139,
+                "demandPressure": -0.3129220989584096,
+                "reliefEffort": 0.515,
+                "blockadeSeverity": 0.8416409122261168,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 156
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 157,
+        "timestamp": 13478400,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.04715781487222799,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.43666666666666665,
+                "incomeShock": 0.5200930748338475
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.019888466081033337,
+                "volatility": 0.020260384697766094,
+                "priceMomentum": 0.07955386432413335,
+                "scarcityIndex": 0.5439373598814199,
+                "affordabilityIndex": 0.23605737361063794
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 35.68764358133781,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 287.94063579131625,
+                "logisticsEfficiency": 0.26755930011695744,
+                "wastageRate": 0.15333878087814656
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 13564800
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8859432723535898,
+                "supplyDisruption": 0.9986755270880934,
+                "demandPressure": -0.3137968444909547,
+                "reliefEffort": 0.5183333333333333,
+                "blockadeSeverity": 0.8418763636960541,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 157
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 158,
+        "timestamp": 13564800,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.047094549691769995,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.4383333333333333,
+                "incomeShock": 0.5202835262123755
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.019583245096226186,
+                "volatility": 0.01998952885715013,
+                "priceMomentum": 0.07833298038490474,
+                "scarcityIndex": 0.5422018600161076,
+                "affordabilityIndex": 0.23694940715486615
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 35.81812014593435,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 288.6752910966666,
+                "logisticsEfficiency": 0.26868424100671423,
+                "wastageRate": 0.15323517838873757
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 13651200
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8862903341957735,
+                "supplyDisruption": 0.9974464979189304,
+                "demandPressure": -0.31467032457724475,
+                "reliefEffort": 0.5216666666666666,
+                "blockadeSeverity": 0.8421051831750139,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 158
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 159,
+        "timestamp": 13651200,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.04703312788267792,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.44,
+                "incomeShock": 0.5204690619990033
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.01926390356512375,
+                "volatility": 0.01969927874033958,
+                "priceMomentum": 0.077055614260495,
+                "scarcityIndex": 0.5403847845899554,
+                "affordabilityIndex": 0.23789834373567542
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 35.95690606071835,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 289.4599520770314,
+                "logisticsEfficiency": 0.26984242712883244,
+                "wastageRate": 0.15312546783792716
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 13737600
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8866288270505419,
+                "supplyDisruption": 0.9962104999912884,
+                "demandPressure": -0.3155425773051781,
+                "reliefEffort": 0.525,
+                "blockadeSeverity": 0.8423275574671151,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 159
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 160,
+        "timestamp": 13737600,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.046973496007172356,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.44166666666666665,
+                "incomeShock": 0.5206498095690375
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.018936851257675826,
+                "volatility": 0.01939430774727408,
+                "priceMomentum": 0.0757474050307033,
+                "scarcityIndex": 0.5385232647763102,
+                "affordabilityIndex": 0.23887802075423487
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 36.10013887783131,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 290.28312543118744,
+                "logisticsEfficiency": 0.27101591310331735,
+                "wastageRate": 0.15301193826379772
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 13824000
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8869589624869484,
+                "supplyDisruption": 0.9949677132079809,
+                "demandPressure": -0.3164136396294858,
+                "reliefEffort": 0.5283333333333333,
+                "blockadeSeverity": 0.8425436681147411,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 160
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 161,
+        "timestamp": 13824000,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.04691560217007561,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.4433333333333333,
+                "incomeShock": 0.5208258929836231
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.018605408610955262,
+                "volatility": 0.019078748092746553,
+                "priceMomentum": 0.07442163444382105,
+                "scarcityIndex": 0.5366360607115243,
+                "affordabilityIndex": 0.23987495291757296
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 36.245841650109945,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 291.13621102108124,
+                "logisticsEfficiency": 0.2721974669835249,
+                "wastageRate": 0.15289609578272262
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 13910400
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8872809468503875,
+                "supplyDisruption": 0.9937183128090754,
+                "demandPressure": -0.3172835474051398,
+                "reliefEffort": 0.5316666666666666,
+                "blockadeSeverity": 0.8427536915467488,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 161
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 162,
+        "timestamp": 13910400,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.04685939597443726,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.445,
+                "incomeShock": 0.5209974330763384
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.018271281823358014,
+                "volatility": 0.018755761584991138,
+                "priceMomentum": 0.07308512729343206,
+                "scarcityIndex": 0.5347326732489007,
+                "affordabilityIndex": 0.24088221786685743
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 36.39300500091376,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 292.0127702838596,
+                "logisticsEfficiency": 0.2733841436474653,
+                "wastageRate": 0.15277884070898806
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 13996800
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8875949813915678,
+                "supplyDisruption": 0.9924624694932376,
+                "demandPressure": -0.3181523354197829,
+                "reliefEffort": 0.535,
+                "blockadeSeverity": 0.842957799222501,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 162
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 163,
+        "timestamp": 13996800,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.04680482847843253,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.44666666666666666,
+                "incomeShock": 0.5211645475375166
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.01793534665789062,
+                "volatility": 0.01842759561415093,
+                "priceMomentum": 0.07174138663156247,
+                "scarcityIndex": 0.5328179422965229,
+                "affordabilityIndex": 0.24189626542284812
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 36.541113357037176,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 292.9079802902818,
+                "logisticsEfficiency": 0.2745747141150231,
+                "wastageRate": 0.15266068464874288
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 14083200
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8879012623923,
+                "supplyDisruption": 0.9912003495359104,
+                "demandPressure": -0.31902003742520946,
+                "reliefEffort": 0.5383333333333333,
+                "blockadeSeverity": 0.8431561577718437,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 163
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 164,
+        "timestamp": 14083200,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.04675185215349688,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.4483333333333333,
+                "incomeShock": 0.521327350996356
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.017598055546786333,
+                "volatility": 0.01809577958720509,
+                "priceMomentum": 0.07039222218714533,
+                "scarcityIndex": 0.5308943633965724,
+                "affordabilityIndex": 0.2429152684589253
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 36.68990212803681,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 293.8182261899982,
+                "logisticsEfficiency": 0.2757686372366128,
+                "wastageRate": 0.1525419104625408
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 14169600
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8881999812881802,
+                "supplyDisruption": 0.9899321149043977,
+                "demandPressure": -0.3198866861679245,
+                "reliefEffort": 0.5416666666666666,
+                "blockadeSeverity": 0.8433489291311388,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 164
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 165,
+        "timestamp": 14169600,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.04670042084366155,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.45,
+                "incomeShock": 0.5214859551008746
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.017259646254205778,
+                "volatility": 0.017761326254005366,
+                "priceMomentum": 0.06903858501682311,
+                "scarcityIndex": 0.5289632531851343,
+                "affordabilityIndex": 0.2439382766871565
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 36.83923391349714,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 294.740796851687,
+                "logisticsEfficiency": 0.2769656483314466,
+                "wastageRate": 0.15242267281469807
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 14256000
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8884913247882424,
+                "supplyDisruption": 0.9886579233699466,
+                "demandPressure": -0.32075231341880805,
+                "reliefEffort": 0.545,
+                "blockadeSeverity": 0.8435362706754665,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 165
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 166,
+        "timestamp": 14256000,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.04665048972605563,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.45166666666666666,
+                "incomeShock": 0.5216404685957691
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.016920247970596825,
+                "volatility": 0.01742489494064195,
+                "priceMomentum": 0.0676809918823873,
+                "scarcityIndex": 0.5270253350964227,
+                "affordabilityIndex": 0.2449647848182149
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 36.9890356497188,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 295.6736574831088,
+                "logisticsEfficiency": 0.27816559460665824,
+                "wastageRate": 0.15230305667701613
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 14342400
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.888775474991658,
+                "supplyDisruption": 0.9873779286168982,
+                "demandPressure": -0.32161695000191004,
+                "reliefEffort": 0.5483333333333333,
+                "blockadeSeverity": 0.8437183353471036,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 166
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 167,
+        "timestamp": 14342400,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.04660201527254137,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.4533333333333333,
+                "incomeShock": 0.5217909973982302
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.016579934986761177,
+                "volatility": 0.017086910959089638,
+                "priceMomentum": 0.06631973994704471,
+                "scarcityIndex": 0.5250810334664043,
+                "affordabilityIndex": 0.2459945131096421
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 37.13926679775795,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 296.61527969644766,
+                "logisticsEfficiency": 0.279368369289752,
+                "wastageRate": 0.15218310987402045
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 14428800
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8890526095015542,
+                "supplyDisruption": 0.9860922803489888,
+                "demandPressure": -0.32248062582240233,
+                "reliefEffort": 0.5516666666666666,
+                "blockadeSeverity": 0.8438952717803827,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 167
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 168,
+        "timestamp": 14428800,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.04655495521245018,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.455,
+                "incomeShock": 0.521937644671771
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.016238753762300294,
+                "volatility": 0.0167476480803739,
+                "priceMomentum": 0.06495501504920118,
+                "scarcityIndex": 0.5231306211268251,
+                "affordabilityIndex": 0.247027296204351
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 37.2899032814087,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 297.5645144571556,
+                "logisticsEfficiency": 0.2805738852473384,
+                "wastageRate": 0.1520628606746433
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 14515200
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.889322901536021,
+                "supplyDisruption": 0.9848011243928735,
+                "demandPressure": -0.3233433698937116,
+                "reliefEffort": 0.555,
+                "blockadeSeverity": 0.8440672244230343,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 168
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 169,
+        "timestamp": 14515200,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.04650926849638794,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.45666666666666667,
+                "incomeShock": 0.5220805108981178
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.01589673654986215,
+                "volatility": 0.0164072834681692,
+                "priceMomentum": 0.0635869461994486,
+                "scarcityIndex": 0.5211742934512553,
+                "affordabilityIndex": 0.24806302695981736
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 37.44092939213409,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 298.52049705759396,
+                "logisticsEfficiency": 0.28178206439931375,
+                "wastageRate": 0.15194232711735597
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 14601600
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8895865200363788,
+                "supplyDisruption": 0.9835046027989476,
+                "demandPressure": -0.3242052103638566,
+                "reliefEffort": 0.5583333333333333,
+                "blockadeSeverity": 0.844234333654112,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 169
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 170,
+        "timestamp": 14601600,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.04646491526107886,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.4583333333333333,
+                "incomeShock": 0.5222196939472181
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.015553908245325286,
+                "volatility": 0.016065933379031633,
+                "priceMomentum": 0.062215632981301144,
+                "scarcityIndex": 0.5192122055051759,
+                "affordabilityIndex": 0.249101628114265
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 37.59233371439436,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 299.4825760152398,
+                "logisticsEfficiency": 0.2829928334521235,
+                "wastageRate": 0.15182152188607181
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 14688000
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8898436297727719,
+                "supplyDisruption": 0.9822028539395329,
+                "demandPressure": -0.3250661745410143,
+                "reliefEffort": 0.5616666666666666,
+                "blockadeSeverity": 0.8443967358985949,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 170
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 171,
+        "timestamp": 14688000,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.04642185679521839,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.46,
+                "incomeShock": 0.5223552891454112
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.01521028983130357,
+                "volatility": 0.015723675959940408,
+                "priceMomentum": 0.06084115932521428,
+                "scarcityIndex": 0.5172444906967887,
+                "affordabilityIndex": 0.25014303800972987
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 37.74410707601875,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 300.45025985077143,
+                "logisticsEfficiency": 0.2842061221605383,
+                "wastageRate": 0.151700454835009
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 14774400
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.890094391447155,
+                "supplyDisruption": 0.9808960126045019,
+                "demandPressure": -0.32592628891833586,
+                "reliefEffort": 0.5650000000000001,
+                "blockadeSeverity": 0.8445545637387624,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 171
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 172,
+        "timestamp": 14774400,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.04638005550630605,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.46166666666666667,
+                "incomeShock": 0.5224873893418127
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.014865900109647577,
+                "volatility": 0.015380565619823275,
+                "priceMomentum": 0.05946360043859031,
+                "scarcityIndex": 0.5152712701561618,
+                "affordabilityIndex": 0.25118720339986095
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 37.896241517089635,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 301.4231772336271,
+                "logisticsEfficiency": 0.28542186260169106,
+                "wastageRate": 0.15157913428741993
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 14860800
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8903389617937376,
+                "supplyDisruption": 0.9795842100944071,
+                "demandPressure": -0.3267855791980351,
+                "reliefEffort": 0.5683333333333334,
+                "blockadeSeverity": 0.8447079460224325,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 172
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 173,
+        "timestamp": 14860800,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.046339474888430314,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.4633333333333333,
+                "incomeShock": 0.5226160849729597
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.014520756575338791,
+                "volatility": 0.01503664200202948,
+                "priceMomentum": 0.058083026301355166,
+                "scarcityIndex": 0.5132926574687096,
+                "affordabilityIndex": 0.2522340758231814
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 38.048729770521845,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 302.4010471252502,
+                "logisticsEfficiency": 0.2866399888548525,
+                "wastageRate": 0.15145756770096735
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 14947200
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8905774936769478,
+                "supplyDisruption": 0.9782675743111742,
+                "demandPressure": -0.32764407031477083,
+                "reliefEffort": 0.5716666666666667,
+                "blockadeSeverity": 0.8448570079681508,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 173
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 174,
+        "timestamp": 14947200,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.04630007949097821,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.465,
+                "incomeShock": 0.5227414641257607
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.01417487585974994,
+                "volatility": 0.014691935545117664,
+                "priceMomentum": 0.05669950343899976,
+                "scarcityIndex": 0.5113087610811196,
+                "affordabilityIndex": 0.25328360976870956
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 38.20156499950299,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 303.3836564025935,
+                "logisticsEfficiency": 0.28786043684431084,
+                "wastageRate": 0.15133576200826815
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 15033600
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8908101361869776,
+                "supplyDisruption": 0.9769462298464333,
+                "demandPressure": -0.32850178645834305,
+                "reliefEffort": 0.5750000000000001,
+                "blockadeSeverity": 0.8450018712674163,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 174
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 175,
+        "timestamp": 15033600,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.04626183488824317,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.4666666666666667,
+                "incomeShock": 0.5228636125987963
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.013828273957965154,
+                "volatility": 0.01434647091025666,
+                "priceMomentum": 0.055313095831860615,
+                "scarcityIndex": 0.5093196855409498,
+                "affordabilityIndex": 0.25433576174191913
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 38.35474066380536,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 304.37084308051374,
+                "logisticsEfficiency": 0.2890831442482824,
+                "wastageRate": 0.15121372379171996
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 15120000
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8910370347329688,
+                "supplyDisruption": 0.9756202980675426,
+                "demandPressure": -0.32935875109572305,
+                "reliefEffort": 0.5783333333333334,
+                "blockadeSeverity": 0.8451426541840282,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 175
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 176,
+        "timestamp": 15120000,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.04622470764990539,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.4683333333333333,
+                "incomeShock": 0.5229826139620144
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.013480966347794672,
+                "volatility": 0.014000269085271865,
+                "priceMomentum": 0.05392386539117869,
+                "scarcityIndex": 0.507325532151436,
+                "affordabilityIndex": 0.25539048978279205
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 38.50825045074402,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 305.362483726512,
+                "logisticsEfficiency": 0.29030805043500024,
+                "wastageRate": 0.15109145937410998
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 15206400
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8912583311338987,
+                "supplyDisruption": 0.9742898972013665,
+                "demandPressure": -0.3302149869924378,
+                "reliefEffort": 0.5816666666666667,
+                "blockadeSeverity": 0.8452794716506347,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 176
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 177,
+        "timestamp": 15206400,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.046188665312359836,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.47000000000000003,
+                "incomeShock": 0.5230985496148605
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.013132968054422382,
+                "volatility": 0.013653348672932072,
+                "priceMomentum": 0.052531872217689526,
+                "scarcityIndex": 0.505326399332697,
+                "affordabilityIndex": 0.2564477532109215
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 38.66208823857512,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 306.358484015864,
+                "logisticsEfficiency": 0.2915350964104205,
+                "wastageRate": 0.15096897486653396
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 15292800
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.891474163707222,
+                "supplyDisruption": 0.9729551424158687,
+                "demandPressure": -0.33107051623332584,
+                "reliefEffort": 0.5850000000000001,
+                "blockadeSeverity": 0.8454124353625616,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 177
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 178,
+        "timestamp": 15292800,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.0461536763508674,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.4716666666666667,
+                "incomeShock": 0.5232114988428861
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.01278429368770717,
+                "volatility": 0.013305726678842111,
+                "priceMomentum": 0.05113717475082868,
+                "scarcityIndex": 0.5033223828351191,
+                "affordabilityIndex": 0.2575075124847608
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 38.81624807619284,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 307.3587716400813,
+                "logisticsEfficiency": 0.292764224771301,
+                "wastageRate": 0.15084627619470192
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 15379200
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8916846673553227,
+                "supplyDisruption": 0.9716161458995771,
+                "demandPressure": -0.3319253602426846,
+                "reliefEffort": 0.5883333333333334,
+                "blockadeSeverity": 0.8455416538689986,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 178
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 179,
+        "timestamp": 15379200,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.0461197101525059,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.47333333333333333,
+                "incomeShock": 0.523321538872874
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.012434957465672502,
+                "volatility": 0.012957418993574266,
+                "priceMomentum": 0.04973982986269001,
+                "scarcityIndex": 0.5013135758779109,
+                "affordabilityIndex": 0.25856972911840204
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 38.9707241710382,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 308.3632909796115,
+                "logisticsEfficiency": 0.29399537966113376,
+                "wastageRate": 0.1507233691142943
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 15465600
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8918899736498334,
+                "supplyDisruption": 0.9702730169389743,
+                "demandPressure": -0.3327795398038259,
+                "reliefEffort": 0.5916666666666667,
+                "blockadeSeverity": 0.8456672326616168,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 179
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 180,
+        "timestamp": 15465600,
+        "deltaSeconds": 86400
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "food-market",
+            "components": {
+              "foodDemand": {
+                "baselineDemand": 100,
+                "currentDemand": 40,
+                "priceElasticity": 0.3,
+                "panicFactor": 0.0460867369898978,
+                "rationingEffectiveness": 0.6,
+                "substitutionRate": 0.47500000000000003,
+                "incomeShock": 0.52342874492652
+              },
+              "foodPrice": {
+                "baselinePrice": 100,
+                "currentPrice": 320,
+                "inflationRate": 0.012084973230963254,
+                "volatility": 0.012608440688529862,
+                "priceMomentum": 0.04833989292385302,
+                "scarcityIndex": 0.4993000692493762,
+                "affordabilityIndex": 0.25963436562750286
+              },
+              "foodSupply": {
+                "baselineProduction": 100,
+                "currentProduction": 39.12551088116872,
+                "importDependency": 0.4,
+                "resilience": 0.55,
+                "stockpile": 0,
+                "targetStockpile": 309.3719990996898,
+                "logisticsEfficiency": 0.29522850672790707,
+                "wastageRate": 0.1506002592207518
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 15552000
+              }
+            }
+          },
+          {
+            "id": "war",
+            "components": {
+              "warImpact": {
+                "intensity": 0.8920902109138716,
+                "supplyDisruption": 0.9689258619938709,
+                "demandPressure": -0.33363307507805695,
+                "reliefEffort": 0.5950000000000001,
+                "blockadeSeverity": 0.8457892742606901,
+                "policyRationing": 0.6,
+                "infrastructureDamage": 1,
+                "elapsedDays": 180
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 181,
+        "timestamp": 15552000,
+        "deltaSeconds": 86400
+      }
+    }
+  ]
+}

--- a/workspaces/verifications/food_prices_war/report.md
+++ b/workspaces/verifications/food_prices_war/report.md
@@ -1,0 +1,28 @@
+# Food prices during war — simulation summary
+
+## Form D reasoning
+- **Hypothetical:** “What happens to food prices during war?”
+- **Environment (E):** A national food market represented by a single aggregate entity capturing supply, demand, price formation, and a war impact actor that perturbs logistics and behaviour.
+- **Phenomenon (X):** Escalating warfare intensity that drives supply disruptions, blockades, policy rationing, and relief efforts.
+- **Conditions (C):** Observe the market for the duration of a 180-day conflict phase (simulated day-by-day) while war intensity remains non-zero, tracking food price levels, supply capacity, demand adjustments, and stockpiles.
+
+## Simulation implementation
+- **Components:**
+  - `warImpact` stores conflict intensity, disruption, rationing, and relief signals for the dedicated war entity, exposing levers that downstream systems consume.【F:workspaces/Describing_Simulation_0/project/plugins/simulation/components/WarImpactComponent.ts†L1-L26】
+  - `foodSupply`, `foodDemand`, and `foodPrice` components describe production, consumption, and price metrics for the aggregated market entity, including reserves, behavioural modifiers, and affordability indices.【F:workspaces/Describing_Simulation_0/project/plugins/simulation/components/FoodSupplyComponent.ts†L1-L26】【F:workspaces/Describing_Simulation_0/project/plugins/simulation/components/FoodDemandComponent.ts†L1-L22】【F:workspaces/Describing_Simulation_0/project/plugins/simulation/components/FoodPriceComponent.ts†L1-L22】
+- **Systems:**
+  - `WarImpactSystem` escalates conflict intensity, blockade severity, rationing, and relief according to elapsed time, feeding consistent shocks into the market.【F:workspaces/Describing_Simulation_0/project/plugins/simulation/systems/WarImpactSystem.ts†L1-L138】
+  - `FoodSupplySystem` maps war-induced disruptions to production, logistics efficiency, wastage, and desired stockpiles, capturing the erosion of output capacity.【F:workspaces/Describing_Simulation_0/project/plugins/simulation/systems/FoodSupplySystem.ts†L1-L138】
+  - `FoodDemandSystem` combines panic hoarding, rationing, substitution, income shocks, and price feedback to adjust effective demand.【F:workspaces/Describing_Simulation_0/project/plugins/simulation/systems/FoodDemandSystem.ts†L1-L162】
+  - `FoodPriceSystem` synthesises supply-demand gaps, stockpiles, and behavioural signals into price momentum, inflation, and affordability indicators while updating reserve drawdowns.【F:workspaces/Describing_Simulation_0/project/plugins/simulation/systems/FoodPriceSystem.ts†L1-L196】
+- **Execution harness:** A manual simulation/evaluation runner wires the systems, advances daily ticks for 180 days, collects evaluation frames, and writes the raw output and summary to `verifications/food_prices_war/raw_output.json`.【F:workspaces/Describing_Simulation_0/project/plugins/simulation/scenarios/foodPricesWar/runSimulation.ts†L1-L152】
+
+## Findings
+- **Baseline:** The market starts balanced at 100 index units for demand and supply with ample reserves (220 days of stockpile) and a price index of 100 before the conflict intensifies.【F:verifications/food_prices_war/raw_output.json†L54-L85】
+- **Panic and early depletion:** Within the first week panic buying lifts demand above baseline and draws stockpiles down rapidly; by day 9 reserves hit zero while prices already breach 111 due to tightening logistics.【F:verifications/food_prices_war/raw_output.json†L393-L417】【F:verifications/food_prices_war/raw_output.json†L668-L694】
+- **Policy rationing drives demand collapse:** Around day 58, aggressive rationing and income shocks compress effective demand to the enforced floor of 40 units even as prices temporarily dip from peak levels, signalling forced austerity rather than recovery.【F:verifications/food_prices_war/raw_output.json†L3997-L4027】
+- **Supply erosion:** Production capacity keeps falling, bottoming near 30 units around day 82 as logistics efficiency slides toward 0.25 despite growing relief efforts.【F:verifications/food_prices_war/raw_output.json†L5630-L5658】
+- **Price escalation and affordability crisis:** Prices cross 139 by day 90 and surge to the capped ceiling of 320 by day 119, driving affordability below 0.22 while stockpiles remain exhausted.【F:verifications/food_prices_war/raw_output.json†L6173-L6193】【F:verifications/food_prices_war/raw_output.json†L8145-L8174】
+- **End-state (day 180):** Supply stabilises near 39 units with logistics efficiency under 0.3, demand stays rationed at 40 units, and relief reaches ~0.6 but cannot offset near-total supply disruption, leaving the price index stuck at 320 with affordability around 0.26.【F:verifications/food_prices_war/raw_output.json†L9-L45】
+
+The raw event log supporting these observations is stored alongside this report in `raw_output.json`.【F:verifications/food_prices_war/raw_output.json†L1-L147】


### PR DESCRIPTION
## Summary
- add war impact, supply, demand, and price components plus supporting systems for a food price conflict scenario
- add a runner that executes a 180-day manual simulation and captures evaluation frames into a verification dataset
- document the Form D reasoning and simulation findings alongside the raw evaluation output

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d634527e10832a932dd58e4a622594