### PR TITLE
Add rumor spread simulation scenario and reporting artifacts

### DIFF
--- a/verifications/village_rumor/raw_output.json
+++ b/verifications/village_rumor/raw_output.json
@@ -1,0 +1,2973 @@
+{
+  "frames": [
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "amelie",
+            "components": {
+              "village/profile": {
+                "name": "Amélie",
+                "susceptibility": 1.1,
+                "expressiveness": 1,
+                "patience": 3
+              },
+              "village/rumor-state": {
+                "status": "spreader",
+                "exposure": 1.1,
+                "heardTick": 0,
+                "activeTicks": 1
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "bao",
+                  "clara"
+                ]
+              }
+            }
+          },
+          {
+            "id": "bao",
+            "components": {
+              "village/profile": {
+                "name": "Bao",
+                "susceptibility": 1.4,
+                "expressiveness": 0.8,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "ignorant",
+                "exposure": 0.85,
+                "heardTick": null,
+                "activeTicks": 0
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "amelie",
+                  "clara",
+                  "darius"
+                ]
+              }
+            }
+          },
+          {
+            "id": "clara",
+            "components": {
+              "village/profile": {
+                "name": "Clara",
+                "susceptibility": 1.2,
+                "expressiveness": 0.6,
+                "patience": 3
+              },
+              "village/rumor-state": {
+                "status": "ignorant",
+                "exposure": 0.85,
+                "heardTick": null,
+                "activeTicks": 0
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "amelie",
+                  "bao",
+                  "elin"
+                ]
+              }
+            }
+          },
+          {
+            "id": "darius",
+            "components": {
+              "village/profile": {
+                "name": "Darius",
+                "susceptibility": 1.6,
+                "expressiveness": 0.9,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "ignorant",
+                "exposure": 0,
+                "heardTick": null,
+                "activeTicks": 0
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "bao",
+                  "elin",
+                  "farah"
+                ]
+              }
+            }
+          },
+          {
+            "id": "elin",
+            "components": {
+              "village/profile": {
+                "name": "Elin",
+                "susceptibility": 1.1,
+                "expressiveness": 0.5,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "ignorant",
+                "exposure": 0,
+                "heardTick": null,
+                "activeTicks": 0
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "clara",
+                  "darius",
+                  "farah"
+                ]
+              }
+            }
+          },
+          {
+            "id": "farah",
+            "components": {
+              "village/profile": {
+                "name": "Farah",
+                "susceptibility": 1.8,
+                "expressiveness": 0.7,
+                "patience": 4
+              },
+              "village/rumor-state": {
+                "status": "ignorant",
+                "exposure": 0,
+                "heardTick": null,
+                "activeTicks": 0
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "darius",
+                  "elin"
+                ]
+              }
+            }
+          },
+          {
+            "id": "rumor-metrics",
+            "components": {
+              "village/rumor-metrics": {
+                "history": [
+                  {
+                    "tick": 1,
+                    "ignorant": 5,
+                    "spreaders": 1,
+                    "stiflers": 0,
+                    "newlyInformed": 0
+                  }
+                ],
+                "completed": false,
+                "completionTick": null
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 0.01
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 1,
+        "timestamp": 20,
+        "deltaSeconds": 0.01
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "amelie",
+            "components": {
+              "village/profile": {
+                "name": "Amélie",
+                "susceptibility": 1.1,
+                "expressiveness": 1,
+                "patience": 3
+              },
+              "village/rumor-state": {
+                "status": "spreader",
+                "exposure": 1.1,
+                "heardTick": 0,
+                "activeTicks": 2
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "bao",
+                  "clara"
+                ]
+              }
+            }
+          },
+          {
+            "id": "bao",
+            "components": {
+              "village/profile": {
+                "name": "Bao",
+                "susceptibility": 1.4,
+                "expressiveness": 0.8,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "spreader",
+                "exposure": 1.85,
+                "heardTick": 2,
+                "activeTicks": 0
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "amelie",
+                  "clara",
+                  "darius"
+                ]
+              }
+            }
+          },
+          {
+            "id": "clara",
+            "components": {
+              "village/profile": {
+                "name": "Clara",
+                "susceptibility": 1.2,
+                "expressiveness": 0.6,
+                "patience": 3
+              },
+              "village/rumor-state": {
+                "status": "spreader",
+                "exposure": 1.85,
+                "heardTick": 2,
+                "activeTicks": 0
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "amelie",
+                  "bao",
+                  "elin"
+                ]
+              }
+            }
+          },
+          {
+            "id": "darius",
+            "components": {
+              "village/profile": {
+                "name": "Darius",
+                "susceptibility": 1.6,
+                "expressiveness": 0.9,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "ignorant",
+                "exposure": 0,
+                "heardTick": null,
+                "activeTicks": 0
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "bao",
+                  "elin",
+                  "farah"
+                ]
+              }
+            }
+          },
+          {
+            "id": "elin",
+            "components": {
+              "village/profile": {
+                "name": "Elin",
+                "susceptibility": 1.1,
+                "expressiveness": 0.5,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "ignorant",
+                "exposure": 0,
+                "heardTick": null,
+                "activeTicks": 0
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "clara",
+                  "darius",
+                  "farah"
+                ]
+              }
+            }
+          },
+          {
+            "id": "farah",
+            "components": {
+              "village/profile": {
+                "name": "Farah",
+                "susceptibility": 1.8,
+                "expressiveness": 0.7,
+                "patience": 4
+              },
+              "village/rumor-state": {
+                "status": "ignorant",
+                "exposure": 0,
+                "heardTick": null,
+                "activeTicks": 0
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "darius",
+                  "elin"
+                ]
+              }
+            }
+          },
+          {
+            "id": "rumor-metrics",
+            "components": {
+              "village/rumor-metrics": {
+                "history": [
+                  {
+                    "tick": 1,
+                    "ignorant": 5,
+                    "spreaders": 1,
+                    "stiflers": 0,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 2,
+                    "ignorant": 3,
+                    "spreaders": 3,
+                    "stiflers": 0,
+                    "newlyInformed": 2
+                  }
+                ],
+                "completed": false,
+                "completionTick": null
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 0.02
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 2,
+        "timestamp": 30,
+        "deltaSeconds": 0.01
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "amelie",
+            "components": {
+              "village/profile": {
+                "name": "Amélie",
+                "susceptibility": 1.1,
+                "expressiveness": 1,
+                "patience": 3
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.1,
+                "heardTick": 0,
+                "activeTicks": 3
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "bao",
+                  "clara"
+                ]
+              }
+            }
+          },
+          {
+            "id": "bao",
+            "components": {
+              "village/profile": {
+                "name": "Bao",
+                "susceptibility": 1.4,
+                "expressiveness": 0.8,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "spreader",
+                "exposure": 1.85,
+                "heardTick": 2,
+                "activeTicks": 1
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "amelie",
+                  "clara",
+                  "darius"
+                ]
+              }
+            }
+          },
+          {
+            "id": "clara",
+            "components": {
+              "village/profile": {
+                "name": "Clara",
+                "susceptibility": 1.2,
+                "expressiveness": 0.6,
+                "patience": 3
+              },
+              "village/rumor-state": {
+                "status": "spreader",
+                "exposure": 1.85,
+                "heardTick": 2,
+                "activeTicks": 1
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "amelie",
+                  "bao",
+                  "elin"
+                ]
+              }
+            }
+          },
+          {
+            "id": "darius",
+            "components": {
+              "village/profile": {
+                "name": "Darius",
+                "susceptibility": 1.6,
+                "expressiveness": 0.9,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "ignorant",
+                "exposure": 0.65,
+                "heardTick": null,
+                "activeTicks": 0
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "bao",
+                  "elin",
+                  "farah"
+                ]
+              }
+            }
+          },
+          {
+            "id": "elin",
+            "components": {
+              "village/profile": {
+                "name": "Elin",
+                "susceptibility": 1.1,
+                "expressiveness": 0.5,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "ignorant",
+                "exposure": 0.44999999999999996,
+                "heardTick": null,
+                "activeTicks": 0
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "clara",
+                  "darius",
+                  "farah"
+                ]
+              }
+            }
+          },
+          {
+            "id": "farah",
+            "components": {
+              "village/profile": {
+                "name": "Farah",
+                "susceptibility": 1.8,
+                "expressiveness": 0.7,
+                "patience": 4
+              },
+              "village/rumor-state": {
+                "status": "ignorant",
+                "exposure": 0,
+                "heardTick": null,
+                "activeTicks": 0
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "darius",
+                  "elin"
+                ]
+              }
+            }
+          },
+          {
+            "id": "rumor-metrics",
+            "components": {
+              "village/rumor-metrics": {
+                "history": [
+                  {
+                    "tick": 1,
+                    "ignorant": 5,
+                    "spreaders": 1,
+                    "stiflers": 0,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 2,
+                    "ignorant": 3,
+                    "spreaders": 3,
+                    "stiflers": 0,
+                    "newlyInformed": 2
+                  },
+                  {
+                    "tick": 3,
+                    "ignorant": 3,
+                    "spreaders": 2,
+                    "stiflers": 1,
+                    "newlyInformed": 0
+                  }
+                ],
+                "completed": false,
+                "completionTick": null
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 0.03
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 3,
+        "timestamp": 40,
+        "deltaSeconds": 0.01
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "amelie",
+            "components": {
+              "village/profile": {
+                "name": "Amélie",
+                "susceptibility": 1.1,
+                "expressiveness": 1,
+                "patience": 3
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.1,
+                "heardTick": 0,
+                "activeTicks": 3
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "bao",
+                  "clara"
+                ]
+              }
+            }
+          },
+          {
+            "id": "bao",
+            "components": {
+              "village/profile": {
+                "name": "Bao",
+                "susceptibility": 1.4,
+                "expressiveness": 0.8,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.85,
+                "heardTick": 2,
+                "activeTicks": 2
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "amelie",
+                  "clara",
+                  "darius"
+                ]
+              }
+            }
+          },
+          {
+            "id": "clara",
+            "components": {
+              "village/profile": {
+                "name": "Clara",
+                "susceptibility": 1.2,
+                "expressiveness": 0.6,
+                "patience": 3
+              },
+              "village/rumor-state": {
+                "status": "spreader",
+                "exposure": 1.85,
+                "heardTick": 2,
+                "activeTicks": 2
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "amelie",
+                  "bao",
+                  "elin"
+                ]
+              }
+            }
+          },
+          {
+            "id": "darius",
+            "components": {
+              "village/profile": {
+                "name": "Darius",
+                "susceptibility": 1.6,
+                "expressiveness": 0.9,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "ignorant",
+                "exposure": 1.3000000000000003,
+                "heardTick": null,
+                "activeTicks": 0
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "bao",
+                  "elin",
+                  "farah"
+                ]
+              }
+            }
+          },
+          {
+            "id": "elin",
+            "components": {
+              "village/profile": {
+                "name": "Elin",
+                "susceptibility": 1.1,
+                "expressiveness": 0.5,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "ignorant",
+                "exposure": 0.8999999999999998,
+                "heardTick": null,
+                "activeTicks": 0
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "clara",
+                  "darius",
+                  "farah"
+                ]
+              }
+            }
+          },
+          {
+            "id": "farah",
+            "components": {
+              "village/profile": {
+                "name": "Farah",
+                "susceptibility": 1.8,
+                "expressiveness": 0.7,
+                "patience": 4
+              },
+              "village/rumor-state": {
+                "status": "ignorant",
+                "exposure": 0,
+                "heardTick": null,
+                "activeTicks": 0
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "darius",
+                  "elin"
+                ]
+              }
+            }
+          },
+          {
+            "id": "rumor-metrics",
+            "components": {
+              "village/rumor-metrics": {
+                "history": [
+                  {
+                    "tick": 1,
+                    "ignorant": 5,
+                    "spreaders": 1,
+                    "stiflers": 0,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 2,
+                    "ignorant": 3,
+                    "spreaders": 3,
+                    "stiflers": 0,
+                    "newlyInformed": 2
+                  },
+                  {
+                    "tick": 3,
+                    "ignorant": 3,
+                    "spreaders": 2,
+                    "stiflers": 1,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 4,
+                    "ignorant": 3,
+                    "spreaders": 1,
+                    "stiflers": 2,
+                    "newlyInformed": 0
+                  }
+                ],
+                "completed": false,
+                "completionTick": null
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 0.04
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 4,
+        "timestamp": 50,
+        "deltaSeconds": 0.01
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "amelie",
+            "components": {
+              "village/profile": {
+                "name": "Amélie",
+                "susceptibility": 1.1,
+                "expressiveness": 1,
+                "patience": 3
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.1,
+                "heardTick": 0,
+                "activeTicks": 3
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "bao",
+                  "clara"
+                ]
+              }
+            }
+          },
+          {
+            "id": "bao",
+            "components": {
+              "village/profile": {
+                "name": "Bao",
+                "susceptibility": 1.4,
+                "expressiveness": 0.8,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.85,
+                "heardTick": 2,
+                "activeTicks": 2
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "amelie",
+                  "clara",
+                  "darius"
+                ]
+              }
+            }
+          },
+          {
+            "id": "clara",
+            "components": {
+              "village/profile": {
+                "name": "Clara",
+                "susceptibility": 1.2,
+                "expressiveness": 0.6,
+                "patience": 3
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.85,
+                "heardTick": 2,
+                "activeTicks": 3
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "amelie",
+                  "bao",
+                  "elin"
+                ]
+              }
+            }
+          },
+          {
+            "id": "darius",
+            "components": {
+              "village/profile": {
+                "name": "Darius",
+                "susceptibility": 1.6,
+                "expressiveness": 0.9,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "ignorant",
+                "exposure": 1.1500000000000004,
+                "heardTick": null,
+                "activeTicks": 0
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "bao",
+                  "elin",
+                  "farah"
+                ]
+              }
+            }
+          },
+          {
+            "id": "elin",
+            "components": {
+              "village/profile": {
+                "name": "Elin",
+                "susceptibility": 1.1,
+                "expressiveness": 0.5,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "spreader",
+                "exposure": 1.4999999999999998,
+                "heardTick": 5,
+                "activeTicks": 0
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "clara",
+                  "darius",
+                  "farah"
+                ]
+              }
+            }
+          },
+          {
+            "id": "farah",
+            "components": {
+              "village/profile": {
+                "name": "Farah",
+                "susceptibility": 1.8,
+                "expressiveness": 0.7,
+                "patience": 4
+              },
+              "village/rumor-state": {
+                "status": "ignorant",
+                "exposure": 0,
+                "heardTick": null,
+                "activeTicks": 0
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "darius",
+                  "elin"
+                ]
+              }
+            }
+          },
+          {
+            "id": "rumor-metrics",
+            "components": {
+              "village/rumor-metrics": {
+                "history": [
+                  {
+                    "tick": 1,
+                    "ignorant": 5,
+                    "spreaders": 1,
+                    "stiflers": 0,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 2,
+                    "ignorant": 3,
+                    "spreaders": 3,
+                    "stiflers": 0,
+                    "newlyInformed": 2
+                  },
+                  {
+                    "tick": 3,
+                    "ignorant": 3,
+                    "spreaders": 2,
+                    "stiflers": 1,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 4,
+                    "ignorant": 3,
+                    "spreaders": 1,
+                    "stiflers": 2,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 5,
+                    "ignorant": 2,
+                    "spreaders": 1,
+                    "stiflers": 3,
+                    "newlyInformed": 1
+                  }
+                ],
+                "completed": false,
+                "completionTick": null
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 0.05
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 5,
+        "timestamp": 60,
+        "deltaSeconds": 0.01
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "amelie",
+            "components": {
+              "village/profile": {
+                "name": "Amélie",
+                "susceptibility": 1.1,
+                "expressiveness": 1,
+                "patience": 3
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.1,
+                "heardTick": 0,
+                "activeTicks": 3
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "bao",
+                  "clara"
+                ]
+              }
+            }
+          },
+          {
+            "id": "bao",
+            "components": {
+              "village/profile": {
+                "name": "Bao",
+                "susceptibility": 1.4,
+                "expressiveness": 0.8,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.85,
+                "heardTick": 2,
+                "activeTicks": 2
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "amelie",
+                  "clara",
+                  "darius"
+                ]
+              }
+            }
+          },
+          {
+            "id": "clara",
+            "components": {
+              "village/profile": {
+                "name": "Clara",
+                "susceptibility": 1.2,
+                "expressiveness": 0.6,
+                "patience": 3
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.85,
+                "heardTick": 2,
+                "activeTicks": 3
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "amelie",
+                  "bao",
+                  "elin"
+                ]
+              }
+            }
+          },
+          {
+            "id": "darius",
+            "components": {
+              "village/profile": {
+                "name": "Darius",
+                "susceptibility": 1.6,
+                "expressiveness": 0.9,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "spreader",
+                "exposure": 1.6500000000000004,
+                "heardTick": 6,
+                "activeTicks": 0
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "bao",
+                  "elin",
+                  "farah"
+                ]
+              }
+            }
+          },
+          {
+            "id": "elin",
+            "components": {
+              "village/profile": {
+                "name": "Elin",
+                "susceptibility": 1.1,
+                "expressiveness": 0.5,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "spreader",
+                "exposure": 1.4999999999999998,
+                "heardTick": 5,
+                "activeTicks": 1
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "clara",
+                  "darius",
+                  "farah"
+                ]
+              }
+            }
+          },
+          {
+            "id": "farah",
+            "components": {
+              "village/profile": {
+                "name": "Farah",
+                "susceptibility": 1.8,
+                "expressiveness": 0.7,
+                "patience": 4
+              },
+              "village/rumor-state": {
+                "status": "ignorant",
+                "exposure": 0.35,
+                "heardTick": null,
+                "activeTicks": 0
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "darius",
+                  "elin"
+                ]
+              }
+            }
+          },
+          {
+            "id": "rumor-metrics",
+            "components": {
+              "village/rumor-metrics": {
+                "history": [
+                  {
+                    "tick": 1,
+                    "ignorant": 5,
+                    "spreaders": 1,
+                    "stiflers": 0,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 2,
+                    "ignorant": 3,
+                    "spreaders": 3,
+                    "stiflers": 0,
+                    "newlyInformed": 2
+                  },
+                  {
+                    "tick": 3,
+                    "ignorant": 3,
+                    "spreaders": 2,
+                    "stiflers": 1,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 4,
+                    "ignorant": 3,
+                    "spreaders": 1,
+                    "stiflers": 2,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 5,
+                    "ignorant": 2,
+                    "spreaders": 1,
+                    "stiflers": 3,
+                    "newlyInformed": 1
+                  },
+                  {
+                    "tick": 6,
+                    "ignorant": 1,
+                    "spreaders": 2,
+                    "stiflers": 3,
+                    "newlyInformed": 1
+                  }
+                ],
+                "completed": false,
+                "completionTick": null
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 0.060000000000000005
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 6,
+        "timestamp": 70,
+        "deltaSeconds": 0.01
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "amelie",
+            "components": {
+              "village/profile": {
+                "name": "Amélie",
+                "susceptibility": 1.1,
+                "expressiveness": 1,
+                "patience": 3
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.1,
+                "heardTick": 0,
+                "activeTicks": 3
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "bao",
+                  "clara"
+                ]
+              }
+            }
+          },
+          {
+            "id": "bao",
+            "components": {
+              "village/profile": {
+                "name": "Bao",
+                "susceptibility": 1.4,
+                "expressiveness": 0.8,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.85,
+                "heardTick": 2,
+                "activeTicks": 2
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "amelie",
+                  "clara",
+                  "darius"
+                ]
+              }
+            }
+          },
+          {
+            "id": "clara",
+            "components": {
+              "village/profile": {
+                "name": "Clara",
+                "susceptibility": 1.2,
+                "expressiveness": 0.6,
+                "patience": 3
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.85,
+                "heardTick": 2,
+                "activeTicks": 3
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "amelie",
+                  "bao",
+                  "elin"
+                ]
+              }
+            }
+          },
+          {
+            "id": "darius",
+            "components": {
+              "village/profile": {
+                "name": "Darius",
+                "susceptibility": 1.6,
+                "expressiveness": 0.9,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "spreader",
+                "exposure": 1.6500000000000004,
+                "heardTick": 6,
+                "activeTicks": 1
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "bao",
+                  "elin",
+                  "farah"
+                ]
+              }
+            }
+          },
+          {
+            "id": "elin",
+            "components": {
+              "village/profile": {
+                "name": "Elin",
+                "susceptibility": 1.1,
+                "expressiveness": 0.5,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.4999999999999998,
+                "heardTick": 5,
+                "activeTicks": 2
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "clara",
+                  "darius",
+                  "farah"
+                ]
+              }
+            }
+          },
+          {
+            "id": "farah",
+            "components": {
+              "village/profile": {
+                "name": "Farah",
+                "susceptibility": 1.8,
+                "expressiveness": 0.7,
+                "patience": 4
+              },
+              "village/rumor-state": {
+                "status": "ignorant",
+                "exposure": 1.6,
+                "heardTick": null,
+                "activeTicks": 0
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "darius",
+                  "elin"
+                ]
+              }
+            }
+          },
+          {
+            "id": "rumor-metrics",
+            "components": {
+              "village/rumor-metrics": {
+                "history": [
+                  {
+                    "tick": 1,
+                    "ignorant": 5,
+                    "spreaders": 1,
+                    "stiflers": 0,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 2,
+                    "ignorant": 3,
+                    "spreaders": 3,
+                    "stiflers": 0,
+                    "newlyInformed": 2
+                  },
+                  {
+                    "tick": 3,
+                    "ignorant": 3,
+                    "spreaders": 2,
+                    "stiflers": 1,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 4,
+                    "ignorant": 3,
+                    "spreaders": 1,
+                    "stiflers": 2,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 5,
+                    "ignorant": 2,
+                    "spreaders": 1,
+                    "stiflers": 3,
+                    "newlyInformed": 1
+                  },
+                  {
+                    "tick": 6,
+                    "ignorant": 1,
+                    "spreaders": 2,
+                    "stiflers": 3,
+                    "newlyInformed": 1
+                  },
+                  {
+                    "tick": 7,
+                    "ignorant": 1,
+                    "spreaders": 1,
+                    "stiflers": 4,
+                    "newlyInformed": 0
+                  }
+                ],
+                "completed": false,
+                "completionTick": null
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 0.07
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 7,
+        "timestamp": 80,
+        "deltaSeconds": 0.01
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "amelie",
+            "components": {
+              "village/profile": {
+                "name": "Amélie",
+                "susceptibility": 1.1,
+                "expressiveness": 1,
+                "patience": 3
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.1,
+                "heardTick": 0,
+                "activeTicks": 3
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "bao",
+                  "clara"
+                ]
+              }
+            }
+          },
+          {
+            "id": "bao",
+            "components": {
+              "village/profile": {
+                "name": "Bao",
+                "susceptibility": 1.4,
+                "expressiveness": 0.8,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.85,
+                "heardTick": 2,
+                "activeTicks": 2
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "amelie",
+                  "clara",
+                  "darius"
+                ]
+              }
+            }
+          },
+          {
+            "id": "clara",
+            "components": {
+              "village/profile": {
+                "name": "Clara",
+                "susceptibility": 1.2,
+                "expressiveness": 0.6,
+                "patience": 3
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.85,
+                "heardTick": 2,
+                "activeTicks": 3
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "amelie",
+                  "bao",
+                  "elin"
+                ]
+              }
+            }
+          },
+          {
+            "id": "darius",
+            "components": {
+              "village/profile": {
+                "name": "Darius",
+                "susceptibility": 1.6,
+                "expressiveness": 0.9,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.6500000000000004,
+                "heardTick": 6,
+                "activeTicks": 2
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "bao",
+                  "elin",
+                  "farah"
+                ]
+              }
+            }
+          },
+          {
+            "id": "elin",
+            "components": {
+              "village/profile": {
+                "name": "Elin",
+                "susceptibility": 1.1,
+                "expressiveness": 0.5,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.4999999999999998,
+                "heardTick": 5,
+                "activeTicks": 2
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "clara",
+                  "darius",
+                  "farah"
+                ]
+              }
+            }
+          },
+          {
+            "id": "farah",
+            "components": {
+              "village/profile": {
+                "name": "Farah",
+                "susceptibility": 1.8,
+                "expressiveness": 0.7,
+                "patience": 4
+              },
+              "village/rumor-state": {
+                "status": "spreader",
+                "exposure": 2.5,
+                "heardTick": 8,
+                "activeTicks": 0
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "darius",
+                  "elin"
+                ]
+              }
+            }
+          },
+          {
+            "id": "rumor-metrics",
+            "components": {
+              "village/rumor-metrics": {
+                "history": [
+                  {
+                    "tick": 1,
+                    "ignorant": 5,
+                    "spreaders": 1,
+                    "stiflers": 0,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 2,
+                    "ignorant": 3,
+                    "spreaders": 3,
+                    "stiflers": 0,
+                    "newlyInformed": 2
+                  },
+                  {
+                    "tick": 3,
+                    "ignorant": 3,
+                    "spreaders": 2,
+                    "stiflers": 1,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 4,
+                    "ignorant": 3,
+                    "spreaders": 1,
+                    "stiflers": 2,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 5,
+                    "ignorant": 2,
+                    "spreaders": 1,
+                    "stiflers": 3,
+                    "newlyInformed": 1
+                  },
+                  {
+                    "tick": 6,
+                    "ignorant": 1,
+                    "spreaders": 2,
+                    "stiflers": 3,
+                    "newlyInformed": 1
+                  },
+                  {
+                    "tick": 7,
+                    "ignorant": 1,
+                    "spreaders": 1,
+                    "stiflers": 4,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 8,
+                    "ignorant": 0,
+                    "spreaders": 1,
+                    "stiflers": 5,
+                    "newlyInformed": 1
+                  }
+                ],
+                "completed": false,
+                "completionTick": null
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 0.08
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 8,
+        "timestamp": 90,
+        "deltaSeconds": 0.01
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "amelie",
+            "components": {
+              "village/profile": {
+                "name": "Amélie",
+                "susceptibility": 1.1,
+                "expressiveness": 1,
+                "patience": 3
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.1,
+                "heardTick": 0,
+                "activeTicks": 3
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "bao",
+                  "clara"
+                ]
+              }
+            }
+          },
+          {
+            "id": "bao",
+            "components": {
+              "village/profile": {
+                "name": "Bao",
+                "susceptibility": 1.4,
+                "expressiveness": 0.8,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.85,
+                "heardTick": 2,
+                "activeTicks": 2
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "amelie",
+                  "clara",
+                  "darius"
+                ]
+              }
+            }
+          },
+          {
+            "id": "clara",
+            "components": {
+              "village/profile": {
+                "name": "Clara",
+                "susceptibility": 1.2,
+                "expressiveness": 0.6,
+                "patience": 3
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.85,
+                "heardTick": 2,
+                "activeTicks": 3
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "amelie",
+                  "bao",
+                  "elin"
+                ]
+              }
+            }
+          },
+          {
+            "id": "darius",
+            "components": {
+              "village/profile": {
+                "name": "Darius",
+                "susceptibility": 1.6,
+                "expressiveness": 0.9,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.6500000000000004,
+                "heardTick": 6,
+                "activeTicks": 2
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "bao",
+                  "elin",
+                  "farah"
+                ]
+              }
+            }
+          },
+          {
+            "id": "elin",
+            "components": {
+              "village/profile": {
+                "name": "Elin",
+                "susceptibility": 1.1,
+                "expressiveness": 0.5,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.4999999999999998,
+                "heardTick": 5,
+                "activeTicks": 2
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "clara",
+                  "darius",
+                  "farah"
+                ]
+              }
+            }
+          },
+          {
+            "id": "farah",
+            "components": {
+              "village/profile": {
+                "name": "Farah",
+                "susceptibility": 1.8,
+                "expressiveness": 0.7,
+                "patience": 4
+              },
+              "village/rumor-state": {
+                "status": "spreader",
+                "exposure": 2.5,
+                "heardTick": 8,
+                "activeTicks": 1
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "darius",
+                  "elin"
+                ]
+              }
+            }
+          },
+          {
+            "id": "rumor-metrics",
+            "components": {
+              "village/rumor-metrics": {
+                "history": [
+                  {
+                    "tick": 1,
+                    "ignorant": 5,
+                    "spreaders": 1,
+                    "stiflers": 0,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 2,
+                    "ignorant": 3,
+                    "spreaders": 3,
+                    "stiflers": 0,
+                    "newlyInformed": 2
+                  },
+                  {
+                    "tick": 3,
+                    "ignorant": 3,
+                    "spreaders": 2,
+                    "stiflers": 1,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 4,
+                    "ignorant": 3,
+                    "spreaders": 1,
+                    "stiflers": 2,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 5,
+                    "ignorant": 2,
+                    "spreaders": 1,
+                    "stiflers": 3,
+                    "newlyInformed": 1
+                  },
+                  {
+                    "tick": 6,
+                    "ignorant": 1,
+                    "spreaders": 2,
+                    "stiflers": 3,
+                    "newlyInformed": 1
+                  },
+                  {
+                    "tick": 7,
+                    "ignorant": 1,
+                    "spreaders": 1,
+                    "stiflers": 4,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 8,
+                    "ignorant": 0,
+                    "spreaders": 1,
+                    "stiflers": 5,
+                    "newlyInformed": 1
+                  },
+                  {
+                    "tick": 9,
+                    "ignorant": 0,
+                    "spreaders": 1,
+                    "stiflers": 5,
+                    "newlyInformed": 0
+                  }
+                ],
+                "completed": false,
+                "completionTick": null
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 0.09
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 9,
+        "timestamp": 100,
+        "deltaSeconds": 0.01
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "amelie",
+            "components": {
+              "village/profile": {
+                "name": "Amélie",
+                "susceptibility": 1.1,
+                "expressiveness": 1,
+                "patience": 3
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.1,
+                "heardTick": 0,
+                "activeTicks": 3
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "bao",
+                  "clara"
+                ]
+              }
+            }
+          },
+          {
+            "id": "bao",
+            "components": {
+              "village/profile": {
+                "name": "Bao",
+                "susceptibility": 1.4,
+                "expressiveness": 0.8,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.85,
+                "heardTick": 2,
+                "activeTicks": 2
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "amelie",
+                  "clara",
+                  "darius"
+                ]
+              }
+            }
+          },
+          {
+            "id": "clara",
+            "components": {
+              "village/profile": {
+                "name": "Clara",
+                "susceptibility": 1.2,
+                "expressiveness": 0.6,
+                "patience": 3
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.85,
+                "heardTick": 2,
+                "activeTicks": 3
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "amelie",
+                  "bao",
+                  "elin"
+                ]
+              }
+            }
+          },
+          {
+            "id": "darius",
+            "components": {
+              "village/profile": {
+                "name": "Darius",
+                "susceptibility": 1.6,
+                "expressiveness": 0.9,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.6500000000000004,
+                "heardTick": 6,
+                "activeTicks": 2
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "bao",
+                  "elin",
+                  "farah"
+                ]
+              }
+            }
+          },
+          {
+            "id": "elin",
+            "components": {
+              "village/profile": {
+                "name": "Elin",
+                "susceptibility": 1.1,
+                "expressiveness": 0.5,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.4999999999999998,
+                "heardTick": 5,
+                "activeTicks": 2
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "clara",
+                  "darius",
+                  "farah"
+                ]
+              }
+            }
+          },
+          {
+            "id": "farah",
+            "components": {
+              "village/profile": {
+                "name": "Farah",
+                "susceptibility": 1.8,
+                "expressiveness": 0.7,
+                "patience": 4
+              },
+              "village/rumor-state": {
+                "status": "spreader",
+                "exposure": 2.5,
+                "heardTick": 8,
+                "activeTicks": 2
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "darius",
+                  "elin"
+                ]
+              }
+            }
+          },
+          {
+            "id": "rumor-metrics",
+            "components": {
+              "village/rumor-metrics": {
+                "history": [
+                  {
+                    "tick": 1,
+                    "ignorant": 5,
+                    "spreaders": 1,
+                    "stiflers": 0,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 2,
+                    "ignorant": 3,
+                    "spreaders": 3,
+                    "stiflers": 0,
+                    "newlyInformed": 2
+                  },
+                  {
+                    "tick": 3,
+                    "ignorant": 3,
+                    "spreaders": 2,
+                    "stiflers": 1,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 4,
+                    "ignorant": 3,
+                    "spreaders": 1,
+                    "stiflers": 2,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 5,
+                    "ignorant": 2,
+                    "spreaders": 1,
+                    "stiflers": 3,
+                    "newlyInformed": 1
+                  },
+                  {
+                    "tick": 6,
+                    "ignorant": 1,
+                    "spreaders": 2,
+                    "stiflers": 3,
+                    "newlyInformed": 1
+                  },
+                  {
+                    "tick": 7,
+                    "ignorant": 1,
+                    "spreaders": 1,
+                    "stiflers": 4,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 8,
+                    "ignorant": 0,
+                    "spreaders": 1,
+                    "stiflers": 5,
+                    "newlyInformed": 1
+                  },
+                  {
+                    "tick": 9,
+                    "ignorant": 0,
+                    "spreaders": 1,
+                    "stiflers": 5,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 10,
+                    "ignorant": 0,
+                    "spreaders": 1,
+                    "stiflers": 5,
+                    "newlyInformed": 0
+                  }
+                ],
+                "completed": false,
+                "completionTick": null
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 0.09999999999999999
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 10,
+        "timestamp": 110,
+        "deltaSeconds": 0.01
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "amelie",
+            "components": {
+              "village/profile": {
+                "name": "Amélie",
+                "susceptibility": 1.1,
+                "expressiveness": 1,
+                "patience": 3
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.1,
+                "heardTick": 0,
+                "activeTicks": 3
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "bao",
+                  "clara"
+                ]
+              }
+            }
+          },
+          {
+            "id": "bao",
+            "components": {
+              "village/profile": {
+                "name": "Bao",
+                "susceptibility": 1.4,
+                "expressiveness": 0.8,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.85,
+                "heardTick": 2,
+                "activeTicks": 2
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "amelie",
+                  "clara",
+                  "darius"
+                ]
+              }
+            }
+          },
+          {
+            "id": "clara",
+            "components": {
+              "village/profile": {
+                "name": "Clara",
+                "susceptibility": 1.2,
+                "expressiveness": 0.6,
+                "patience": 3
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.85,
+                "heardTick": 2,
+                "activeTicks": 3
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "amelie",
+                  "bao",
+                  "elin"
+                ]
+              }
+            }
+          },
+          {
+            "id": "darius",
+            "components": {
+              "village/profile": {
+                "name": "Darius",
+                "susceptibility": 1.6,
+                "expressiveness": 0.9,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.6500000000000004,
+                "heardTick": 6,
+                "activeTicks": 2
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "bao",
+                  "elin",
+                  "farah"
+                ]
+              }
+            }
+          },
+          {
+            "id": "elin",
+            "components": {
+              "village/profile": {
+                "name": "Elin",
+                "susceptibility": 1.1,
+                "expressiveness": 0.5,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.4999999999999998,
+                "heardTick": 5,
+                "activeTicks": 2
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "clara",
+                  "darius",
+                  "farah"
+                ]
+              }
+            }
+          },
+          {
+            "id": "farah",
+            "components": {
+              "village/profile": {
+                "name": "Farah",
+                "susceptibility": 1.8,
+                "expressiveness": 0.7,
+                "patience": 4
+              },
+              "village/rumor-state": {
+                "status": "spreader",
+                "exposure": 2.5,
+                "heardTick": 8,
+                "activeTicks": 3
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "darius",
+                  "elin"
+                ]
+              }
+            }
+          },
+          {
+            "id": "rumor-metrics",
+            "components": {
+              "village/rumor-metrics": {
+                "history": [
+                  {
+                    "tick": 1,
+                    "ignorant": 5,
+                    "spreaders": 1,
+                    "stiflers": 0,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 2,
+                    "ignorant": 3,
+                    "spreaders": 3,
+                    "stiflers": 0,
+                    "newlyInformed": 2
+                  },
+                  {
+                    "tick": 3,
+                    "ignorant": 3,
+                    "spreaders": 2,
+                    "stiflers": 1,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 4,
+                    "ignorant": 3,
+                    "spreaders": 1,
+                    "stiflers": 2,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 5,
+                    "ignorant": 2,
+                    "spreaders": 1,
+                    "stiflers": 3,
+                    "newlyInformed": 1
+                  },
+                  {
+                    "tick": 6,
+                    "ignorant": 1,
+                    "spreaders": 2,
+                    "stiflers": 3,
+                    "newlyInformed": 1
+                  },
+                  {
+                    "tick": 7,
+                    "ignorant": 1,
+                    "spreaders": 1,
+                    "stiflers": 4,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 8,
+                    "ignorant": 0,
+                    "spreaders": 1,
+                    "stiflers": 5,
+                    "newlyInformed": 1
+                  },
+                  {
+                    "tick": 9,
+                    "ignorant": 0,
+                    "spreaders": 1,
+                    "stiflers": 5,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 10,
+                    "ignorant": 0,
+                    "spreaders": 1,
+                    "stiflers": 5,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 11,
+                    "ignorant": 0,
+                    "spreaders": 1,
+                    "stiflers": 5,
+                    "newlyInformed": 0
+                  }
+                ],
+                "completed": false,
+                "completionTick": null
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 0.10999999999999999
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 11,
+        "timestamp": 120,
+        "deltaSeconds": 0.01
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "amelie",
+            "components": {
+              "village/profile": {
+                "name": "Amélie",
+                "susceptibility": 1.1,
+                "expressiveness": 1,
+                "patience": 3
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.1,
+                "heardTick": 0,
+                "activeTicks": 3
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "bao",
+                  "clara"
+                ]
+              }
+            }
+          },
+          {
+            "id": "bao",
+            "components": {
+              "village/profile": {
+                "name": "Bao",
+                "susceptibility": 1.4,
+                "expressiveness": 0.8,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.85,
+                "heardTick": 2,
+                "activeTicks": 2
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "amelie",
+                  "clara",
+                  "darius"
+                ]
+              }
+            }
+          },
+          {
+            "id": "clara",
+            "components": {
+              "village/profile": {
+                "name": "Clara",
+                "susceptibility": 1.2,
+                "expressiveness": 0.6,
+                "patience": 3
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.85,
+                "heardTick": 2,
+                "activeTicks": 3
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "amelie",
+                  "bao",
+                  "elin"
+                ]
+              }
+            }
+          },
+          {
+            "id": "darius",
+            "components": {
+              "village/profile": {
+                "name": "Darius",
+                "susceptibility": 1.6,
+                "expressiveness": 0.9,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.6500000000000004,
+                "heardTick": 6,
+                "activeTicks": 2
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "bao",
+                  "elin",
+                  "farah"
+                ]
+              }
+            }
+          },
+          {
+            "id": "elin",
+            "components": {
+              "village/profile": {
+                "name": "Elin",
+                "susceptibility": 1.1,
+                "expressiveness": 0.5,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.4999999999999998,
+                "heardTick": 5,
+                "activeTicks": 2
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "clara",
+                  "darius",
+                  "farah"
+                ]
+              }
+            }
+          },
+          {
+            "id": "farah",
+            "components": {
+              "village/profile": {
+                "name": "Farah",
+                "susceptibility": 1.8,
+                "expressiveness": 0.7,
+                "patience": 4
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 2.5,
+                "heardTick": 8,
+                "activeTicks": 4
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "darius",
+                  "elin"
+                ]
+              }
+            }
+          },
+          {
+            "id": "rumor-metrics",
+            "components": {
+              "village/rumor-metrics": {
+                "history": [
+                  {
+                    "tick": 1,
+                    "ignorant": 5,
+                    "spreaders": 1,
+                    "stiflers": 0,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 2,
+                    "ignorant": 3,
+                    "spreaders": 3,
+                    "stiflers": 0,
+                    "newlyInformed": 2
+                  },
+                  {
+                    "tick": 3,
+                    "ignorant": 3,
+                    "spreaders": 2,
+                    "stiflers": 1,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 4,
+                    "ignorant": 3,
+                    "spreaders": 1,
+                    "stiflers": 2,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 5,
+                    "ignorant": 2,
+                    "spreaders": 1,
+                    "stiflers": 3,
+                    "newlyInformed": 1
+                  },
+                  {
+                    "tick": 6,
+                    "ignorant": 1,
+                    "spreaders": 2,
+                    "stiflers": 3,
+                    "newlyInformed": 1
+                  },
+                  {
+                    "tick": 7,
+                    "ignorant": 1,
+                    "spreaders": 1,
+                    "stiflers": 4,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 8,
+                    "ignorant": 0,
+                    "spreaders": 1,
+                    "stiflers": 5,
+                    "newlyInformed": 1
+                  },
+                  {
+                    "tick": 9,
+                    "ignorant": 0,
+                    "spreaders": 1,
+                    "stiflers": 5,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 10,
+                    "ignorant": 0,
+                    "spreaders": 1,
+                    "stiflers": 5,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 11,
+                    "ignorant": 0,
+                    "spreaders": 1,
+                    "stiflers": 5,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 12,
+                    "ignorant": 0,
+                    "spreaders": 0,
+                    "stiflers": 6,
+                    "newlyInformed": 0
+                  }
+                ],
+                "completed": true,
+                "completionTick": 12
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 0.11999999999999998
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 12,
+        "timestamp": 130,
+        "deltaSeconds": 0.01
+      }
+    },
+    {
+      "type": "evaluation/frame",
+      "payload": {
+        "entities": [
+          {
+            "id": "amelie",
+            "components": {
+              "village/profile": {
+                "name": "Amélie",
+                "susceptibility": 1.1,
+                "expressiveness": 1,
+                "patience": 3
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.1,
+                "heardTick": 0,
+                "activeTicks": 3
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "bao",
+                  "clara"
+                ]
+              }
+            }
+          },
+          {
+            "id": "bao",
+            "components": {
+              "village/profile": {
+                "name": "Bao",
+                "susceptibility": 1.4,
+                "expressiveness": 0.8,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.85,
+                "heardTick": 2,
+                "activeTicks": 2
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "amelie",
+                  "clara",
+                  "darius"
+                ]
+              }
+            }
+          },
+          {
+            "id": "clara",
+            "components": {
+              "village/profile": {
+                "name": "Clara",
+                "susceptibility": 1.2,
+                "expressiveness": 0.6,
+                "patience": 3
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.85,
+                "heardTick": 2,
+                "activeTicks": 3
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "amelie",
+                  "bao",
+                  "elin"
+                ]
+              }
+            }
+          },
+          {
+            "id": "darius",
+            "components": {
+              "village/profile": {
+                "name": "Darius",
+                "susceptibility": 1.6,
+                "expressiveness": 0.9,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.6500000000000004,
+                "heardTick": 6,
+                "activeTicks": 2
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "bao",
+                  "elin",
+                  "farah"
+                ]
+              }
+            }
+          },
+          {
+            "id": "elin",
+            "components": {
+              "village/profile": {
+                "name": "Elin",
+                "susceptibility": 1.1,
+                "expressiveness": 0.5,
+                "patience": 2
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 1.4999999999999998,
+                "heardTick": 5,
+                "activeTicks": 2
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "clara",
+                  "darius",
+                  "farah"
+                ]
+              }
+            }
+          },
+          {
+            "id": "farah",
+            "components": {
+              "village/profile": {
+                "name": "Farah",
+                "susceptibility": 1.8,
+                "expressiveness": 0.7,
+                "patience": 4
+              },
+              "village/rumor-state": {
+                "status": "stifler",
+                "exposure": 2.5,
+                "heardTick": 8,
+                "activeTicks": 4
+              },
+              "village/social-network": {
+                "neighbors": [
+                  "darius",
+                  "elin"
+                ]
+              }
+            }
+          },
+          {
+            "id": "rumor-metrics",
+            "components": {
+              "village/rumor-metrics": {
+                "history": [
+                  {
+                    "tick": 1,
+                    "ignorant": 5,
+                    "spreaders": 1,
+                    "stiflers": 0,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 2,
+                    "ignorant": 3,
+                    "spreaders": 3,
+                    "stiflers": 0,
+                    "newlyInformed": 2
+                  },
+                  {
+                    "tick": 3,
+                    "ignorant": 3,
+                    "spreaders": 2,
+                    "stiflers": 1,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 4,
+                    "ignorant": 3,
+                    "spreaders": 1,
+                    "stiflers": 2,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 5,
+                    "ignorant": 2,
+                    "spreaders": 1,
+                    "stiflers": 3,
+                    "newlyInformed": 1
+                  },
+                  {
+                    "tick": 6,
+                    "ignorant": 1,
+                    "spreaders": 2,
+                    "stiflers": 3,
+                    "newlyInformed": 1
+                  },
+                  {
+                    "tick": 7,
+                    "ignorant": 1,
+                    "spreaders": 1,
+                    "stiflers": 4,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 8,
+                    "ignorant": 0,
+                    "spreaders": 1,
+                    "stiflers": 5,
+                    "newlyInformed": 1
+                  },
+                  {
+                    "tick": 9,
+                    "ignorant": 0,
+                    "spreaders": 1,
+                    "stiflers": 5,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 10,
+                    "ignorant": 0,
+                    "spreaders": 1,
+                    "stiflers": 5,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 11,
+                    "ignorant": 0,
+                    "spreaders": 1,
+                    "stiflers": 5,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 12,
+                    "ignorant": 0,
+                    "spreaders": 0,
+                    "stiflers": 6,
+                    "newlyInformed": 0
+                  },
+                  {
+                    "tick": 13,
+                    "ignorant": 0,
+                    "spreaders": 0,
+                    "stiflers": 6,
+                    "newlyInformed": 0
+                  }
+                ],
+                "completed": true,
+                "completionTick": 12
+              }
+            }
+          },
+          {
+            "id": "time",
+            "components": {
+              "time": {
+                "elapsed": 0.12999999999999998
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "tick": 13,
+        "timestamp": 140,
+        "deltaSeconds": 0.01
+      }
+    }
+  ],
+  "villagers": [
+    {
+      "id": "amelie",
+      "name": "Amélie",
+      "neighbors": [
+        "bao",
+        "clara"
+      ],
+      "susceptibility": 1.1,
+      "expressiveness": 1,
+      "patience": 3,
+      "initialStatus": "spreader"
+    },
+    {
+      "id": "bao",
+      "name": "Bao",
+      "neighbors": [
+        "amelie",
+        "clara",
+        "darius"
+      ],
+      "susceptibility": 1.4,
+      "expressiveness": 0.8,
+      "patience": 2,
+      "initialStatus": "ignorant"
+    },
+    {
+      "id": "clara",
+      "name": "Clara",
+      "neighbors": [
+        "amelie",
+        "bao",
+        "elin"
+      ],
+      "susceptibility": 1.2,
+      "expressiveness": 0.6,
+      "patience": 3,
+      "initialStatus": "ignorant"
+    },
+    {
+      "id": "darius",
+      "name": "Darius",
+      "neighbors": [
+        "bao",
+        "elin",
+        "farah"
+      ],
+      "susceptibility": 1.6,
+      "expressiveness": 0.9,
+      "patience": 2,
+      "initialStatus": "ignorant"
+    },
+    {
+      "id": "elin",
+      "name": "Elin",
+      "neighbors": [
+        "clara",
+        "darius",
+        "farah"
+      ],
+      "susceptibility": 1.1,
+      "expressiveness": 0.5,
+      "patience": 2,
+      "initialStatus": "ignorant"
+    },
+    {
+      "id": "farah",
+      "name": "Farah",
+      "neighbors": [
+        "darius",
+        "elin"
+      ],
+      "susceptibility": 1.8,
+      "expressiveness": 0.7,
+      "patience": 4,
+      "initialStatus": "ignorant"
+    }
+  ],
+  "options": {
+    "ticks": 12,
+    "tickIntervalMs": 10,
+    "exposureDecay": 0.15
+  }
+}

--- a/verifications/village_rumor/report.md
+++ b/verifications/village_rumor/report.md
@@ -1,0 +1,17 @@
+# Village Rumor Simulation Report
+
+## Form D framing
+- **Environment (E):** Six villagers (Amélie, Bao, Clara, Darius, Elin, Farah) connected by directed neighbor lists share a single rumor alongside a global timekeeper entity. Each villager carries profile, social-network, and rumor-state components that determine how they hear and propagate information.【F:verifications/village_rumor/raw_output.json†L5-L126】【F:workspaces/Describing_Simulation_0/project/plugins/simulation/components/VillageComponents.ts†L1-L63】
+- **Phenomenon (X):** Amélie begins the simulation as the sole spreader with the rumor fully internalized, triggering propagation attempts along the network each tick.【F:workspaces/Describing_Simulation_0/project/src/scenarios/villageRumor.ts†L40-L72】【F:verifications/village_rumor/raw_output.json†L12-L30】
+- **Condition set (C):** Observe the village until no spreaders remain or the twelve-tick horizon is reached; completion is detected when the metrics component reports zero active spreaders and records a completion tick.【F:workspaces/Describing_Simulation_0/project/src/scenarios/villageRumor.ts†L142-L231】【F:verifications/village_rumor/raw_output.json†L132-L201】
+
+## Simulation setup
+- **Propagation dynamics:** `RumorSpreadingSystem` adds each spreader’s expressiveness to neighbor exposure, converts neighbors whose cumulative exposure exceeds their susceptibility, increments spreader fatigue, and applies a gentle 0.15 decay to residual exposure among ignorants.【F:workspaces/Describing_Simulation_0/project/plugins/simulation/systems/RumorSpreadingSystem.ts†L12-L86】 
+- **Metrics tracking:** `RumorMetricsSystem` records per-tick counts of ignorants, spreaders, stiflers, and newly informed villagers, while capturing the first tick with no spreaders as the completion tick.【F:workspaces/Describing_Simulation_0/project/plugins/simulation/systems/RumorMetricsSystem.ts†L10-L76】
+- **Network structure and parameters:** Villager susceptibilities range from 1.1–1.8, expressiveness spans 0.5–1.0, and patience varies from two to four ticks, creating staggered adoption and fatigue. The social graph routes influence from Amélie through Bao and Clara to Darius, Elin, and Farah; the simulation advances in twelve one-millisecond ticks with 0.15 exposure decay.【F:workspaces/Describing_Simulation_0/project/src/scenarios/villageRumor.ts†L40-L231】
+
+## Findings
+- **Rapid initial amplification (ticks 1–3):** By tick two the rumor reaches Bao and Clara (two newly informed spreaders), shrinking the ignorant population from five to three; Amélie exits as a stifler on tick three while the rumor persists through her neighbors.【F:verifications/village_rumor/raw_output.json†L2518-L2545】
+- **Mid-village cascade (ticks 4–8):** Elin adopts on tick five, Darius on tick six, and Farah on tick eight, sequentially reducing ignorants to zero while keeping one or two active spreaders in circulation.【F:verifications/village_rumor/raw_output.json†L2546-L2574】
+- **Termination (ticks 9–12):** Farah sustains the final wave alone until fatigue transitions her to a stifler on tick twelve, marking completion with six stiflers and no remaining spreaders.【F:verifications/village_rumor/raw_output.json†L2575-L2605】
+- **Individual outcomes:** Final rumor-state snapshots show each villager’s adoption tick and spreading duration—Bao and Clara spread for two to three ticks after hearing on tick two, Elin and Darius sustain short bridges, and Farah remains active for four ticks before closure.【F:verifications/village_rumor/raw_output.json†L2480-L2513】

--- a/workspaces/Describing_Simulation_0/project/plugins/simulation/components/VillageComponents.ts
+++ b/workspaces/Describing_Simulation_0/project/plugins/simulation/components/VillageComponents.ts
@@ -1,0 +1,68 @@
+import { ComponentType } from '../../../src/core/components/ComponentType';
+
+/** Static personal attributes that shape how a villager reacts to the rumor. */
+export interface VillagerProfileComponent {
+  /** Display name used for reporting. */
+  readonly name: string;
+  /** Exposure threshold required before the villager starts spreading the rumor. */
+  readonly susceptibility: number;
+  /** Influence applied to neighbors on every sharing attempt. */
+  readonly expressiveness: number;
+  /** Number of ticks the villager remains an active spreader before becoming a stifler. */
+  readonly patience: number;
+}
+
+/** Component type holding {@link VillagerProfileComponent} data. */
+export const VILLAGER_PROFILE = new ComponentType<VillagerProfileComponent>(
+  'village/profile',
+);
+
+/** Describes local relationships that determine who receives rumor attempts. */
+export interface SocialNetworkComponent {
+  /** Ordered list of neighbor entity identifiers. */
+  readonly neighbors: string[];
+}
+
+/** Component type storing {@link SocialNetworkComponent} data. */
+export const SOCIAL_NETWORK = new ComponentType<SocialNetworkComponent>(
+  'village/social-network',
+);
+
+export type RumorStatus = 'ignorant' | 'spreader' | 'stifler';
+
+/** Tracks the dynamic rumor state for each villager. */
+export interface RumorStateComponent {
+  /** Current stage in the rumor lifecycle. */
+  readonly status: RumorStatus;
+  /** Cumulative exposure from neighboring spreaders. */
+  readonly exposure: number;
+  /** Tick when the villager first heard the rumor, if ever. */
+  readonly heardTick: number | null;
+  /** Number of ticks spent as an active spreader. */
+  readonly activeTicks: number;
+}
+
+/** Component type for {@link RumorStateComponent}. */
+export const RUMOR_STATE = new ComponentType<RumorStateComponent>(
+  'village/rumor-state',
+);
+
+export interface RumorMetricsEntry {
+  readonly tick: number;
+  readonly ignorant: number;
+  readonly spreaders: number;
+  readonly stiflers: number;
+  readonly newlyInformed: number;
+}
+
+/** Aggregated counts for tracing rumor progression through the village. */
+export interface RumorMetricsComponent {
+  readonly history: RumorMetricsEntry[];
+  readonly completed: boolean;
+  readonly completionTick: number | null;
+}
+
+/** Component type for {@link RumorMetricsComponent}. */
+export const RUMOR_METRICS = new ComponentType<RumorMetricsComponent>(
+  'village/rumor-metrics',
+);

--- a/workspaces/Describing_Simulation_0/project/plugins/simulation/systems/RumorMetricsSystem.ts
+++ b/workspaces/Describing_Simulation_0/project/plugins/simulation/systems/RumorMetricsSystem.ts
@@ -1,0 +1,100 @@
+import { ComponentManager } from '../../../src/core/components/ComponentManager';
+import { EntityManager } from '../../../src/core/entity/EntityManager';
+import { System } from '../../../src/core/systems/System';
+import {
+  RUMOR_METRICS,
+  RUMOR_STATE,
+  type RumorMetricsComponent,
+} from '../components/VillageComponents';
+
+const METRICS_ENTITY_ID = 'rumor-metrics';
+
+/**
+ * Aggregates the population state after each simulation tick.
+ */
+export class RumorMetricsSystem extends System {
+  private currentTick = 0;
+
+  constructor(
+    private readonly entities: EntityManager,
+    private readonly components: ComponentManager,
+  ) {
+    super();
+  }
+
+  protected override onInit(): void {
+    if (!this.components.isRegistered(RUMOR_METRICS)) {
+      this.components.register(RUMOR_METRICS);
+    }
+
+    if (!this.entities.has(METRICS_ENTITY_ID)) {
+      this.entities.create(METRICS_ENTITY_ID);
+    }
+
+    if (!this.components.hasComponent(METRICS_ENTITY_ID, RUMOR_METRICS)) {
+      const initial: RumorMetricsComponent = {
+        history: [],
+        completed: false,
+        completionTick: null,
+      };
+      this.components.setComponent(METRICS_ENTITY_ID, RUMOR_METRICS, initial);
+    }
+  }
+
+  protected override update(deltaTime: number): void {
+    this.currentTick += 1;
+
+    let ignorant = 0;
+    let spreaders = 0;
+    let stiflers = 0;
+    let newlyInformed = 0;
+
+    const entityIds = this.components.entitiesWithComponent(RUMOR_STATE);
+    for (const entityId of entityIds) {
+      const state = this.components.getComponent(entityId, RUMOR_STATE);
+      if (!state) {
+        continue;
+      }
+
+      switch (state.status) {
+        case 'ignorant':
+          ignorant += 1;
+          break;
+        case 'spreader':
+          spreaders += 1;
+          if (state.heardTick === this.currentTick) {
+            newlyInformed += 1;
+          }
+          break;
+        case 'stifler':
+          stiflers += 1;
+          break;
+        default:
+          break;
+      }
+    }
+
+    const metrics = this.components.getComponent(METRICS_ENTITY_ID, RUMOR_METRICS);
+    const history = metrics?.history ?? [];
+
+    const completed = spreaders === 0;
+    const completionTick = metrics?.completionTick ?? null;
+    const resolvedCompletionTick =
+      completionTick ?? (completed ? this.currentTick : null);
+
+    this.components.setComponent(METRICS_ENTITY_ID, RUMOR_METRICS, {
+      history: [
+        ...history,
+        {
+          tick: this.currentTick,
+          ignorant,
+          spreaders,
+          stiflers,
+          newlyInformed,
+        },
+      ],
+      completed,
+      completionTick: resolvedCompletionTick,
+    });
+  }
+}

--- a/workspaces/Describing_Simulation_0/project/plugins/simulation/systems/RumorSpreadingSystem.ts
+++ b/workspaces/Describing_Simulation_0/project/plugins/simulation/systems/RumorSpreadingSystem.ts
@@ -1,0 +1,128 @@
+import { ComponentManager } from '../../../src/core/components/ComponentManager';
+import { EntityManager } from '../../../src/core/entity/EntityManager';
+import { System } from '../../../src/core/systems/System';
+import {
+  RUMOR_STATE,
+  SOCIAL_NETWORK,
+  VILLAGER_PROFILE,
+  type RumorStatus,
+} from '../components/VillageComponents';
+
+export interface RumorSpreadingOptions {
+  /** Exposure removed from ignorant villagers every tick to model fading memory. */
+  readonly exposureDecay?: number;
+}
+
+/**
+ * Propagates the rumor between villagers based on local social connections.
+ */
+export class RumorSpreadingSystem extends System {
+  private currentTick = 0;
+
+  constructor(
+    private readonly entities: EntityManager,
+    private readonly components: ComponentManager,
+    private readonly options: RumorSpreadingOptions = {},
+  ) {
+    super();
+  }
+
+  protected override onInit(): void {
+    for (const type of [VILLAGER_PROFILE, SOCIAL_NETWORK, RUMOR_STATE]) {
+      if (!this.components.isRegistered(type)) {
+        this.components.register(type);
+      }
+    }
+  }
+
+  protected override update(deltaTime: number): void {
+    this.currentTick += 1;
+
+    const spreaders = this.components
+      .entitiesWithComponent(RUMOR_STATE)
+      .filter((entityId) => this.isActiveSpreader(entityId));
+
+    for (const entityId of spreaders) {
+      const profile = this.components.getComponent(entityId, VILLAGER_PROFILE);
+      const social = this.components.getComponent(entityId, SOCIAL_NETWORK);
+      const state = this.components.getComponent(entityId, RUMOR_STATE);
+
+      if (!profile || !social || !state) {
+        continue;
+      }
+
+      for (const neighborId of social.neighbors) {
+        const neighborState = this.components.getComponent(neighborId, RUMOR_STATE);
+        if (!neighborState || neighborState.status !== 'ignorant') {
+          continue;
+        }
+
+        const neighborProfile = this.components.getComponent(
+          neighborId,
+          VILLAGER_PROFILE,
+        );
+        if (!neighborProfile) {
+          continue;
+        }
+
+        const nextExposure = neighborState.exposure + profile.expressiveness;
+        if (nextExposure >= neighborProfile.susceptibility) {
+          this.components.setComponent(neighborId, RUMOR_STATE, {
+            status: 'spreader',
+            exposure: nextExposure,
+            heardTick: this.currentTick,
+            activeTicks: 0,
+          });
+        } else {
+          this.components.setComponent(neighborId, RUMOR_STATE, {
+            ...neighborState,
+            exposure: nextExposure,
+          });
+        }
+      }
+
+      const nextActive = state.activeTicks + 1;
+      const nextStatus: RumorStatus =
+        nextActive >= profile.patience ? 'stifler' : 'spreader';
+
+      this.components.setComponent(entityId, RUMOR_STATE, {
+        ...state,
+        status: nextStatus,
+        activeTicks: nextActive,
+      });
+    }
+
+    const exposureDecay = this.options.exposureDecay ?? 0.15;
+    if (exposureDecay > 0) {
+      const entityIds = this.components.entitiesWithComponent(RUMOR_STATE);
+      for (const entityId of entityIds) {
+        const state = this.components.getComponent(entityId, RUMOR_STATE);
+        if (!state || state.status !== 'ignorant' || state.exposure <= 0) {
+          continue;
+        }
+
+        const decayed = Math.max(0, state.exposure - exposureDecay);
+        if (decayed !== state.exposure) {
+          this.components.setComponent(entityId, RUMOR_STATE, {
+            ...state,
+            exposure: decayed,
+          });
+        }
+      }
+    }
+  }
+
+  private isActiveSpreader(entityId: string): boolean {
+    const state = this.components.getComponent(entityId, RUMOR_STATE);
+    if (!state || state.status !== 'spreader') {
+      return false;
+    }
+
+    const social = this.components.getComponent(entityId, SOCIAL_NETWORK);
+    if (!social || social.neighbors.length === 0) {
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/workspaces/Describing_Simulation_0/project/src/scenarios/villageRumor.ts
+++ b/workspaces/Describing_Simulation_0/project/src/scenarios/villageRumor.ts
@@ -1,0 +1,342 @@
+import fs from 'fs';
+import path from 'path';
+
+import { ComponentManager } from '../core/components/ComponentManager';
+import { EntityManager } from '../core/entity/EntityManager';
+import { SystemManager } from '../core/systems/SystemManager';
+import { TimeSystem } from '../core/systems/TimeSystem';
+import { SimulationPlayer } from '../core/simplayer/SimulationPlayer';
+import { EvaluationPlayer } from '../core/evalplayer/EvaluationPlayer';
+import { Bus, acknowledge } from '../core/messaging';
+import type { SnapshotFrame } from '../core/IOPlayer';
+
+import {
+  RUMOR_METRICS,
+  RUMOR_STATE,
+  SOCIAL_NETWORK,
+  VILLAGER_PROFILE,
+  type RumorMetricsComponent,
+  type RumorStatus,
+  type VillagerProfileComponent,
+} from '../../plugins/simulation/components/VillageComponents';
+import { RumorSpreadingSystem } from '../../plugins/simulation/systems/RumorSpreadingSystem';
+import { RumorMetricsSystem } from '../../plugins/simulation/systems/RumorMetricsSystem';
+
+interface VillagerConfig extends VillagerProfileComponent {
+  readonly id: string;
+  readonly neighbors: string[];
+  readonly initialStatus: RumorStatus;
+}
+
+interface SimulationOptions {
+  readonly ticks: number;
+  readonly tickIntervalMs: number;
+  readonly exposureDecay: number;
+}
+
+interface SimulationArtifacts {
+  readonly frames: SnapshotFrame[];
+  readonly villagers: VillagerConfig[];
+  readonly options: SimulationOptions;
+}
+
+function createDefaultVillagers(): VillagerConfig[] {
+  return [
+    {
+      id: 'amelie',
+      name: 'Amélie',
+      neighbors: ['bao', 'clara'],
+      susceptibility: 1.1,
+      expressiveness: 1,
+      patience: 3,
+      initialStatus: 'spreader',
+    },
+    {
+      id: 'bao',
+      name: 'Bao',
+      neighbors: ['amelie', 'clara', 'darius'],
+      susceptibility: 1.4,
+      expressiveness: 0.8,
+      patience: 2,
+      initialStatus: 'ignorant',
+    },
+    {
+      id: 'clara',
+      name: 'Clara',
+      neighbors: ['amelie', 'bao', 'elin'],
+      susceptibility: 1.2,
+      expressiveness: 0.6,
+      patience: 3,
+      initialStatus: 'ignorant',
+    },
+    {
+      id: 'darius',
+      name: 'Darius',
+      neighbors: ['bao', 'elin', 'farah'],
+      susceptibility: 1.6,
+      expressiveness: 0.9,
+      patience: 2,
+      initialStatus: 'ignorant',
+    },
+    {
+      id: 'elin',
+      name: 'Elin',
+      neighbors: ['clara', 'darius', 'farah'],
+      susceptibility: 1.1,
+      expressiveness: 0.5,
+      patience: 2,
+      initialStatus: 'ignorant',
+    },
+    {
+      id: 'farah',
+      name: 'Farah',
+      neighbors: ['darius', 'elin'],
+      susceptibility: 1.8,
+      expressiveness: 0.7,
+      patience: 4,
+      initialStatus: 'ignorant',
+    },
+  ];
+}
+
+function registerVillagers(
+  villagers: VillagerConfig[],
+  entities: EntityManager,
+  components: ComponentManager,
+): void {
+  for (const villager of villagers) {
+    if (!components.isRegistered(VILLAGER_PROFILE)) {
+      components.register(VILLAGER_PROFILE);
+    }
+    if (!components.isRegistered(SOCIAL_NETWORK)) {
+      components.register(SOCIAL_NETWORK);
+    }
+    if (!components.isRegistered(RUMOR_STATE)) {
+      components.register(RUMOR_STATE);
+    }
+
+    const entity = entities.create(villager.id);
+    components.setComponent(entity.id, VILLAGER_PROFILE, {
+      name: villager.name,
+      susceptibility: villager.susceptibility,
+      expressiveness: villager.expressiveness,
+      patience: villager.patience,
+    });
+
+    components.setComponent(entity.id, SOCIAL_NETWORK, {
+      neighbors: villager.neighbors,
+    });
+
+    const initialExposure =
+      villager.initialStatus === 'spreader' ? villager.susceptibility : 0;
+    const heardTick = villager.initialStatus === 'spreader' ? 0 : null;
+
+    components.setComponent(entity.id, RUMOR_STATE, {
+      status: villager.initialStatus,
+      exposure: initialExposure,
+      heardTick,
+      activeTicks: 0,
+    });
+  }
+}
+
+function createMonotonicTimeProvider(stepMs: number): () => number {
+  let current = 0;
+  return () => {
+    current += stepMs;
+    return current;
+  };
+}
+
+async function runSimulation(
+  villagers: VillagerConfig[],
+  options: SimulationOptions,
+): Promise<SimulationArtifacts> {
+  const components = new ComponentManager();
+  const entities = new EntityManager(components);
+  const systems = new SystemManager();
+
+  registerVillagers(villagers, entities, components);
+
+  const timeSystem = new TimeSystem(entities, components);
+  const rumorSystem = new RumorSpreadingSystem(entities, components, {
+    exposureDecay: options.exposureDecay,
+  });
+  const metricsSystem = new RumorMetricsSystem(entities, components);
+
+  systems.register(timeSystem, -1);
+  systems.register(rumorSystem, 0);
+  systems.register(metricsSystem, 1);
+
+  const simulationInbound = new Bus();
+  const simulationOutbound = new Bus();
+  const evaluationInbound = new Bus();
+  const evaluationOutbound = new Bus();
+
+  const simulationPlayer = new SimulationPlayer(
+    entities,
+    components,
+    systems,
+    simulationInbound,
+    simulationOutbound,
+    {
+      tickIntervalMs: options.tickIntervalMs,
+      timeProvider: createMonotonicTimeProvider(options.tickIntervalMs),
+    },
+  );
+
+  const evaluationComponents = new ComponentManager();
+  const evaluationEntities = new EntityManager(evaluationComponents);
+  const evaluationSystems = new SystemManager();
+
+  const evaluationPlayer = new EvaluationPlayer(
+    evaluationEntities,
+    evaluationComponents,
+    evaluationSystems,
+    evaluationInbound,
+    evaluationOutbound,
+    {
+      tickIntervalMs: options.tickIntervalMs,
+      timeProvider: createMonotonicTimeProvider(options.tickIntervalMs),
+    },
+  );
+
+  const frames: SnapshotFrame[] = [];
+  let simulationCompleted = false;
+  let evaluationCaughtUp = false;
+  let stopScheduled = false;
+
+  let resolveCompletion: (() => void) | null = null;
+  const completionPromise = new Promise<void>((resolve) => {
+    resolveCompletion = resolve;
+  });
+
+  const finalize = () => {
+    if (stopScheduled) {
+      return;
+    }
+
+    stopScheduled = true;
+
+    setTimeout(() => {
+      simulationPlayer.stop();
+      evaluationPlayer.stop();
+      resolveCompletion?.();
+    }, Math.max(options.tickIntervalMs * 2, 10));
+  };
+
+  const maybeFinalize = () => {
+    if (simulationCompleted && evaluationCaughtUp) {
+      finalize();
+    }
+  };
+
+  simulationOutbound.subscribe((frame) => {
+    const snapshot = frame as SnapshotFrame;
+    const acknowledgement = evaluationInbound.send(frame);
+
+    const tick = typeof snapshot.metadata.tick === 'number' ? snapshot.metadata.tick : 0;
+    if (!simulationCompleted && tick >= options.ticks) {
+      simulationCompleted = true;
+      maybeFinalize();
+    }
+
+    return acknowledgement;
+  });
+
+  evaluationOutbound.subscribe((frame) => {
+    const snapshot = frame as SnapshotFrame;
+    frames.push(snapshot);
+
+    const metricsEntity = snapshot.payload.entities.find(
+      (entity) => entity.id === 'rumor-metrics',
+    );
+
+    const metrics = metricsEntity?.components?.[RUMOR_METRICS.name] as
+      | RumorMetricsComponent
+      | undefined;
+
+    const lastEntry = metrics?.history.length
+      ? metrics.history[metrics.history.length - 1]
+      : undefined;
+    const lastTick = lastEntry?.tick ?? 0;
+    if (!evaluationCaughtUp && lastTick >= options.ticks) {
+      evaluationCaughtUp = true;
+      maybeFinalize();
+    }
+
+    return acknowledge();
+  });
+
+  const safetyTimeout = setTimeout(() => {
+    finalize();
+  }, options.tickIntervalMs * (options.ticks + 5));
+
+  simulationPlayer.start();
+  evaluationPlayer.start();
+
+  await completionPromise;
+  clearTimeout(safetyTimeout);
+
+  return { frames, villagers, options };
+}
+
+interface CliOptions {
+  outputPath?: string;
+  ticks?: number;
+  tickIntervalMs?: number;
+  exposureDecay?: number;
+}
+
+function parseCliArguments(argv: string[]): CliOptions {
+  const options: CliOptions = {};
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--output' && i + 1 < argv.length) {
+      options.outputPath = argv[++i];
+    } else if (arg === '--ticks' && i + 1 < argv.length) {
+      options.ticks = Number.parseInt(argv[++i], 10);
+    } else if (arg === '--tick-interval' && i + 1 < argv.length) {
+      options.tickIntervalMs = Number.parseInt(argv[++i], 10);
+    } else if (arg === '--exposure-decay' && i + 1 < argv.length) {
+      options.exposureDecay = Number.parseFloat(argv[++i]);
+    }
+  }
+
+  return options;
+}
+
+async function main(): Promise<void> {
+  const args = parseCliArguments(process.argv.slice(2));
+
+  const villagers = createDefaultVillagers();
+  const ticks = Number.isInteger(args.ticks) ? (args.ticks as number) : 12;
+  const tickIntervalMs = Number.isInteger(args.tickIntervalMs)
+    ? (args.tickIntervalMs as number)
+    : 10;
+  const exposureDecay =
+    typeof args.exposureDecay === 'number' ? args.exposureDecay : 0.15;
+
+  const artifacts = await runSimulation(villagers, {
+    ticks,
+    tickIntervalMs,
+    exposureDecay,
+  });
+
+  if (args.outputPath) {
+    const outputPath = path.resolve(args.outputPath);
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(outputPath, JSON.stringify(artifacts, null, 2), 'utf8');
+  } else {
+    process.stdout.write(`${JSON.stringify(artifacts, null, 2)}\n`);
+  }
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    // eslint-disable-next-line no-console
+    console.error('Failed to run village rumor simulation:', error);
+    process.exitCode = 1;
+  });
+}

--- a/workspaces/Describing_Simulation_0/project/tsconfig.json
+++ b/workspaces/Describing_Simulation_0/project/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "src/*": ["src/*"]
     },
-    "rootDir": "src",
+    "rootDir": ".",
     "outDir": "dist",
     "strict": true,
     "esModuleInterop": true,
@@ -18,6 +18,6 @@
     "skipLibCheck": true,
     "types": ["jest", "node"]
   },
-  "include": ["src", "tests"],
+  "include": ["src", "tests", "plugins"],
   "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
## Summary
- add village-focused rumor components and systems plugins to model exposure, spreading fatigue, and aggregate metrics
- implement a runnable TypeScript scenario that wires the simulation and evaluation players together for the rumor study
- capture the evaluation frames and accompanying analysis report under `verifications/village_rumor`

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d63e8fc12c832aa57481c3922dde6c