### PR TITLE
Add bank collapse credit market simulation and reporting

### DIFF
--- a/verifications/bank_collapses/raw_output.json
+++ b/verifications/bank_collapses/raw_output.json
@@ -1,0 +1,16852 @@
+[
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market-summary",
+          "components": {}
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 86400
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 1,
+      "timestamp": 86400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 316.55698879464,
+              "liquidityIndex": 0.5594464703434,
+              "lendingVolume": 0.6528105077530001,
+              "stressLevel": 0.6807061164,
+              "fundingCost": 4.6655698879464005
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 2,
+              "creditSpreadBps": 316.55698879464,
+              "liquidityIndex": 0.5594464703434,
+              "lendingVolume": 0.6528105077530001,
+              "stressLevel": 0.6807061164,
+              "depositOutflowRatio": 0.1982330526221,
+              "riskAppetite": 0.382853784282,
+              "interbankTrust": 0.5490279459814,
+              "policySupportLevel": 0.399218,
+              "liquidityBackstop": 0.52608,
+              "capitalInjection": 0.349676,
+              "emergencyRateCutBps": 121.628,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": null,
+                "averageSpreadBps": 316.55698879464,
+                "cumulativeLendingGap": 0.3471894922469999
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.382853784282,
+              "depositOutflowRatio": 0.1982330526221,
+              "interbankTrust": 0.5490279459814
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.399218,
+              "liquidityBackstop": 0.52608,
+              "capitalInjection": 0.349676,
+              "emergencyRateCutBps": 121.628,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 172800
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 2,
+      "timestamp": 172800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 231.6129245093736,
+              "liquidityIndex": 0.810561982247662,
+              "lendingVolume": 0.85404577926415,
+              "stressLevel": 0.422402486348,
+              "fundingCost": 3.816129245093736
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 3,
+              "creditSpreadBps": 231.6129245093736,
+              "liquidityIndex": 0.810561982247662,
+              "lendingVolume": 0.85404577926415,
+              "stressLevel": 0.422402486348,
+              "depositOutflowRatio": 0.10020487367994499,
+              "riskAppetite": 0.55785542998382,
+              "interbankTrust": 0.7045848113701421,
+              "policySupportLevel": 0.5387807356563397,
+              "liquidityBackstop": 0.6330479935307186,
+              "capitalInjection": 0.5010689898371004,
+              "emergencyRateCutBps": 138.8435439254426,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": null,
+                "averageSpreadBps": 274.0849566520068,
+                "cumulativeLendingGap": 0.49314371298284987
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.55785542998382,
+              "depositOutflowRatio": 0.10020487367994499,
+              "interbankTrust": 0.7045848113701421
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.5387807356563397,
+              "liquidityBackstop": 0.6330479935307186,
+              "capitalInjection": 0.5010689898371004,
+              "emergencyRateCutBps": 138.8435439254426,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 259200
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 3,
+      "timestamp": 259200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 189.9903330095931,
+              "liquidityIndex": 0.9185416523664947,
+              "lendingVolume": 0.9647251785952826,
+              "stressLevel": 0.27516941721835997,
+              "fundingCost": 3.399903330095931
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 4,
+              "creditSpreadBps": 189.9903330095931,
+              "liquidityIndex": 0.9185416523664947,
+              "lendingVolume": 0.9647251785952826,
+              "stressLevel": 0.27516941721835997,
+              "depositOutflowRatio": 0.056092193155975245,
+              "riskAppetite": 0.6471062692917482,
+              "interbankTrust": 0.7870299500261753,
+              "policySupportLevel": 0.5497312800203175,
+              "liquidityBackstop": 0.5873274334414196,
+              "capitalInjection": 0.5454324510971382,
+              "emergencyRateCutBps": 122.68480169360947,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": null,
+                "averageSpreadBps": 246.0534154378689,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.6471062692917482,
+              "depositOutflowRatio": 0.056092193155975245,
+              "interbankTrust": 0.7870299500261753
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.5497312800203175,
+              "liquidityBackstop": 0.5873274334414196,
+              "capitalInjection": 0.5454324510971382,
+              "emergencyRateCutBps": 122.68480169360947,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 345600
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 4,
+      "timestamp": 345600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 169.59526317470062,
+              "liquidityIndex": 0.9649729105175927,
+              "lendingVolume": 1.0255988482274054,
+              "stressLevel": 0.1912465678144652,
+              "fundingCost": 3.195952631747006
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 5,
+              "creditSpreadBps": 169.59526317470062,
+              "liquidityIndex": 0.9649729105175927,
+              "lendingVolume": 1.0255988482274054,
+              "stressLevel": 0.1912465678144652,
+              "depositOutflowRatio": 0.03624148692018886,
+              "riskAppetite": 0.6926241973387915,
+              "interbankTrust": 0.8307258735138728,
+              "policySupportLevel": 0.5239601850667396,
+              "liquidityBackstop": 0.5197267592171068,
+              "capitalInjection": 0.5497104172214116,
+              "emergencyRateCutBps": 105.91390575985574,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": null,
+                "averageSpreadBps": 226.93887737207683,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.6926241973387915,
+              "depositOutflowRatio": 0.03624148692018886,
+              "interbankTrust": 0.8307258735138728
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.5239601850667396,
+              "liquidityBackstop": 0.5197267592171068,
+              "capitalInjection": 0.5497104172214116,
+              "emergencyRateCutBps": 105.91390575985574,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 432000
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 5,
+      "timestamp": 432000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 159.6016789556033,
+              "liquidityIndex": 0.9849383515225648,
+              "lendingVolume": 1.059079366525073,
+              "stressLevel": 0.14341054365424516,
+              "fundingCost": 3.0960167895560327
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 6,
+              "creditSpreadBps": 159.6016789556033,
+              "liquidityIndex": 0.9849383515225648,
+              "lendingVolume": 1.059079366525073,
+              "stressLevel": 0.14341054365424516,
+              "depositOutflowRatio": 0.027308669114084985,
+              "riskAppetite": 0.7158383406427837,
+              "interbankTrust": 0.8538847129623526,
+              "policySupportLevel": 0.4943878417140178,
+              "liquidityBackstop": 0.46560525556270244,
+              "capitalInjection": 0.5415602697470637,
+              "emergencyRateCutBps": 94.44199030495055,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": null,
+                "averageSpreadBps": 213.47143768878215,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7158383406427837,
+              "depositOutflowRatio": 0.027308669114084985,
+              "interbankTrust": 0.8538847129623526
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.4943878417140178,
+              "liquidityBackstop": 0.46560525556270244,
+              "capitalInjection": 0.5415602697470637,
+              "emergencyRateCutBps": 94.44199030495055,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 518400
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 6,
+      "timestamp": 518400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 154.7048226882456,
+              "liquidityIndex": 0.9935234911547028,
+              "lendingVolume": 1.0774936515887903,
+              "stressLevel": 0.11614400988291974,
+              "fundingCost": 3.047048226882456
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 7,
+              "creditSpreadBps": 154.7048226882456,
+              "liquidityIndex": 0.9935234911547028,
+              "lendingVolume": 1.0774936515887903,
+              "stressLevel": 0.11614400988291974,
+              "depositOutflowRatio": 0.02458957193709749,
+              "riskAppetite": 0.7276775537278197,
+              "interbankTrust": 0.8661588978700469,
+              "policySupportLevel": 0.47064971967705316,
+              "liquidityBackstop": 0.4292392043607408,
+              "capitalInjection": 0.531548565105162,
+              "emergencyRateCutBps": 87.58776772760217,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 203.6770018553594,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7276775537278197,
+              "depositOutflowRatio": 0.02458957193709749,
+              "interbankTrust": 0.8661588978700469
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.47064971967705316,
+              "liquidityBackstop": 0.4292392043607408,
+              "capitalInjection": 0.531548565105162,
+              "emergencyRateCutBps": 87.58776772760217,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 604800
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 7,
+      "timestamp": 604800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 152.30536311724035,
+              "liquidityIndex": 0.9972151011965222,
+              "lendingVolume": 1.0876215083738348,
+              "stressLevel": 0.10060208563326425,
+              "fundingCost": 3.023053631172403
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 8,
+              "creditSpreadBps": 152.30536311724035,
+              "liquidityIndex": 0.9972151011965222,
+              "lendingVolume": 1.0876215083738348,
+              "stressLevel": 0.10060208563326425,
+              "depositOutflowRatio": 0.026096408290914957,
+              "riskAppetite": 0.733715552401188,
+              "interbankTrust": 0.8726642158711249,
+              "policySupportLevel": 0.45426304024059677,
+              "liquidityBackstop": 0.4072067529585696,
+              "capitalInjection": 0.523309817412157,
+              "emergencyRateCutBps": 83.84914494013478,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 196.3381963213424,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.733715552401188,
+              "depositOutflowRatio": 0.026096408290914957,
+              "interbankTrust": 0.8726642158711249
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.45426304024059677,
+              "liquidityBackstop": 0.4072067529585696,
+              "capitalInjection": 0.523309817412157,
+              "emergencyRateCutBps": 83.84914494013478,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 691200
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 8,
+      "timestamp": 691200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 151.12962792744776,
+              "liquidityIndex": 0.9988024935145046,
+              "lendingVolume": 1.0931918296056091,
+              "stressLevel": 0.09174318881096062,
+              "fundingCost": 3.0112962792744775
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 9,
+              "creditSpreadBps": 151.12962792744776,
+              "liquidityIndex": 0.9988024935145046,
+              "lendingVolume": 1.0931918296056091,
+              "stressLevel": 0.09174318881096062,
+              "depositOutflowRatio": 0.028395488880260788,
+              "riskAppetite": 0.7367949317246059,
+              "interbankTrust": 0.8761120344116962,
+              "policySupportLevel": 0.44424704091371187,
+              "liquidityBackstop": 0.3953097211937753,
+              "capitalInjection": 0.5177280747985297,
+              "emergencyRateCutBps": 82.07205292380074,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 190.68712527210556,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7367949317246059,
+              "depositOutflowRatio": 0.028395488880260788,
+              "interbankTrust": 0.8761120344116962
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.44424704091371187,
+              "liquidityBackstop": 0.3953097211937753,
+              "capitalInjection": 0.5177280747985297,
+              "emergencyRateCutBps": 82.07205292380074,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 777600
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 9,
+      "timestamp": 777600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.5535176844494,
+              "liquidityIndex": 0.999485072211237,
+              "lendingVolume": 1.096255506283085,
+              "stressLevel": 0.08669361762224756,
+              "fundingCost": 3.005535176844494
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 10,
+              "creditSpreadBps": 150.5535176844494,
+              "liquidityIndex": 0.999485072211237,
+              "lendingVolume": 1.096255506283085,
+              "stressLevel": 0.08669361762224756,
+              "depositOutflowRatio": 0.03029735949024232,
+              "riskAppetite": 0.738365415179549,
+              "interbankTrust": 0.877939378238199,
+              "policySupportLevel": 0.4385821812768365,
+              "liquidityBackstop": 0.3894252781857062,
+              "capitalInjection": 0.5143093543950146,
+              "emergencyRateCutBps": 81.32461393115926,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 186.22783554014376,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.738365415179549,
+              "depositOutflowRatio": 0.03029735949024232,
+              "interbankTrust": 0.877939378238199
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.4385821812768365,
+              "liquidityBackstop": 0.3894252781857062,
+              "capitalInjection": 0.5143093543950146,
+              "emergencyRateCutBps": 81.32461393115926,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 864000
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 10,
+      "timestamp": 864000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.2712236653802,
+              "liquidityIndex": 0.9997785810508318,
+              "lendingVolume": 1.097940528455697,
+              "stressLevel": 0.08381536204468111,
+              "fundingCost": 3.002712236653802
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 11,
+              "creditSpreadBps": 150.2712236653802,
+              "liquidityIndex": 0.9997785810508318,
+              "lendingVolume": 1.097940528455697,
+              "stressLevel": 0.08381536204468111,
+              "depositOutflowRatio": 0.03158155504160755,
+              "riskAppetite": 0.73916636174157,
+              "interbankTrust": 0.8789078704662455,
+              "policySupportLevel": 0.4355499074875538,
+              "liquidityBackstop": 0.38673274962523013,
+              "capitalInjection": 0.5123407901972776,
+              "emergencyRateCutBps": 81.05248519848048,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 182.6321743526674,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.73916636174157,
+              "depositOutflowRatio": 0.03158155504160755,
+              "interbankTrust": 0.8789078704662455
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.4355499074875538,
+              "liquidityBackstop": 0.38673274962523013,
+              "capitalInjection": 0.5123407901972776,
+              "emergencyRateCutBps": 81.05248519848048,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 950400
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 11,
+      "timestamp": 950400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.1328995960363,
+              "liquidityIndex": 0.9999047898518577,
+              "lendingVolume": 1.0988672906506334,
+              "stressLevel": 0.08217475636546823,
+              "fundingCost": 3.001328995960363
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 12,
+              "creditSpreadBps": 150.1328995960363,
+              "liquidityIndex": 0.9999047898518577,
+              "lendingVolume": 1.0988672906506334,
+              "stressLevel": 0.08217475636546823,
+              "depositOutflowRatio": 0.03235674774157029,
+              "riskAppetite": 0.7395748444882007,
+              "interbankTrust": 0.8794211713471102,
+              "policySupportLevel": 0.433991215233309,
+              "liquidityBackstop": 0.38559321602376606,
+              "capitalInjection": 0.5112509214126949,
+              "emergencyRateCutBps": 80.97428296494748,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 179.6776948293373,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7395748444882007,
+              "depositOutflowRatio": 0.03235674774157029,
+              "interbankTrust": 0.8794211713471102
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.433991215233309,
+              "liquidityBackstop": 0.38559321602376606,
+              "capitalInjection": 0.5112509214126949,
+              "emergencyRateCutBps": 80.97428296494748,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 1036800
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 12,
+      "timestamp": 1036800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.0651208020578,
+              "liquidityIndex": 0.9999590596362988,
+              "lendingVolume": 1.0993770098578484,
+              "stressLevel": 0.08123961112831689,
+              "fundingCost": 3.000651208020578
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 13,
+              "creditSpreadBps": 150.0651208020578,
+              "liquidityIndex": 0.9999590596362988,
+              "lendingVolume": 1.0993770098578484,
+              "stressLevel": 0.08123961112831689,
+              "depositOutflowRatio": 0.032790596633224284,
+              "riskAppetite": 0.7397831706889824,
+              "interbankTrust": 0.8796932208139684,
+              "policySupportLevel": 0.43321276864250213,
+              "liquidityBackstop": 0.38515140933451136,
+              "capitalInjection": 0.5106614082839283,
+              "emergencyRateCutBps": 80.9636900851792,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 177.20998032706402,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7397831706889824,
+              "depositOutflowRatio": 0.032790596633224284,
+              "interbankTrust": 0.8796932208139684
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43321276864250213,
+              "liquidityBackstop": 0.38515140933451136,
+              "capitalInjection": 0.5106614082839283,
+              "emergencyRateCutBps": 80.9636900851792,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 1123200
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 13,
+      "timestamp": 1123200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.03190919300832,
+              "liquidityIndex": 0.9999823956436085,
+              "lendingVolume": 1.0996573554218165,
+              "stressLevel": 0.08070657834314063,
+              "fundingCost": 3.0003190919300833
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 14,
+              "creditSpreadBps": 150.03190919300832,
+              "liquidityIndex": 0.9999823956436085,
+              "lendingVolume": 1.0996573554218165,
+              "stressLevel": 0.08070657834314063,
+              "depositOutflowRatio": 0.03302003485736472,
+              "riskAppetite": 0.739889417051381,
+              "interbankTrust": 0.8798374070314032,
+              "policySupportLevel": 0.43283080210683494,
+              "liquidityBackstop": 0.3849981859205645,
+              "capitalInjection": 0.5103457531006597,
+              "emergencyRateCutBps": 80.97075830000267,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 175.11935947059817,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.739889417051381,
+              "depositOutflowRatio": 0.03302003485736472,
+              "interbankTrust": 0.8798374070314032
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43283080210683494,
+              "liquidityBackstop": 0.3849981859205645,
+              "capitalInjection": 0.5103457531006597,
+              "emergencyRateCutBps": 80.97075830000267,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 1209600
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 14,
+      "timestamp": 1209600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.01563550457408,
+              "liquidityIndex": 0.9999924301267517,
+              "lendingVolume": 1.0998115454819992,
+              "stressLevel": 0.08040274965559016,
+              "fundingCost": 3.000156355045741
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 15,
+              "creditSpreadBps": 150.01563550457408,
+              "liquidityIndex": 0.9999924301267517,
+              "lendingVolume": 1.0998115454819992,
+              "stressLevel": 0.08040274965559016,
+              "depositOutflowRatio": 0.033136071702369374,
+              "riskAppetite": 0.7399436026962043,
+              "interbankTrust": 0.8799138257266437,
+              "policySupportLevel": 0.4326444665085707,
+              "liquidityBackstop": 0.3849532240352406,
+              "capitalInjection": 0.5101765466538947,
+              "emergencyRateCutBps": 80.97890221996141,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 173.3262363301679,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399436026962043,
+              "depositOutflowRatio": 0.033136071702369374,
+              "interbankTrust": 0.8799138257266437
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.4326444665085707,
+              "liquidityBackstop": 0.3849532240352406,
+              "capitalInjection": 0.5101765466538947,
+              "emergencyRateCutBps": 80.97890221996141,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 1296000
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 15,
+      "timestamp": 1296000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.0076613972413,
+              "liquidityIndex": 0.9999967449545032,
+              "lendingVolume": 1.0998963500150996,
+              "stressLevel": 0.0802295673036864,
+              "fundingCost": 3.000076613972413
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 16,
+              "creditSpreadBps": 150.0076613972413,
+              "liquidityIndex": 0.9999967449545032,
+              "lendingVolume": 1.0998963500150996,
+              "stressLevel": 0.0802295673036864,
+              "depositOutflowRatio": 0.033192709287451376,
+              "riskAppetite": 0.7399712373750642,
+              "interbankTrust": 0.8799543276351212,
+              "policySupportLevel": 0.4325529503807613,
+              "liquidityBackstop": 0.38494377675597147,
+              "capitalInjection": 0.510084917467264,
+              "emergencyRateCutBps": 80.98430190828597,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 171.7716646679728,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399712373750642,
+              "depositOutflowRatio": 0.033192709287451376,
+              "interbankTrust": 0.8799543276351212
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.4325529503807613,
+              "liquidityBackstop": 0.38494377675597147,
+              "capitalInjection": 0.510084917467264,
+              "emergencyRateCutBps": 80.98430190828597,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 1382400
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 16,
+      "timestamp": 1382400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.00375408464822,
+              "liquidityIndex": 0.9999986003304364,
+              "lendingVolume": 1.0999429925083049,
+              "stressLevel": 0.08013085336310125,
+              "fundingCost": 3.000037540846482
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 17,
+              "creditSpreadBps": 150.00375408464822,
+              "liquidityIndex": 0.9999986003304364,
+              "lendingVolume": 1.0999429925083049,
+              "stressLevel": 0.08013085336310125,
+              "depositOutflowRatio": 0.03321961930119803,
+              "riskAppetite": 0.7399853310612827,
+              "interbankTrust": 0.8799757936466143,
+              "policySupportLevel": 0.43250715382385024,
+              "liquidityBackstop": 0.3849435571687674,
+              "capitalInjection": 0.5100344900007971,
+              "emergencyRateCutBps": 80.98714474374633,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 170.41117025651502,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399853310612827,
+              "depositOutflowRatio": 0.03321961930119803,
+              "interbankTrust": 0.8799757936466143
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43250715382385024,
+              "liquidityBackstop": 0.3849435571687674,
+              "capitalInjection": 0.5100344900007971,
+              "emergencyRateCutBps": 80.98714474374633,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 1468800
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 17,
+      "timestamp": 1468800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.00183950147763,
+              "liquidityIndex": 0.9999993981420877,
+              "lendingVolume": 1.0999686458795677,
+              "stressLevel": 0.08007458641696771,
+              "fundingCost": 3.0000183950147763
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 18,
+              "creditSpreadBps": 150.00183950147763,
+              "liquidityIndex": 0.9999993981420877,
+              "lendingVolume": 1.0999686458795677,
+              "stressLevel": 0.08007458641696771,
+              "depositOutflowRatio": 0.03323218400222115,
+              "riskAppetite": 0.7399925188412542,
+              "interbankTrust": 0.8799871706327056,
+              "policySupportLevel": 0.43248359329941455,
+              "liquidityBackstop": 0.3849445182598639,
+              "capitalInjection": 0.5100062198610622,
+              "emergencyRateCutBps": 80.98839025923743,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 169.21062138857164,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399925188412542,
+              "depositOutflowRatio": 0.03323218400222115,
+              "interbankTrust": 0.8799871706327056
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43248359329941455,
+              "liquidityBackstop": 0.3849445182598639,
+              "capitalInjection": 0.5100062198610622,
+              "emergencyRateCutBps": 80.98839025923743,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 1555200
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 18,
+      "timestamp": 1555200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.00090135572404,
+              "liquidityIndex": 0.9999997412010977,
+              "lendingVolume": 1.0999827552337622,
+              "stressLevel": 0.0800425142576716,
+              "fundingCost": 3.00000901355724
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 19,
+              "creditSpreadBps": 150.00090135572404,
+              "liquidityIndex": 0.9999997412010977,
+              "lendingVolume": 1.0999827552337622,
+              "stressLevel": 0.0800425142576716,
+              "depositOutflowRatio": 0.033238015752202685,
+              "riskAppetite": 0.7399961846090396,
+              "interbankTrust": 0.879993200435334,
+              "policySupportLevel": 0.43247108844825205,
+              "liquidityBackstop": 0.38494492428011673,
+              "capitalInjection": 0.509990094055524,
+              "emergencyRateCutBps": 80.9888199329388,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 168.14341472008013,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399961846090396,
+              "depositOutflowRatio": 0.033238015752202685,
+              "interbankTrust": 0.879993200435334
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43247108844825205,
+              "liquidityBackstop": 0.38494492428011673,
+              "capitalInjection": 0.509990094055524,
+              "emergencyRateCutBps": 80.9888199329388,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 1641600
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 19,
+      "timestamp": 1641600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.0004416643048,
+              "liquidityIndex": 0.999999888716472,
+              "lendingVolume": 1.0999905153785692,
+              "stressLevel": 0.08002423312687282,
+              "fundingCost": 3.0000044166430477
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 20,
+              "creditSpreadBps": 150.0004416643048,
+              "liquidityIndex": 0.999999888716472,
+              "lendingVolume": 1.0999905153785692,
+              "stressLevel": 0.08002423312687282,
+              "depositOutflowRatio": 0.033240743151050814,
+              "riskAppetite": 0.7399980541506102,
+              "interbankTrust": 0.879996396230727,
+              "policySupportLevel": 0.4324642589297897,
+              "liquidityBackstop": 0.3849448062165871,
+              "capitalInjection": 0.5099807679752122,
+              "emergencyRateCutBps": 80.98889922701858,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 167.1885214013551,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399980541506102,
+              "depositOutflowRatio": 0.033240743151050814,
+              "interbankTrust": 0.879996396230727
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.4324642589297897,
+              "liquidityBackstop": 0.3849448062165871,
+              "capitalInjection": 0.5099807679752122,
+              "emergencyRateCutBps": 80.98889922701858,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 1728000
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 20,
+      "timestamp": 1728000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.00021641550936,
+              "liquidityIndex": 0.999999952148083,
+              "lendingVolume": 1.099994783458213,
+              "stressLevel": 0.0800138128823175,
+              "fundingCost": 3.0000021641550934
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 21,
+              "creditSpreadBps": 150.00021641550936,
+              "liquidityIndex": 0.999999952148083,
+              "lendingVolume": 1.099994783458213,
+              "stressLevel": 0.0800138128823175,
+              "depositOutflowRatio": 0.03324204685494382,
+              "riskAppetite": 0.7399990076168111,
+              "interbankTrust": 0.8799980900022853,
+              "policySupportLevel": 0.4324604477012376,
+              "liquidityBackstop": 0.38494446775047336,
+              "capitalInjection": 0.5099753246339686,
+              "emergencyRateCutBps": 80.98885953653141,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 166.32910615206282,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399990076168111,
+              "depositOutflowRatio": 0.03324204685494382,
+              "interbankTrust": 0.8799980900022853
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.4324604477012376,
+              "liquidityBackstop": 0.38494446775047336,
+              "capitalInjection": 0.5099753246339686,
+              "emergencyRateCutBps": 80.98885953653141,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 1814400
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 21,
+      "timestamp": 1814400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.00010604359957,
+              "liquidityIndex": 0.9999999794236757,
+              "lendingVolume": 1.0999971309020173,
+              "stressLevel": 0.08000787334292098,
+              "fundingCost": 3.000001060435996
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 22,
+              "creditSpreadBps": 150.00010604359957,
+              "liquidityIndex": 0.9999999794236757,
+              "lendingVolume": 1.0999971309020173,
+              "stressLevel": 0.08000787334292098,
+              "depositOutflowRatio": 0.03324269116429041,
+              "riskAppetite": 0.7399994938845736,
+              "interbankTrust": 0.8799989877012112,
+              "policySupportLevel": 0.43245829321686785,
+              "liquidityBackstop": 0.38494411507207116,
+              "capitalInjection": 0.5099721324141143,
+              "emergencyRateCutBps": 80.98879828499793,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 165.55153471832648,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399994938845736,
+              "depositOutflowRatio": 0.03324269116429041,
+              "interbankTrust": 0.8799989877012112
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245829321686785,
+              "liquidityBackstop": 0.38494411507207116,
+              "capitalInjection": 0.5099721324141143,
+              "emergencyRateCutBps": 80.98879828499793,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 1900800
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 22,
+      "timestamp": 1900800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.0000519613638,
+              "liquidityIndex": 0.9999999911521805,
+              "lendingVolume": 1.0999984219961096,
+              "stressLevel": 0.08000448780546496,
+              "fundingCost": 3.000000519613638
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 23,
+              "creditSpreadBps": 150.0000519613638,
+              "liquidityIndex": 0.9999999911521805,
+              "lendingVolume": 1.0999984219961096,
+              "stressLevel": 0.08000448780546496,
+              "depositOutflowRatio": 0.033243022015909084,
+              "riskAppetite": 0.7399997418811326,
+              "interbankTrust": 0.8799994634816419,
+              "policySupportLevel": 0.43245706918354904,
+              "liquidityBackstop": 0.3849438340058923,
+              "capitalInjection": 0.509970258183669,
+              "emergencyRateCutBps": 80.98874792529445,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 164.84464913846452,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399997418811326,
+              "depositOutflowRatio": 0.033243022015909084,
+              "interbankTrust": 0.8799994634816419
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245706918354904,
+              "liquidityBackstop": 0.3849438340058923,
+              "capitalInjection": 0.509970258183669,
+              "emergencyRateCutBps": 80.98874792529445,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 1987200
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 23,
+      "timestamp": 1987200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.00002546106825,
+              "liquidityIndex": 0.9999999961954377,
+              "lendingVolume": 1.0999991320978604,
+              "stressLevel": 0.08000255804911503,
+              "fundingCost": 3.0000002546106828
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 24,
+              "creditSpreadBps": 150.00002546106825,
+              "liquidityIndex": 0.9999999961954377,
+              "lendingVolume": 1.0999991320978604,
+              "stressLevel": 0.08000255804911503,
+              "depositOutflowRatio": 0.03324319794562917,
+              "riskAppetite": 0.7399998683593776,
+              "interbankTrust": 0.8799997156452702,
+              "policySupportLevel": 0.4324563744292778,
+              "liquidityBackstop": 0.38494363899073186,
+              "capitalInjection": 0.5099691592539117,
+              "emergencyRateCutBps": 80.9887141001266,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 164.19923071770816,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399998683593776,
+              "depositOutflowRatio": 0.03324319794562917,
+              "interbankTrust": 0.8799997156452702
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.4324563744292778,
+              "liquidityBackstop": 0.38494363899073186,
+              "capitalInjection": 0.5099691592539117,
+              "emergencyRateCutBps": 80.9887141001266,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 2073600
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 24,
+      "timestamp": 2073600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.00001247592346,
+              "liquidityIndex": 0.9999999983640382,
+              "lendingVolume": 1.0999995226538233,
+              "stressLevel": 0.08000145808799557,
+              "fundingCost": 3.0000001247592345
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 25,
+              "creditSpreadBps": 150.00001247592346,
+              "liquidityIndex": 0.9999999983640382,
+              "lendingVolume": 1.0999995226538233,
+              "stressLevel": 0.08000145808799557,
+              "depositOutflowRatio": 0.03324329389386507,
+              "riskAppetite": 0.7399999328632826,
+              "interbankTrust": 0.8799998492919933,
+              "policySupportLevel": 0.4324559819552655,
+              "liquidityBackstop": 0.3849435151105608,
+              "capitalInjection": 0.5099685167257266,
+              "emergencyRateCutBps": 80.98869372307175,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 163.60759662430047,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999328632826,
+              "depositOutflowRatio": 0.03324329389386507,
+              "interbankTrust": 0.8799998492919933
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.4324559819552655,
+              "liquidityBackstop": 0.3849435151105608,
+              "capitalInjection": 0.5099685167257266,
+              "emergencyRateCutBps": 80.98869372307175,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 2160000
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 25,
+      "timestamp": 2160000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.0000061132025,
+              "liquidityIndex": 0.9999999992965364,
+              "lendingVolume": 1.0999997374596029,
+              "stressLevel": 0.08000083111015747,
+              "fundingCost": 3.0000000611320248
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 26,
+              "creditSpreadBps": 150.0000061132025,
+              "liquidityIndex": 0.9999999992965364,
+              "lendingVolume": 1.0999997374596029,
+              "stressLevel": 0.08000083111015747,
+              "depositOutflowRatio": 0.033243346933485116,
+              "riskAppetite": 0.7399999657602742,
+              "interbankTrust": 0.8799999201247565,
+              "policySupportLevel": 0.43245576171871813,
+              "liquidityBackstop": 0.3849434411565592,
+              "capitalInjection": 0.5099681423502116,
+              "emergencyRateCutBps": 80.98868228741128,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 163.06329300385653,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999657602742,
+              "depositOutflowRatio": 0.033243346933485116,
+              "interbankTrust": 0.8799999201247565
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245576171871813,
+              "liquidityBackstop": 0.3849434411565592,
+              "capitalInjection": 0.5099681423502116,
+              "emergencyRateCutBps": 80.98868228741128,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 2246400
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 26,
+      "timestamp": 2246400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.00000299546923,
+              "liquidityIndex": 0.9999999996975106,
+              "lendingVolume": 1.0999998556027817,
+              "stressLevel": 0.08000047373278976,
+              "fundingCost": 3.000000029954692
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 27,
+              "creditSpreadBps": 150.00000299546923,
+              "liquidityIndex": 0.9999999996975106,
+              "lendingVolume": 1.0999998556027817,
+              "stressLevel": 0.08000047373278976,
+              "depositOutflowRatio": 0.03324337633911911,
+              "riskAppetite": 0.7399999825377398,
+              "interbankTrust": 0.8799999576661209,
+              "policySupportLevel": 0.43245563902274636,
+              "liquidityBackstop": 0.38494339898487295,
+              "capitalInjection": 0.509967924983466,
+              "emergencyRateCutBps": 80.98867618309355,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 162.56085877276473,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999825377398,
+              "depositOutflowRatio": 0.03324337633911911,
+              "interbankTrust": 0.8799999576661209
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245563902274636,
+              "liquidityBackstop": 0.38494339898487295,
+              "capitalInjection": 0.509967924983466,
+              "emergencyRateCutBps": 80.98867618309355,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 2332800
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 27,
+      "timestamp": 2332800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.00000146777992,
+              "liquidityIndex": 0.9999999998699296,
+              "lendingVolume": 1.09999992058153,
+              "stressLevel": 0.08000027002769017,
+              "fundingCost": 3.0000000146777994
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 28,
+              "creditSpreadBps": 150.00000146777992,
+              "liquidityIndex": 0.9999999998699296,
+              "lendingVolume": 1.09999992058153,
+              "stressLevel": 0.08000027002769017,
+              "depositOutflowRatio": 0.033243392561958074,
+              "riskAppetite": 0.7399999910942473,
+              "interbankTrust": 0.879999977563044,
+              "policySupportLevel": 0.43245557113065936,
+              "liquidityBackstop": 0.384943375743241,
+              "capitalInjection": 0.5099677991792985,
+              "emergencyRateCutBps": 80.98867303863959,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 162.09564183554306,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999910942473,
+              "depositOutflowRatio": 0.033243392561958074,
+              "interbankTrust": 0.879999977563044
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245557113065936,
+              "liquidityBackstop": 0.384943375743241,
+              "capitalInjection": 0.5099677991792985,
+              "emergencyRateCutBps": 80.98867303863959,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 2419200
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 28,
+      "timestamp": 2419200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.00000071921215,
+              "liquidityIndex": 0.9999999999440697,
+              "lendingVolume": 1.0999999563198415,
+              "stressLevel": 0.0800001539157834,
+              "fundingCost": 3.0000000071921216
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 29,
+              "creditSpreadBps": 150.00000071921215,
+              "liquidityIndex": 0.9999999999440697,
+              "lendingVolume": 1.0999999563198415,
+              "stressLevel": 0.0800001539157834,
+              "depositOutflowRatio": 0.0332434014238937,
+              "riskAppetite": 0.7399999954580662,
+              "interbankTrust": 0.8799999881084134,
+              "policySupportLevel": 0.43245553377874213,
+              "liquidityBackstop": 0.38494336324540496,
+              "capitalInjection": 0.5099677265599476,
+              "emergencyRateCutBps": 80.98867145611122,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 161.66365465281697,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999954580662,
+              "depositOutflowRatio": 0.0332434014238937,
+              "interbankTrust": 0.8799999881084134
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245553377874213,
+              "liquidityBackstop": 0.38494336324540496,
+              "capitalInjection": 0.5099677265599476,
+              "emergencyRateCutBps": 80.98867145611122,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 2505600
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 29,
+      "timestamp": 2505600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.00000035241396,
+              "liquidityIndex": 0.99999999997595,
+              "lendingVolume": 1.099999975975913,
+              "stressLevel": 0.08000008773199654,
+              "fundingCost": 3.0000000035241396
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 30,
+              "creditSpreadBps": 150.00000035241396,
+              "liquidityIndex": 0.99999999997595,
+              "lendingVolume": 1.099999975975913,
+              "stressLevel": 0.08000008773199654,
+              "depositOutflowRatio": 0.03324340620446893,
+              "riskAppetite": 0.7399999976836137,
+              "interbankTrust": 0.8799999936974591,
+              "policySupportLevel": 0.4324555133179773,
+              "liquidityBackstop": 0.38494335663207224,
+              "capitalInjection": 0.5099676847249418,
+              "emergencyRateCutBps": 80.9886706683902,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 161.261459676941,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999976836137,
+              "depositOutflowRatio": 0.03324340620446893,
+              "interbankTrust": 0.8799999936974591
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.4324555133179773,
+              "liquidityBackstop": 0.38494335663207224,
+              "capitalInjection": 0.5099676847249418,
+              "emergencyRateCutBps": 80.9886706683902,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 2592000
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 30,
+      "timestamp": 2592000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.00000017268283,
+              "liquidityIndex": 0.9999999999896585,
+              "lendingVolume": 1.0999999867867523,
+              "stressLevel": 0.08000005000723803,
+              "fundingCost": 3.0000000017268285
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 31,
+              "creditSpreadBps": 150.00000017268283,
+              "liquidityIndex": 0.9999999999896585,
+              "lendingVolume": 1.0999999867867523,
+              "stressLevel": 0.08000005000723803,
+              "depositOutflowRatio": 0.03324340874868199,
+              "riskAppetite": 0.739999998818643,
+              "interbankTrust": 0.8799999966596533,
+              "policySupportLevel": 0.4324555021412045,
+              "liquidityBackstop": 0.3849433531607592,
+              "capitalInjection": 0.5099676606577057,
+              "emergencyRateCutBps": 80.9886702756138,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 160.88607769346572,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.739999998818643,
+              "depositOutflowRatio": 0.03324340874868199,
+              "interbankTrust": 0.8799999966596533
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.4324555021412045,
+              "liquidityBackstop": 0.3849433531607592,
+              "capitalInjection": 0.5099676606577057,
+              "emergencyRateCutBps": 80.9886702756138,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 2678400
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 31,
+      "timestamp": 2678400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.00000008461458,
+              "liquidityIndex": 0.9999999999955531,
+              "lendingVolume": 1.0999999927327138,
+              "stressLevel": 0.08000002850412567,
+              "fundingCost": 3.000000000846146
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 32,
+              "creditSpreadBps": 150.00000008461458,
+              "liquidityIndex": 0.9999999999955531,
+              "lendingVolume": 1.0999999927327138,
+              "stressLevel": 0.08000002850412567,
+              "depositOutflowRatio": 0.03324341008472309,
+              "riskAppetite": 0.7399999993975079,
+              "interbankTrust": 0.8799999982296163,
+              "policySupportLevel": 0.4324554960436989,
+              "liquidityBackstop": 0.3849433513397934,
+              "capitalInjection": 0.5099676468237279,
+              "emergencyRateCutBps": 80.98867007695344,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 160.53491389963182,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999993975079,
+              "depositOutflowRatio": 0.03324341008472309,
+              "interbankTrust": 0.8799999982296163
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.4324554960436989,
+              "liquidityBackstop": 0.3849433513397934,
+              "capitalInjection": 0.5099676468237279,
+              "emergencyRateCutBps": 80.98867007695344,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 2764800
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 32,
+      "timestamp": 2764800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.00000004146113,
+              "liquidityIndex": 0.9999999999980879,
+              "lendingVolume": 1.0999999960029927,
+              "stressLevel": 0.08000001624735163,
+              "fundingCost": 3.0000000004146115
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 33,
+              "creditSpreadBps": 150.00000004146113,
+              "liquidityIndex": 0.9999999999980879,
+              "lendingVolume": 1.0999999960029927,
+              "stressLevel": 0.08000001624735163,
+              "depositOutflowRatio": 0.033243410777647066,
+              "riskAppetite": 0.739999999692729,
+              "interbankTrust": 0.8799999990616967,
+              "policySupportLevel": 0.4324554927170154,
+              "liquidityBackstop": 0.3849433503788613,
+              "capitalInjection": 0.5099676388751461,
+              "emergencyRateCutBps": 80.98866997397744,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 160.205697841564,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.739999999692729,
+              "depositOutflowRatio": 0.033243410777647066,
+              "interbankTrust": 0.8799999990616967
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.4324554927170154,
+              "liquidityBackstop": 0.3849433503788613,
+              "capitalInjection": 0.5099676388751461,
+              "emergencyRateCutBps": 80.98866997397744,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 2851200
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 33,
+      "timestamp": 2851200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.00000002031595,
+              "liquidityIndex": 0.9999999999991778,
+              "lendingVolume": 1.099999997801646,
+              "stressLevel": 0.08000000926099043,
+              "fundingCost": 3.0000000002031593
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 34,
+              "creditSpreadBps": 150.00000002031595,
+              "liquidityIndex": 0.9999999999991778,
+              "lendingVolume": 1.099999997801646,
+              "stressLevel": 0.08000000926099043,
+              "depositOutflowRatio": 0.03324341113309645,
+              "riskAppetite": 0.7399999998432918,
+              "interbankTrust": 0.8799999995026992,
+              "policySupportLevel": 0.43245549089998914,
+              "liquidityBackstop": 0.38494334986618906,
+              "capitalInjection": 0.5099676343086013,
+              "emergencyRateCutBps": 80.988669918967,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 159.89643427122314,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999998432918,
+              "depositOutflowRatio": 0.03324341113309645,
+              "interbankTrust": 0.8799999995026992
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245549089998914,
+              "liquidityBackstop": 0.38494334986618906,
+              "capitalInjection": 0.5099676343086013,
+              "emergencyRateCutBps": 80.988669918967,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 2937600
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 34,
+      "timestamp": 2937600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.00000000995482,
+              "liquidityIndex": 0.9999999999996464,
+              "lendingVolume": 1.0999999987909053,
+              "stressLevel": 0.08000000527876455,
+              "fundingCost": 3.000000000099548
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 35,
+              "creditSpreadBps": 150.00000000995482,
+              "liquidityIndex": 0.9999999999996464,
+              "lendingVolume": 1.0999999987909053,
+              "stressLevel": 0.08000000527876455,
+              "depositOutflowRatio": 0.033243411313755224,
+              "riskAppetite": 0.7399999999200788,
+              "interbankTrust": 0.8799999997364306,
+              "policySupportLevel": 0.43245548990566135,
+              "liquidityBackstop": 0.3849433495888638,
+              "capitalInjection": 0.5099676316848418,
+              "emergencyRateCutBps": 80.98866988869341,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 159.60536267530347,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999200788,
+              "depositOutflowRatio": 0.033243411313755224,
+              "interbankTrust": 0.8799999997364306
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548990566135,
+              "liquidityBackstop": 0.3849433495888638,
+              "capitalInjection": 0.5099676316848418,
+              "emergencyRateCutBps": 80.98866988869341,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 3024000
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 35,
+      "timestamp": 3024000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.00000000487785,
+              "liquidityIndex": 0.9999999999998479,
+              "lendingVolume": 1.099999999334998,
+              "stressLevel": 0.0800000030088958,
+              "fundingCost": 3.0000000000487788
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 36,
+              "creditSpreadBps": 150.00000000487785,
+              "liquidityIndex": 0.9999999999998479,
+              "lendingVolume": 1.099999999334998,
+              "stressLevel": 0.0800000030088958,
+              "depositOutflowRatio": 0.03324341140490515,
+              "riskAppetite": 0.7399999999592402,
+              "interbankTrust": 0.8799999998603082,
+              "policySupportLevel": 0.43245548936027833,
+              "liquidityBackstop": 0.38494334943667907,
+              "capitalInjection": 0.509967630177063,
+              "emergencyRateCutBps": 80.98866987162405,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 159.33092374186273,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999592402,
+              "depositOutflowRatio": 0.03324341140490515,
+              "interbankTrust": 0.8799999998603082
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548936027833,
+              "liquidityBackstop": 0.38494334943667907,
+              "capitalInjection": 0.509967630177063,
+              "emergencyRateCutBps": 80.98866987162405,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 3110400
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 36,
+      "timestamp": 3110400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.00000000239015,
+              "liquidityIndex": 0.9999999999999346,
+              "lendingVolume": 1.0999999996342489,
+              "stressLevel": 0.0800000017150706,
+              "fundingCost": 3.0000000000239018
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 37,
+              "creditSpreadBps": 150.00000000239015,
+              "liquidityIndex": 0.9999999999999346,
+              "lendingVolume": 1.0999999996342489,
+              "stressLevel": 0.0800000017150706,
+              "depositOutflowRatio": 0.033243411450644356,
+              "riskAppetite": 0.7399999999792125,
+              "interbankTrust": 0.8799999999259633,
+              "policySupportLevel": 0.43245548906040904,
+              "liquidityBackstop": 0.3849433493520866,
+              "capitalInjection": 0.5099676293104323,
+              "emergencyRateCutBps": 80.98866986184211,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 159.0717314157663,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999792125,
+              "depositOutflowRatio": 0.033243411450644356,
+              "interbankTrust": 0.8799999999259633
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548906040904,
+              "liquidityBackstop": 0.3849433493520866,
+              "capitalInjection": 0.5099676293104323,
+              "emergencyRateCutBps": 80.98866986184211,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 3196800
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 37,
+      "timestamp": 3196800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.00000000117117,
+              "liquidityIndex": 0.9999999999999719,
+              "lendingVolume": 1.099999999798837,
+              "stressLevel": 0.08000000097759025,
+              "fundingCost": 3.0000000000117115
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 38,
+              "creditSpreadBps": 150.00000000117117,
+              "liquidityIndex": 0.9999999999999719,
+              "lendingVolume": 1.099999999798837,
+              "stressLevel": 0.08000000097759025,
+              "depositOutflowRatio": 0.033243411473510585,
+              "riskAppetite": 0.7399999999893984,
+              "interbankTrust": 0.8799999999607606,
+              "policySupportLevel": 0.4324554888951477,
+              "liquidityBackstop": 0.38494334930459134,
+              "capitalInjection": 0.5099676288122404,
+              "emergencyRateCutBps": 80.98866985618984,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 158.8265494856421,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999893984,
+              "depositOutflowRatio": 0.033243411473510585,
+              "interbankTrust": 0.8799999999607606
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.4324554888951477,
+              "liquidityBackstop": 0.38494334930459134,
+              "capitalInjection": 0.5099676288122404,
+              "emergencyRateCutBps": 80.98866985618984,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 3283200
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 38,
+      "timestamp": 3283200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.00000000057386,
+              "liquidityIndex": 0.9999999999999879,
+              "lendingVolume": 1.0999999998893604,
+              "stressLevel": 0.08000000055722645,
+              "fundingCost": 3.0000000000057385
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 39,
+              "creditSpreadBps": 150.00000000057386,
+              "liquidityIndex": 0.9999999999999879,
+              "lendingVolume": 1.0999999998893604,
+              "stressLevel": 0.08000000055722645,
+              "depositOutflowRatio": 0.033243411484914484,
+              "riskAppetite": 0.7399999999945932,
+              "interbankTrust": 0.8799999999792031,
+              "policySupportLevel": 0.4324554888038839,
+              "liquidityBackstop": 0.38494334927774465,
+              "capitalInjection": 0.5099676285258257,
+              "emergencyRateCutBps": 80.98866985291775,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 158.594271867614,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999945932,
+              "depositOutflowRatio": 0.033243411484914484,
+              "interbankTrust": 0.8799999999792031
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.4324554888038839,
+              "liquidityBackstop": 0.38494334927774465,
+              "capitalInjection": 0.5099676285258257,
+              "emergencyRateCutBps": 80.98866985291775,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 3369600
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 39,
+      "timestamp": 3369600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.0000000002812,
+              "liquidityIndex": 0.9999999999999948,
+              "lendingVolume": 1.0999999999391483,
+              "stressLevel": 0.08000000031761907,
+              "fundingCost": 3.000000000002812
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 40,
+              "creditSpreadBps": 150.0000000002812,
+              "liquidityIndex": 0.9999999999999948,
+              "lendingVolume": 1.0999999999391483,
+              "stressLevel": 0.08000000031761907,
+              "depositOutflowRatio": 0.033243411490592685,
+              "riskAppetite": 0.7399999999972425,
+              "interbankTrust": 0.8799999999889776,
+              "policySupportLevel": 0.43245548875339984,
+              "liquidityBackstop": 0.3849433492625147,
+              "capitalInjection": 0.5099676283611625,
+              "emergencyRateCutBps": 80.98866985102823,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 158.37390592229775,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999972425,
+              "depositOutflowRatio": 0.033243411490592685,
+              "interbankTrust": 0.8799999999889776
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548875339984,
+              "liquidityBackstop": 0.3849433492625147,
+              "capitalInjection": 0.5099676283611625,
+              "emergencyRateCutBps": 80.98866985102823,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 3456000
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 40,
+      "timestamp": 3456000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.0000000001378,
+              "liquidityIndex": 0.9999999999999978,
+              "lendingVolume": 1.0999999999665315,
+              "stressLevel": 0.08000000018104288,
+              "fundingCost": 3.0000000000013776
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 41,
+              "creditSpreadBps": 150.0000000001378,
+              "liquidityIndex": 0.9999999999999978,
+              "lendingVolume": 1.0999999999665315,
+              "stressLevel": 0.08000000018104288,
+              "depositOutflowRatio": 0.03324341149341579,
+              "riskAppetite": 0.7399999999985937,
+              "interbankTrust": 0.8799999999941581,
+              "policySupportLevel": 0.4324554887254376,
+              "liquidityBackstop": 0.3849433492538656,
+              "capitalInjection": 0.5099676282665022,
+              "emergencyRateCutBps": 80.98866984994247,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 158.16455827424375,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999985937,
+              "depositOutflowRatio": 0.03324341149341579,
+              "interbankTrust": 0.8799999999941581
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.4324554887254376,
+              "liquidityBackstop": 0.3849433492538656,
+              "capitalInjection": 0.5099676282665022,
+              "emergencyRateCutBps": 80.98866984994247,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 3542400
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 41,
+      "timestamp": 3542400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.00000000006753,
+              "liquidityIndex": 0.999999999999999,
+              "lendingVolume": 1.0999999999815924,
+              "stressLevel": 0.08000000010319444,
+              "fundingCost": 3.000000000000675
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 42,
+              "creditSpreadBps": 150.00000000006753,
+              "liquidityIndex": 0.999999999999999,
+              "lendingVolume": 1.0999999999815924,
+              "stressLevel": 0.08000000010319444,
+              "depositOutflowRatio": 0.03324341149481642,
+              "riskAppetite": 0.7399999999992828,
+              "interbankTrust": 0.8799999999969038,
+              "policySupportLevel": 0.4324554887099352,
+              "liquidityBackstop": 0.3849433492489572,
+              "capitalInjection": 0.5099676282120919,
+              "emergencyRateCutBps": 80.98866984932222,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 157.9654227065809,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999992828,
+              "depositOutflowRatio": 0.03324341149481642,
+              "interbankTrust": 0.8799999999969038
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.4324554887099352,
+              "liquidityBackstop": 0.3849433492489572,
+              "capitalInjection": 0.5099676282120919,
+              "emergencyRateCutBps": 80.98866984932222,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 3628800
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 42,
+      "timestamp": 3628800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.00000000003308,
+              "liquidityIndex": 0.9999999999999996,
+              "lendingVolume": 1.0999999999898757,
+              "stressLevel": 0.08000000005882084,
+              "fundingCost": 3.000000000000331
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 43,
+              "creditSpreadBps": 150.00000000003308,
+              "liquidityIndex": 0.9999999999999996,
+              "lendingVolume": 1.0999999999898757,
+              "stressLevel": 0.08000000005882084,
+              "depositOutflowRatio": 0.03324341149550886,
+              "riskAppetite": 0.7399999999996342,
+              "interbankTrust": 0.879999999998359,
+              "policySupportLevel": 0.43245548870133504,
+              "liquidityBackstop": 0.3849433492461766,
+              "capitalInjection": 0.5099676281808224,
+              "emergencyRateCutBps": 80.98866984896999,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 157.7757697849964,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999996342,
+              "depositOutflowRatio": 0.03324341149550886,
+              "interbankTrust": 0.879999999998359
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548870133504,
+              "liquidityBackstop": 0.3849433492461766,
+              "capitalInjection": 0.5099676281808224,
+              "emergencyRateCutBps": 80.98866984896999,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 3715200
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 43,
+      "timestamp": 3715200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.0000000000162,
+              "liquidityIndex": 0.9999999999999998,
+              "lendingVolume": 1.0999999999944317,
+              "stressLevel": 0.08000000003352788,
+              "fundingCost": 3.000000000000162
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 44,
+              "creditSpreadBps": 150.0000000000162,
+              "liquidityIndex": 0.9999999999999998,
+              "lendingVolume": 1.0999999999944317,
+              "stressLevel": 0.08000000003352788,
+              "depositOutflowRatio": 0.033243411495849154,
+              "riskAppetite": 0.7399999999998135,
+              "interbankTrust": 0.8799999999991303,
+              "policySupportLevel": 0.4324554886965619,
+              "liquidityBackstop": 0.38494334924460505,
+              "capitalInjection": 0.5099676281628558,
+              "emergencyRateCutBps": 80.98866984877101,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 157.59493792953177,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999998135,
+              "depositOutflowRatio": 0.033243411495849154,
+              "interbankTrust": 0.8799999999991303
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.4324554886965619,
+              "liquidityBackstop": 0.38494334924460505,
+              "capitalInjection": 0.5099676281628558,
+              "emergencyRateCutBps": 80.98866984877101,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 3801600
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 44,
+      "timestamp": 3801600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.00000000000793,
+              "liquidityIndex": 0.9999999999999999,
+              "lendingVolume": 1.0999999999969374,
+              "stressLevel": 0.0800000000191109,
+              "fundingCost": 3.000000000000079
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 45,
+              "creditSpreadBps": 150.00000000000793,
+              "liquidityIndex": 0.9999999999999999,
+              "lendingVolume": 1.0999999999969374,
+              "stressLevel": 0.0800000000191109,
+              "depositOutflowRatio": 0.0332434114960149,
+              "riskAppetite": 0.7399999999999048,
+              "interbankTrust": 0.879999999999539,
+              "policySupportLevel": 0.4324554886939119,
+              "liquidityBackstop": 0.38494334924371887,
+              "capitalInjection": 0.5099676281525348,
+              "emergencyRateCutBps": 80.98866984865904,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 157.4223257038608,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999048,
+              "depositOutflowRatio": 0.0332434114960149,
+              "interbankTrust": 0.879999999999539
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.4324554886939119,
+              "liquidityBackstop": 0.38494334924371887,
+              "capitalInjection": 0.5099676281525348,
+              "emergencyRateCutBps": 80.98866984865904,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 3888000
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 45,
+      "timestamp": 3888000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.0000000000039,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999983157,
+              "stressLevel": 0.0800000000108932,
+              "fundingCost": 3.000000000000039
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 46,
+              "creditSpreadBps": 150.0000000000039,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999983157,
+              "stressLevel": 0.0800000000108932,
+              "depositOutflowRatio": 0.03324341149609457,
+              "riskAppetite": 0.7399999999999515,
+              "interbankTrust": 0.8799999999997556,
+              "policySupportLevel": 0.4324554886924403,
+              "liquidityBackstop": 0.3849433492432201,
+              "capitalInjection": 0.5099676281466072,
+              "emergencyRateCutBps": 80.98866984859623,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 157.25738513266396,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999515,
+              "depositOutflowRatio": 0.03324341149609457,
+              "interbankTrust": 0.8799999999997556
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.4324554886924403,
+              "liquidityBackstop": 0.3849433492432201,
+              "capitalInjection": 0.5099676281466072,
+              "emergencyRateCutBps": 80.98866984859623,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 3974400
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 46,
+      "timestamp": 3974400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.0000000000019,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999990737,
+              "stressLevel": 0.08000000000620913,
+              "fundingCost": 3.000000000000019
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 47,
+              "creditSpreadBps": 150.0000000000019,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999990737,
+              "stressLevel": 0.08000000000620913,
+              "depositOutflowRatio": 0.033243411496132115,
+              "riskAppetite": 0.7399999999999752,
+              "interbankTrust": 0.8799999999998704,
+              "policySupportLevel": 0.4324554886916229,
+              "liquidityBackstop": 0.3849433492429399,
+              "capitalInjection": 0.5099676281432036,
+              "emergencyRateCutBps": 80.98866984856106,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 157.09961589064957,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999752,
+              "depositOutflowRatio": 0.033243411496132115,
+              "interbankTrust": 0.8799999999998704
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.4324554886916229,
+              "liquidityBackstop": 0.3849433492429399,
+              "capitalInjection": 0.5099676281432036,
+              "emergencyRateCutBps": 80.98866984856106,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 4060800
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 47,
+      "timestamp": 4060800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.00000000000094,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999994905,
+              "stressLevel": 0.08000000000353921,
+              "fundingCost": 3.0000000000000093
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 48,
+              "creditSpreadBps": 150.00000000000094,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999994905,
+              "stressLevel": 0.08000000000353921,
+              "depositOutflowRatio": 0.033243411496149344,
+              "riskAppetite": 0.7399999999999873,
+              "interbankTrust": 0.8799999999999313,
+              "policySupportLevel": 0.4324554886911688,
+              "liquidityBackstop": 0.38494334924278256,
+              "capitalInjection": 0.5099676281412496,
+              "emergencyRateCutBps": 80.98866984854138,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 156.9485602334017,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999873,
+              "depositOutflowRatio": 0.033243411496149344,
+              "interbankTrust": 0.8799999999999313
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.4324554886911688,
+              "liquidityBackstop": 0.38494334924278256,
+              "capitalInjection": 0.5099676281412496,
+              "emergencyRateCutBps": 80.98866984854138,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 4147200
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 48,
+      "timestamp": 4147200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.00000000000045,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999997199,
+              "stressLevel": 0.08000000000201735,
+              "fundingCost": 3.0000000000000044
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 49,
+              "creditSpreadBps": 150.00000000000045,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999997199,
+              "stressLevel": 0.08000000000201735,
+              "depositOutflowRatio": 0.03324341149615689,
+              "riskAppetite": 0.7399999999999936,
+              "interbankTrust": 0.8799999999999636,
+              "policySupportLevel": 0.4324554886909164,
+              "liquidityBackstop": 0.3849433492426943,
+              "capitalInjection": 0.5099676281401281,
+              "emergencyRateCutBps": 80.98866984853036,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 156.80379856187253,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999936,
+              "depositOutflowRatio": 0.03324341149615689,
+              "interbankTrust": 0.8799999999999636
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.4324554886909164,
+              "liquidityBackstop": 0.3849433492426943,
+              "capitalInjection": 0.5099676281401281,
+              "emergencyRateCutBps": 80.98866984853036,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 4233600
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 49,
+      "timestamp": 4233600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.00000000000023,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.099999999999846,
+              "stressLevel": 0.08000000000114989,
+              "fundingCost": 3.000000000000002
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 50,
+              "creditSpreadBps": 150.00000000000023,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.099999999999846,
+              "stressLevel": 0.08000000000114989,
+              "depositOutflowRatio": 0.03324341149616002,
+              "riskAppetite": 0.7399999999999967,
+              "interbankTrust": 0.8799999999999807,
+              "policySupportLevel": 0.432455488690776,
+              "liquidityBackstop": 0.3849433492426448,
+              "capitalInjection": 0.5099676281394844,
+              "emergencyRateCutBps": 80.9886698485242,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 156.66494552999757,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999967,
+              "depositOutflowRatio": 0.03324341149616002,
+              "interbankTrust": 0.8799999999999807
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.432455488690776,
+              "liquidityBackstop": 0.3849433492426448,
+              "capitalInjection": 0.5099676281394844,
+              "emergencyRateCutBps": 80.9886698485242,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 4320000
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 50,
+      "timestamp": 4320000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.0000000000001,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999153,
+              "stressLevel": 0.08000000000065544,
+              "fundingCost": 3.000000000000001
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 51,
+              "creditSpreadBps": 150.0000000000001,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999153,
+              "stressLevel": 0.08000000000065544,
+              "depositOutflowRatio": 0.033243411496161175,
+              "riskAppetite": 0.7399999999999983,
+              "interbankTrust": 0.8799999999999898,
+              "policySupportLevel": 0.4324554886906979,
+              "liquidityBackstop": 0.38494334924261703,
+              "capitalInjection": 0.509967628139115,
+              "emergencyRateCutBps": 80.98866984852073,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 156.5316466193976,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999983,
+              "depositOutflowRatio": 0.033243411496161175,
+              "interbankTrust": 0.8799999999999898
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.4324554886906979,
+              "liquidityBackstop": 0.38494334924261703,
+              "capitalInjection": 0.509967628139115,
+              "emergencyRateCutBps": 80.98866984852073,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 4406400
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 51,
+      "timestamp": 4406400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.00000000000006,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999535,
+              "stressLevel": 0.0800000000003736,
+              "fundingCost": 3.000000000000001
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 52,
+              "creditSpreadBps": 150.00000000000006,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999535,
+              "stressLevel": 0.0800000000003736,
+              "depositOutflowRatio": 0.033243411496161494,
+              "riskAppetite": 0.7399999999999991,
+              "interbankTrust": 0.8799999999999946,
+              "policySupportLevel": 0.4324554886906544,
+              "liquidityBackstop": 0.38494334924260143,
+              "capitalInjection": 0.5099676281389031,
+              "emergencyRateCutBps": 80.98866984851878,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 156.40357511705648,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999991,
+              "depositOutflowRatio": 0.033243411496161494,
+              "interbankTrust": 0.8799999999999946
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.4324554886906544,
+              "liquidityBackstop": 0.38494334924260143,
+              "capitalInjection": 0.5099676281389031,
+              "emergencyRateCutBps": 80.98866984851878,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 4492800
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 52,
+      "timestamp": 4492800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150.00000000000003,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999743,
+              "stressLevel": 0.08000000000021296,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 53,
+              "creditSpreadBps": 150.00000000000003,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999743,
+              "stressLevel": 0.08000000000021296,
+              "depositOutflowRatio": 0.0332434114961615,
+              "riskAppetite": 0.7399999999999995,
+              "interbankTrust": 0.8799999999999971,
+              "policySupportLevel": 0.4324554886906302,
+              "liquidityBackstop": 0.38494334924259266,
+              "capitalInjection": 0.5099676281387815,
+              "emergencyRateCutBps": 80.98866984851769,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 156.28042944172847,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999995,
+              "depositOutflowRatio": 0.0332434114961615,
+              "interbankTrust": 0.8799999999999971
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.4324554886906302,
+              "liquidityBackstop": 0.38494334924259266,
+              "capitalInjection": 0.5099676281387815,
+              "emergencyRateCutBps": 80.98866984851769,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 4579200
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 53,
+      "timestamp": 4579200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999859,
+              "stressLevel": 0.08000000000012139,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 54,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999859,
+              "stressLevel": 0.08000000000012139,
+              "depositOutflowRatio": 0.033243411496161376,
+              "riskAppetite": 0.7399999999999998,
+              "interbankTrust": 0.8799999999999985,
+              "policySupportLevel": 0.43245548869061673,
+              "liquidityBackstop": 0.3849433492425877,
+              "capitalInjection": 0.5099676281387118,
+              "emergencyRateCutBps": 80.98866984851708,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 156.16193077301662,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999998,
+              "depositOutflowRatio": 0.033243411496161376,
+              "interbankTrust": 0.8799999999999985
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869061673,
+              "liquidityBackstop": 0.3849433492425877,
+              "capitalInjection": 0.5099676281387118,
+              "emergencyRateCutBps": 80.98866984851708,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 4665600
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 54,
+      "timestamp": 4665600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999923,
+              "stressLevel": 0.0800000000000692,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 55,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999923,
+              "stressLevel": 0.0800000000000692,
+              "depositOutflowRatio": 0.033243411496161265,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999992,
+              "policySupportLevel": 0.4324554886906092,
+              "liquidityBackstop": 0.38494334924258494,
+              "capitalInjection": 0.5099676281386718,
+              "emergencyRateCutBps": 80.98866984851674,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 156.04782094388668,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161265,
+              "interbankTrust": 0.8799999999999992
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.4324554886906092,
+              "liquidityBackstop": 0.38494334924258494,
+              "capitalInjection": 0.5099676281386718,
+              "emergencyRateCutBps": 80.98866984851674,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 4752000
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 55,
+      "timestamp": 4752000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999959,
+              "stressLevel": 0.08000000000003944,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 56,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999959,
+              "stressLevel": 0.08000000000003944,
+              "depositOutflowRatio": 0.033243411496161196,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999996,
+              "policySupportLevel": 0.43245548869060496,
+              "liquidityBackstop": 0.3849433492425834,
+              "capitalInjection": 0.5099676281386488,
+              "emergencyRateCutBps": 80.98866984851654,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 155.93786056308875,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161196,
+              "interbankTrust": 0.8799999999999996
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869060496,
+              "liquidityBackstop": 0.3849433492425834,
+              "capitalInjection": 0.5099676281386488,
+              "emergencyRateCutBps": 80.98866984851654,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 4838400
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 56,
+      "timestamp": 4838400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999979,
+              "stressLevel": 0.08000000000002248,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 57,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999979,
+              "stressLevel": 0.08000000000002248,
+              "depositOutflowRatio": 0.03324341149616115,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999998,
+              "policySupportLevel": 0.43245548869060263,
+              "liquidityBackstop": 0.38494334924258256,
+              "capitalInjection": 0.5099676281386356,
+              "emergencyRateCutBps": 80.98866984851642,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 155.83182733874787,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.03324341149616115,
+              "interbankTrust": 0.8799999999999998
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869060263,
+              "liquidityBackstop": 0.38494334924258256,
+              "capitalInjection": 0.5099676281386356,
+              "emergencyRateCutBps": 80.98866984851642,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 4924800
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 57,
+      "timestamp": 4924800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999988,
+              "stressLevel": 0.08000000000001281,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 58,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999988,
+              "stressLevel": 0.08000000000001281,
+              "depositOutflowRatio": 0.0332434114961611,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869060135,
+              "liquidityBackstop": 0.38494334924258206,
+              "capitalInjection": 0.5099676281386281,
+              "emergencyRateCutBps": 80.98866984851637,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 155.72951457841896,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.0332434114961611,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869060135,
+              "liquidityBackstop": 0.38494334924258206,
+              "capitalInjection": 0.5099676281386281,
+              "emergencyRateCutBps": 80.98866984851637,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 5011200
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 58,
+      "timestamp": 5011200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999994,
+              "stressLevel": 0.0800000000000073,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 59,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999994,
+              "stressLevel": 0.0800000000000073,
+              "depositOutflowRatio": 0.03324341149616106,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869060063,
+              "liquidityBackstop": 0.3849433492425818,
+              "capitalInjection": 0.5099676281386237,
+              "emergencyRateCutBps": 80.98866984851632,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 155.6307298443083,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.03324341149616106,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869060063,
+              "liquidityBackstop": 0.3849433492425818,
+              "capitalInjection": 0.5099676281386237,
+              "emergencyRateCutBps": 80.98866984851632,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 5097600
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 59,
+      "timestamp": 5097600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999996,
+              "stressLevel": 0.08000000000000417,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 60,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999996,
+              "stressLevel": 0.08000000000000417,
+              "depositOutflowRatio": 0.03324341149616106,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869060024,
+              "liquidityBackstop": 0.3849433492425816,
+              "capitalInjection": 0.5099676281386213,
+              "emergencyRateCutBps": 80.98866984851631,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 155.5352937452522,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.03324341149616106,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869060024,
+              "liquidityBackstop": 0.3849433492425816,
+              "capitalInjection": 0.5099676281386213,
+              "emergencyRateCutBps": 80.98866984851631,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 5184000
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 60,
+      "timestamp": 5184000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000237,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 61,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000237,
+              "depositOutflowRatio": 0.03324341149616104,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.4324554886906,
+              "liquidityBackstop": 0.38494334924258156,
+              "capitalInjection": 0.50996762813862,
+              "emergencyRateCutBps": 80.98866984851631,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 155.443038849498,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.03324341149616104,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.4324554886906,
+              "liquidityBackstop": 0.38494334924258156,
+              "capitalInjection": 0.50996762813862,
+              "emergencyRateCutBps": 80.98866984851631,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 5270400
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 61,
+      "timestamp": 5270400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000135,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 62,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000135,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.4324554886905999,
+              "liquidityBackstop": 0.3849433492425815,
+              "capitalInjection": 0.5099676281386192,
+              "emergencyRateCutBps": 80.98866984851631,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 155.35380870442427,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.4324554886905999,
+              "liquidityBackstop": 0.3849433492425815,
+              "capitalInjection": 0.5099676281386192,
+              "emergencyRateCutBps": 80.98866984851631,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 5356800
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 62,
+      "timestamp": 5356800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000076,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 63,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000076,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059985,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386187,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 155.26745695112712,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059985,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386187,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 5443200
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 63,
+      "timestamp": 5443200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000043,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 64,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000043,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.4324554886905998,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386184,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 155.18384652333145,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.4324554886905998,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386184,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 5529600
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 64,
+      "timestamp": 5529600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000025,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 65,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000025,
+              "depositOutflowRatio": 0.033243411496161016,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.4324554886905998,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386183,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 155.1028489214044,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161016,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.4324554886905998,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386183,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 5616000
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 65,
+      "timestamp": 5616000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000014,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 66,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000014,
+              "depositOutflowRatio": 0.033243411496160974,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.4324554886905998,
+              "liquidityBackstop": 0.3849433492425815,
+              "capitalInjection": 0.5099676281386182,
+              "emergencyRateCutBps": 80.98866984851631,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 155.02434355338278,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496160974,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.4324554886905998,
+              "liquidityBackstop": 0.3849433492425815,
+              "capitalInjection": 0.5099676281386182,
+              "emergencyRateCutBps": 80.98866984851631,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 5702400
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 66,
+      "timestamp": 5702400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000008,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 67,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000008,
+              "depositOutflowRatio": 0.03324341149616099,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 154.94821713590727,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.03324341149616099,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 5788800
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 67,
+      "timestamp": 5788800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000004,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 68,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000004,
+              "depositOutflowRatio": 0.033243411496160995,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 154.87436314880418,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496160995,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 5875200
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 68,
+      "timestamp": 5875200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000003,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 69,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000003,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 154.80268133779236,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 5961600
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 69,
+      "timestamp": 5961600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 70,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 154.73307726043305,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 6048000
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 70,
+      "timestamp": 6048000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 71,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 154.66546187099829,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 6134400
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 71,
+      "timestamp": 6134400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 72,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 154.59975114042086,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 6220800
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 72,
+      "timestamp": 6220800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 73,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 154.535865707915,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 6307200
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 73,
+      "timestamp": 6307200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 74,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 154.47373056123124,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 6393600
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 74,
+      "timestamp": 6393600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 75,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 154.41327474283622,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 6480000
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 75,
+      "timestamp": 6480000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 76,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 154.3544310795984,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 6566400
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 76,
+      "timestamp": 6566400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 77,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 154.29713593381422,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 6652800
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 77,
+      "timestamp": 6652800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 78,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 154.2413289736348,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 6739200
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 78,
+      "timestamp": 6739200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 79,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 154.18695296115231,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 6825600
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 79,
+      "timestamp": 6825600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 80,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 154.13395355658076,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 6912000
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 80,
+      "timestamp": 6912000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 81,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 154.08227913712352,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 6998400
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 81,
+      "timestamp": 6998400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 82,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 154.03188062925778,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 7084800
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 82,
+      "timestamp": 7084800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 83,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 153.98271135329122,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 7171200
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 83,
+      "timestamp": 7171200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 84,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 153.9347268791552,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 7257600
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 84,
+      "timestamp": 7257600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 85,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 153.8878848924986,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 7344000
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 85,
+      "timestamp": 7344000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 86,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 153.8421450702339,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 7430400
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 86,
+      "timestamp": 7430400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 87,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 153.79746896476607,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 7516800
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 87,
+      "timestamp": 7516800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 88,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 153.75381989620553,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 7603200
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 88,
+      "timestamp": 7603200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 89,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 153.71116285193045,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 7689600
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 89,
+      "timestamp": 7689600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 90,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 153.66946439292002,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 7776000
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 90,
+      "timestamp": 7776000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 91,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 153.628692566332,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 7862400
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 91,
+      "timestamp": 7862400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 92,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 153.58881682384484,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 7948800
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 92,
+      "timestamp": 7948800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 93,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 153.5498079453248,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 8035200
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 93,
+      "timestamp": 8035200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 94,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 153.51163796741807,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 8121600
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 94,
+      "timestamp": 8121600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 95,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 153.47428011670087,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 8208000
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 95,
+      "timestamp": 8208000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 96,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 153.43770874705137,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 8294400
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 96,
+      "timestamp": 8294400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 97,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 153.40189928093625,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 8380800
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 97,
+      "timestamp": 8380800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 98,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 153.36682815432866,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 8467200
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 98,
+      "timestamp": 8467200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 99,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 153.33247276499878,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 8553600
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 99,
+      "timestamp": 8553600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 100,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 153.2988114239382,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 8640000
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 100,
+      "timestamp": 8640000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 101,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 153.26582330969882,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 8726400
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 101,
+      "timestamp": 8726400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 102,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 153.23348842544436,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 8812800
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 102,
+      "timestamp": 8812800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 103,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 153.20178755852825,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 8899200
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 103,
+      "timestamp": 8899200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 104,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 153.17070224242602,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 8985600
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 104,
+      "timestamp": 8985600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 105,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 153.14021472086424,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 9072000
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 105,
+      "timestamp": 9072000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 106,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 153.11030791399887,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 9158400
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 106,
+      "timestamp": 9158400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 107,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 153.0809653865083,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 9244800
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 107,
+      "timestamp": 9244800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 108,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 153.0521713174755,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 9331200
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 108,
+      "timestamp": 9331200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 109,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 153.02391047194337,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 9417600
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 109,
+      "timestamp": 9417600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 110,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.99616817403563,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 9504000
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 110,
+      "timestamp": 9504000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 111,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.96893028154437,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 9590400
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 111,
+      "timestamp": 9590400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 112,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.94218316189082,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 9676800
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 112,
+      "timestamp": 9676800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 113,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.91591366937396,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 9763200
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 113,
+      "timestamp": 9763200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 114,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.89010912362727,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 9849600
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 114,
+      "timestamp": 9849600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 115,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.8647572892095,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 9936000
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 115,
+      "timestamp": 9936000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 116,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.83984635625984,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 10022400
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 116,
+      "timestamp": 10022400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 117,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.81536492215417,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 10108800
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 117,
+      "timestamp": 10108800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 118,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.79130197410157,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 10195200
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 118,
+      "timestamp": 10195200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 119,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.76764687262613,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 10281600
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 119,
+      "timestamp": 10281600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 120,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.74438933588138,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 10368000
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 120,
+      "timestamp": 10368000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 121,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.72151942474903,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 10454400
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 121,
+      "timestamp": 10454400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 122,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.6990275286767,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 10540800
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 122,
+      "timestamp": 10540800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 123,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.67690435221215,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 10627200
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 123,
+      "timestamp": 10627200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 124,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.65514090219418,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 10713600
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 124,
+      "timestamp": 10713600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 125,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.63372847556357,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 10800000
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 125,
+      "timestamp": 10800000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 126,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.61265864775905,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 10886400
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 126,
+      "timestamp": 10886400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 127,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.59192326166573,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 10972800
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 127,
+      "timestamp": 10972800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 128,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.5715144170857,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 11059200
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 128,
+      "timestamp": 11059200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 129,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.5514244607022,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 11145600
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 129,
+      "timestamp": 11145600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 130,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.53164597651073,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 11232000
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 130,
+      "timestamp": 11232000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 131,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.51217177669142,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 11318400
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 131,
+      "timestamp": 11318400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 132,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.49299489289987,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 11404800
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 132,
+      "timestamp": 11404800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 133,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.47410856795366,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 11491200
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 133,
+      "timestamp": 11491200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 134,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.45550624789385,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 11577600
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 134,
+      "timestamp": 11577600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 135,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.4371815744021,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 11664000
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 135,
+      "timestamp": 11664000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 136,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.4191283775547,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 11750400
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 136,
+      "timestamp": 11750400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 137,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.40134066889618,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 11836800
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 137,
+      "timestamp": 11836800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 138,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.38381263481665,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 11923200
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 138,
+      "timestamp": 11923200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 139,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.36653863021655,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 12009600
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 139,
+      "timestamp": 12009600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 140,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.3495131724452,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 12096000
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 140,
+      "timestamp": 12096000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 141,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.33273093549917,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 12182400
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 141,
+      "timestamp": 12182400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 142,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.31618674446725,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 12268800
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 142,
+      "timestamp": 12268800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 143,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.29987557021045,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 12355200
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 143,
+      "timestamp": 12355200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 144,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.28379252426492,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 12441600
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 144,
+      "timestamp": 12441600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 145,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.26793285395752,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 12528000
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 145,
+      "timestamp": 12528000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 146,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.25229193772333,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 12614400
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 146,
+      "timestamp": 12614400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 147,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.23686528061563,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 12700800
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 147,
+      "timestamp": 12700800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 148,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.2216485099992,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 12787200
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 148,
+      "timestamp": 12787200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 149,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.20663737141814,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 12873600
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 149,
+      "timestamp": 12873600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 150,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.1918277246301,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 12960000
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 150,
+      "timestamp": 12960000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 151,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.17721553979922,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 13046400
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 151,
+      "timestamp": 13046400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 152,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.1627968938403,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 13132800
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 152,
+      "timestamp": 13132800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 153,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.1485679669071,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 13219200
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 153,
+      "timestamp": 13219200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 154,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.13452503901885,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 13305600
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 154,
+      "timestamp": 13305600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 155,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.12066448681742,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 13392000
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 155,
+      "timestamp": 13392000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 156,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.10698278045086,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 13478400
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 156,
+      "timestamp": 13478400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 157,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.09347648057616,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 13564800
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 157,
+      "timestamp": 13564800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 158,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.08014223547696,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 13651200
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 158,
+      "timestamp": 13651200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 159,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.0669767782904,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 13737600
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 159,
+      "timestamp": 13737600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 160,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.05397692433888,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 13824000
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 160,
+      "timestamp": 13824000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 161,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.04113956856176,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 13910400
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 161,
+      "timestamp": 13910400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 162,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.02846168304274,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 13996800
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 162,
+      "timestamp": 13996800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 163,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.0159403146289,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 14083200
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 163,
+      "timestamp": 14083200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 164,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 152.0035725826373,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 14169600
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 164,
+      "timestamp": 14169600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 165,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 151.99135567664564,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 14256000
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 165,
+      "timestamp": 14256000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 166,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 151.97928685436293,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 14342400
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 166,
+      "timestamp": 14342400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 167,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 151.9673634395776,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 14428800
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 167,
+      "timestamp": 14428800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 168,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 151.95558282017893,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 14515200
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 168,
+      "timestamp": 14515200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 169,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 151.9439424462493,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 14601600
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 169,
+      "timestamp": 14601600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 170,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 151.93243982822415,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 14688000
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 170,
+      "timestamp": 14688000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 171,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 151.92107253511696,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 14774400
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 171,
+      "timestamp": 14774400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 172,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 151.90983819280632,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 14860800
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 172,
+      "timestamp": 14860800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 173,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 151.89873448238305,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 14947200
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 173,
+      "timestamp": 14947200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 174,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 151.88775913855423,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 15033600
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 174,
+      "timestamp": 15033600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 175,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 151.87690994810276,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 15120000
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 175,
+      "timestamp": 15120000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 176,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 151.86618474839932,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 15206400
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 176,
+      "timestamp": 15206400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 177,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 151.85558142596525,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 15292800
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 177,
+      "timestamp": 15292800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 178,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 151.8450979150841,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 15379200
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 178,
+      "timestamp": 15379200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 179,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 151.83473219646,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 15465600
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 179,
+      "timestamp": 15465600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "credit-market",
+          "components": {
+            "credit.market": {
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "fundingCost": 3
+            }
+          }
+        },
+        {
+          "id": "credit-market-summary",
+          "components": {
+            "evaluation.credit.summary": {
+              "day": 180,
+              "creditSpreadBps": 150,
+              "liquidityIndex": 1,
+              "lendingVolume": 1.0999999999999999,
+              "stressLevel": 0.08000000000000002,
+              "depositOutflowRatio": 0.033243411496161,
+              "riskAppetite": 0.7399999999999999,
+              "interbankTrust": 0.8799999999999999,
+              "policySupportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "metrics": {
+                "peakSpreadBps": 316.55698879464,
+                "peakSpreadDay": 2,
+                "peakStressLevel": 0.6807061164,
+                "daysAboveStressThreshold": 1,
+                "stabilizationDay": 7,
+                "averageSpreadBps": 151.82448229592114,
+                "cumulativeLendingGap": 0.5284185343875673
+              }
+            }
+          }
+        },
+        {
+          "id": "market-confidence",
+          "components": {
+            "market.confidence": {
+              "riskAppetite": 0.7399999999999999,
+              "depositOutflowRatio": 0.033243411496161,
+              "interbankTrust": 0.8799999999999999
+            }
+          }
+        },
+        {
+          "id": "policy-response",
+          "components": {
+            "policy.response": {
+              "supportLevel": 0.43245548869059974,
+              "liquidityBackstop": 0.38494334924258145,
+              "capitalInjection": 0.5099676281386181,
+              "emergencyRateCutBps": 80.9886698485163,
+              "interventionActive": true
+            }
+          }
+        },
+        {
+          "id": "time",
+          "components": {
+            "time": {
+              "elapsed": 15552000
+            }
+          }
+        },
+        {
+          "id": "top-3-bank",
+          "components": {
+            "bank.state": {
+              "solvencyRatio": -0.04,
+              "liquidityCoverage": 0.21999999999999997,
+              "assetBase": 800,
+              "liabilityBase": 1140,
+              "defaulted": true
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 180,
+      "timestamp": 15552000000,
+      "deltaSeconds": 86400
+    }
+  }
+]

--- a/verifications/bank_collapses/report.md
+++ b/verifications/bank_collapses/report.md
@@ -1,0 +1,35 @@
+# Credit Market Simulation Report: Sudden Collapse of a Top-3 Bank
+
+## Form D Reasoning
+- **Environment (E):** Interlinked credit market ecosystem comprising a systemically important bank, aggregate credit markets, investor confidence, policy authorities, and global time progression.
+- **Phenomenon (X):** An abrupt failure of a top-3 bank triggered at the outset of the observation window, removing the bank as a solvent intermediary and forcing rapid balance-sheet revaluation.
+- **Conditions (C):** Observe the environment until market stress drops below the crisis threshold (0.55) for five consecutive days or until 180 simulated days elapse, capturing both the crisis response and medium-term adjustment period.
+
+This mapping ensures the simulation initializes with pre-shock baselines, applies the endogenous collapse, and records state evolution until stability criteria are met.
+
+## Simulation Setup Summary
+- **Entities & Components:**
+  - `top-3-bank` tracks solvency, liquidity coverage, and balance-sheet totals, toggling a `defaulted` flag upon failure.
+  - `credit-market` stores credit spread (basis points), liquidity index, lending volume, stress level, and funding costs.
+  - `market-confidence` measures investor risk appetite, deposit outflows, and interbank trust.
+  - `policy-response` reflects emergency support strength, liquidity backstops, capital injections, and rate-cut magnitudes.
+  - `credit-market-summary` aggregates evaluation metrics for reporting.
+- **Systems:**
+  - `EnvironmentSetupSystem` materializes baseline conditions prior to the shock.
+  - `BankCollapseSystem` applies the immediate solvency and liquidity shock on day 0.
+  - `PolicyResponseSystem` scales fiscal/monetary interventions as stress, withdrawals, and trust evolve.
+  - `CreditMarketEvolutionSystem` propagates stress through spreads, liquidity, lending, and confidence feedback loops.
+  - `CreditMarketSummarySystem` derives peak dislocations, stabilization timing, and cumulative lending gaps each day.
+- **Temporal Resolution:** One tick equals one day (86,400 simulated seconds) with a 180-day horizon.
+- **Data Capture:** Every evaluation-frame snapshot is serialized to `raw_output.json` in `verifications/bank_collapses/`, supporting replay and quantitative review.
+
+## Key Findings
+- **Immediate Shock:** By day 2, the investment-grade spread widens to 317 bps, market stress peaks at 0.68, and deposit outflows spike to 19.8%, evidencing acute liquidity strain and confidence loss.
+- **Policy Intervention:** Support measures ramp quickly—liquidity backstops exceed 0.63 and emergency rate cuts surpass 138 bps by day 3—anchoring expectations despite ongoing bank default resolution.
+- **Recovery Trajectory:** Stress falls below the 0.55 crisis threshold after one high-stress day and stabilizes by day 7. Liquidity and lending recover ahead of spreads, and confidence metrics regain pre-shock territory within the first week.
+- **End-State (Day 180):** Credit spreads normalize to 150 bps, liquidity index reaches 1.0, and lending volume is 10% above baseline. Deposit outflows settle near 3.3%, risk appetite climbs to 0.74, and authorities maintain moderate support (support level 0.43, rate cuts ~81 bps).
+- **Cumulative Impact:** Average spreads over the horizon sit at ~152 bps, while the cumulative lending gap totals 0.53 (normalized lending-years), capturing the transient contraction in credit supply despite medium-term overshoot.
+
+## Artifacts
+- **Raw simulation output:** `verifications/bank_collapses/raw_output.json`
+- **This report:** `verifications/bank_collapses/report.md`

--- a/workspaces/Describing_Simulation_0/project/package-lock.json
+++ b/workspaces/Describing_Simulation_0/project/package-lock.json
@@ -9,8 +9,10 @@
       "version": "0.1.0",
       "devDependencies": {
         "@types/jest": "^30.0.0",
+        "@types/node": "^22.10.2",
         "jest": "^30.1.3",
         "ts-jest": "^29.4.4",
+        "ts-node": "^10.9.2",
         "typescript": "^5.9.2"
       }
     },
@@ -509,6 +511,30 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.5.0",
@@ -1045,6 +1071,34 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1140,13 +1194,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.5.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
-      "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
+      "version": "22.18.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.6.tgz",
+      "integrity": "sha512-r8uszLPpeIWbNKtvWRt/DbVi5zbqZyj1PTmhRMqBMvDnaz1QpmSKujUtJLrqGZeoM8v72MfYggDceY4K1itzWQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.12.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -1449,6 +1503,32 @@
         "win32"
       ]
     },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -1507,6 +1587,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -1944,6 +2031,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2010,6 +2104,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/eastasianwidth": {
@@ -4201,6 +4305,50 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -4261,9 +4409,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
-      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4332,6 +4480,13 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -4586,6 +4741,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/workspaces/Describing_Simulation_0/project/package.json
+++ b/workspaces/Describing_Simulation_0/project/package.json
@@ -9,9 +9,11 @@
   },
   "type": "commonjs",
   "devDependencies": {
+    "@types/node": "^22.10.2",
     "@types/jest": "^30.0.0",
     "jest": "^30.1.3",
     "ts-jest": "^29.4.4",
+    "ts-node": "^10.9.2",
     "typescript": "^5.9.2"
   }
 }

--- a/workspaces/Describing_Simulation_0/project/plugins/evaluation/components/CreditMarketSummaryComponent.ts
+++ b/workspaces/Describing_Simulation_0/project/plugins/evaluation/components/CreditMarketSummaryComponent.ts
@@ -1,0 +1,31 @@
+import { ComponentType } from '../../../src/core/components/ComponentType';
+
+export interface CreditMarketSummaryMetrics {
+  peakSpreadBps: number;
+  peakSpreadDay: number;
+  peakStressLevel: number;
+  daysAboveStressThreshold: number;
+  stabilizationDay: number | null;
+  averageSpreadBps: number;
+  cumulativeLendingGap: number;
+}
+
+export interface CreditMarketSummaryComponent {
+  day: number;
+  creditSpreadBps: number;
+  liquidityIndex: number;
+  lendingVolume: number;
+  stressLevel: number;
+  depositOutflowRatio: number;
+  riskAppetite: number;
+  interbankTrust: number;
+  policySupportLevel: number;
+  liquidityBackstop: number;
+  capitalInjection: number;
+  emergencyRateCutBps: number;
+  metrics: CreditMarketSummaryMetrics;
+}
+
+export const CREDIT_MARKET_SUMMARY_COMPONENT = new ComponentType<CreditMarketSummaryComponent>(
+  'evaluation.credit.summary',
+);

--- a/workspaces/Describing_Simulation_0/project/plugins/evaluation/systems/CreditMarketSummarySystem.ts
+++ b/workspaces/Describing_Simulation_0/project/plugins/evaluation/systems/CreditMarketSummarySystem.ts
@@ -1,0 +1,135 @@
+import { ComponentManager } from '../../../src/core/components/ComponentManager';
+import { TIME_COMPONENT } from '../../../src/core/components/TimeComponent';
+import { EntityManager } from '../../../src/core/entity/EntityManager';
+import { System } from '../../../src/core/systems/System';
+
+import {
+  BANK_STATE_COMPONENT,
+  CREDIT_MARKET_COMPONENT,
+  MARKET_CONFIDENCE_COMPONENT,
+  POLICY_RESPONSE_COMPONENT,
+} from '../../simulation/components/CreditMarketComponents';
+import {
+  CREDIT_MARKET_SUMMARY_COMPONENT,
+  type CreditMarketSummaryComponent,
+} from '../components/CreditMarketSummaryComponent';
+
+const SUMMARY_ENTITY_ID = 'credit-market-summary';
+const TIME_ENTITY_ID = 'time';
+const STRESS_THRESHOLD = 0.55;
+
+const SECONDS_PER_DAY = 86_400;
+
+/**
+ * Derives descriptive metrics for the simulated scenario to support reporting.
+ */
+export class CreditMarketSummarySystem extends System {
+  private observationCount = 0;
+  private cumulativeSpread = 0;
+  private cumulativeLendingGap = 0;
+  private peakSpread = 0;
+  private peakSpreadDay = 0;
+  private peakStress = 0;
+  private daysAboveThreshold = 0;
+  private stabilizationDay: number | null = null;
+  private stableRun = 0;
+
+  constructor(
+    private readonly entities: EntityManager,
+    private readonly components: ComponentManager,
+  ) {
+    super();
+  }
+
+  protected override onInit(): void {
+    if (!this.components.isRegistered(CREDIT_MARKET_SUMMARY_COMPONENT)) {
+      this.components.register(CREDIT_MARKET_SUMMARY_COMPONENT);
+    }
+
+    if (!this.entities.has(SUMMARY_ENTITY_ID)) {
+      this.entities.create(SUMMARY_ENTITY_ID);
+    }
+  }
+
+  protected override update(deltaTime: number): void {
+    if (
+      !this.components.isRegistered(CREDIT_MARKET_COMPONENT) ||
+      !this.components.isRegistered(MARKET_CONFIDENCE_COMPONENT) ||
+      !this.components.isRegistered(POLICY_RESPONSE_COMPONENT) ||
+      !this.components.isRegistered(BANK_STATE_COMPONENT)
+    ) {
+      return;
+    }
+
+    if (!this.entities.has(SUMMARY_ENTITY_ID)) {
+      this.entities.create(SUMMARY_ENTITY_ID);
+    }
+
+    const market = this.components.getComponent('credit-market', CREDIT_MARKET_COMPONENT);
+    const sentiment = this.components.getComponent('market-confidence', MARKET_CONFIDENCE_COMPONENT);
+    const policy = this.components.getComponent('policy-response', POLICY_RESPONSE_COMPONENT);
+    const bank = this.components.getComponent('top-3-bank', BANK_STATE_COMPONENT);
+
+    if (!market || !sentiment || !policy || !bank) {
+      return;
+    }
+
+    const time = this.components.getComponent(TIME_ENTITY_ID, TIME_COMPONENT);
+    const day = time ? time.elapsed / SECONDS_PER_DAY : this.observationCount;
+
+    this.observationCount += 1;
+    this.cumulativeSpread += market.creditSpreadBps;
+    this.cumulativeLendingGap += Math.max(0, 1 - market.lendingVolume);
+
+    if (market.creditSpreadBps > this.peakSpread) {
+      this.peakSpread = market.creditSpreadBps;
+      this.peakSpreadDay = day;
+    }
+
+    if (market.stressLevel > this.peakStress) {
+      this.peakStress = market.stressLevel;
+    }
+
+    if (market.stressLevel > STRESS_THRESHOLD) {
+      this.daysAboveThreshold += 1;
+      this.stableRun = 0;
+    } else {
+      this.stableRun += 1;
+      if (this.stableRun >= 5 && this.stabilizationDay === null) {
+        this.stabilizationDay = day;
+      }
+    }
+
+    const averageSpread = this.cumulativeSpread / this.observationCount;
+
+    const summary: CreditMarketSummaryComponent = {
+      day,
+      creditSpreadBps: market.creditSpreadBps,
+      liquidityIndex: market.liquidityIndex,
+      lendingVolume: market.lendingVolume,
+      stressLevel: market.stressLevel,
+      depositOutflowRatio: sentiment.depositOutflowRatio,
+      riskAppetite: sentiment.riskAppetite,
+      interbankTrust: sentiment.interbankTrust,
+      policySupportLevel: policy.supportLevel,
+      liquidityBackstop: policy.liquidityBackstop,
+      capitalInjection: policy.capitalInjection,
+      emergencyRateCutBps: policy.emergencyRateCutBps,
+      metrics: {
+        peakSpreadBps: this.peakSpread,
+        peakSpreadDay: this.peakSpreadDay,
+        peakStressLevel: this.peakStress,
+        daysAboveStressThreshold: this.daysAboveThreshold,
+        stabilizationDay: this.stabilizationDay,
+        averageSpreadBps: averageSpread,
+        cumulativeLendingGap: this.cumulativeLendingGap,
+      },
+    };
+
+    this.components.setComponent(
+      SUMMARY_ENTITY_ID,
+      CREDIT_MARKET_SUMMARY_COMPONENT,
+      summary,
+    );
+  }
+}

--- a/workspaces/Describing_Simulation_0/project/plugins/simulation/components/CreditMarketComponents.ts
+++ b/workspaces/Describing_Simulation_0/project/plugins/simulation/components/CreditMarketComponents.ts
@@ -1,0 +1,60 @@
+import { ComponentType } from '../../../src/core/components/ComponentType';
+
+export interface BankStateComponent {
+  /** Ratio of tangible equity to risk-weighted assets. */
+  solvencyRatio: number;
+  /** Share of high-quality liquid assets relative to stressed outflows. */
+  liquidityCoverage: number;
+  /** Total assets measured in arbitrary units. */
+  assetBase: number;
+  /** Total liabilities measured in arbitrary units. */
+  liabilityBase: number;
+  /** Flag indicating the bank has failed and is in resolution. */
+  defaulted: boolean;
+}
+
+export interface CreditMarketStateComponent {
+  /** Investment-grade credit spread measured in basis points. */
+  creditSpreadBps: number;
+  /** Relative intermediation liquidity on a 0-1 scale. */
+  liquidityIndex: number;
+  /** Aggregate lending volume normalised to the pre-shock baseline. */
+  lendingVolume: number;
+  /** Composite financial stress measure on a 0-1 scale. */
+  stressLevel: number;
+  /** Weighted average funding cost for issuers in percent. */
+  fundingCost: number;
+}
+
+export interface MarketConfidenceComponent {
+  /** Risk appetite of credit investors on a 0-1 scale. */
+  riskAppetite: number;
+  /** Share of deposits withdrawing each day on a 0-1 scale. */
+  depositOutflowRatio: number;
+  /** Strength of interbank trust on a 0-1 scale. */
+  interbankTrust: number;
+}
+
+export interface PolicyResponseComponent {
+  /** Aggregate strength of extraordinary support on a 0-1 scale. */
+  supportLevel: number;
+  /** Liquidity facilities deployed on a 0-1 scale. */
+  liquidityBackstop: number;
+  /** Size of capital backstops on a 0-1 scale. */
+  capitalInjection: number;
+  /** Policy rate cuts delivered in basis points. */
+  emergencyRateCutBps: number;
+  /** Whether authorities are actively intervening. */
+  interventionActive: boolean;
+}
+
+export const BANK_STATE_COMPONENT = new ComponentType<BankStateComponent>('bank.state');
+export const CREDIT_MARKET_COMPONENT = new ComponentType<CreditMarketStateComponent>(
+  'credit.market',
+);
+export const MARKET_CONFIDENCE_COMPONENT = new ComponentType<MarketConfidenceComponent>(
+  'market.confidence',
+);
+export const POLICY_RESPONSE_COMPONENT = new ComponentType<PolicyResponseComponent>(
+  'policy.response',
+);

--- a/workspaces/Describing_Simulation_0/project/plugins/simulation/runBankCollapseSimulation.ts
+++ b/workspaces/Describing_Simulation_0/project/plugins/simulation/runBankCollapseSimulation.ts
@@ -1,0 +1,139 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+import { ComponentManager } from '../../src/core/components/ComponentManager';
+import { EntityManager } from '../../src/core/entity/EntityManager';
+import { Bus, acknowledge } from '../../src/core/messaging';
+import { SimulationPlayer } from '../../src/core/simplayer/SimulationPlayer';
+import { SystemManager } from '../../src/core/systems/SystemManager';
+import { TimeSystem } from '../../src/core/systems/TimeSystem';
+import { EvaluationPlayer } from '../../src/core/evalplayer/EvaluationPlayer';
+import type { SnapshotFrame } from '../../src/core/IOPlayer';
+
+import { EnvironmentSetupSystem } from './systems/EnvironmentSetupSystem';
+import { BankCollapseSystem } from './systems/BankCollapseSystem';
+import { PolicyResponseSystem } from './systems/PolicyResponseSystem';
+import { CreditMarketEvolutionSystem } from './systems/CreditMarketEvolutionSystem';
+import { CreditMarketSummarySystem } from '../evaluation/systems/CreditMarketSummarySystem';
+
+const SECONDS_PER_DAY = 86_400;
+const TARGET_TICKS = 180;
+
+const createTimeProvider = () => {
+  let current = 0;
+  return () => {
+    const now = current;
+    current += SECONDS_PER_DAY * 1_000; // milliseconds
+    return now;
+  };
+};
+
+const resolveRepoPath = (...segments: string[]): string =>
+  path.resolve(__dirname, '../../../../../', ...segments);
+
+async function runSimulation(): Promise<void> {
+  const simulationComponents = new ComponentManager();
+  const simulationEntities = new EntityManager(simulationComponents);
+  const simulationSystems = new SystemManager();
+
+  simulationSystems.register(new TimeSystem(simulationEntities, simulationComponents), -20);
+  simulationSystems.register(
+    new EnvironmentSetupSystem(simulationEntities, simulationComponents),
+    -15,
+  );
+  simulationSystems.register(new BankCollapseSystem(simulationComponents), -10);
+  simulationSystems.register(new PolicyResponseSystem(simulationComponents), -5);
+  simulationSystems.register(new CreditMarketEvolutionSystem(simulationComponents), 0);
+
+  const simulationInboundBus = new Bus();
+  const simulationOutboundBus = new Bus();
+
+  const simulationPlayer = new SimulationPlayer(
+    simulationEntities,
+    simulationComponents,
+    simulationSystems,
+    simulationInboundBus,
+    simulationOutboundBus,
+    {
+      tickIntervalMs: 1,
+      timeProvider: createTimeProvider(),
+    },
+  );
+
+  const evaluationComponents = new ComponentManager();
+  const evaluationEntities = new EntityManager(evaluationComponents);
+  const evaluationSystems = new SystemManager();
+
+  evaluationSystems.register(new TimeSystem(evaluationEntities, evaluationComponents), -10);
+  evaluationSystems.register(new CreditMarketSummarySystem(evaluationEntities, evaluationComponents), 0);
+
+  const evaluationInboundBus = new Bus();
+  const evaluationOutboundBus = new Bus();
+
+  const evaluationPlayer = new EvaluationPlayer(
+    evaluationEntities,
+    evaluationComponents,
+    evaluationSystems,
+    evaluationInboundBus,
+    evaluationOutboundBus,
+    {
+      tickIntervalMs: 1,
+      timeProvider: createTimeProvider(),
+    },
+  );
+
+  simulationOutboundBus.subscribe((frame) => evaluationInboundBus.send(frame));
+
+  const evaluationFrames: SnapshotFrame[] = [];
+  let resolveRun: (() => void) | null = null;
+  const completion = new Promise<void>((resolve) => {
+    resolveRun = resolve;
+  });
+
+  evaluationOutboundBus.subscribe((frame) => {
+    const snapshot = frame as SnapshotFrame;
+    evaluationFrames.push(snapshot);
+
+    if (snapshot.metadata.tick >= TARGET_TICKS && resolveRun) {
+      simulationInboundBus.send(simulationPlayer.commands.stop, undefined);
+      evaluationPlayer.stop();
+      resolveRun();
+      resolveRun = null;
+    }
+
+    return acknowledge();
+  });
+
+  evaluationPlayer.start();
+  simulationInboundBus.send(simulationPlayer.commands.start, undefined);
+
+  const timeout = setTimeout(() => {
+    if (resolveRun) {
+      simulationInboundBus.send(simulationPlayer.commands.stop, undefined);
+      evaluationPlayer.stop();
+      resolveRun();
+      resolveRun = null;
+    }
+  }, 10_000);
+
+  await completion;
+  clearTimeout(timeout);
+
+  const outputDir = resolveRepoPath('verifications', 'bank_collapses');
+  await fs.mkdir(outputDir, { recursive: true });
+
+  const rawOutputPath = path.join(outputDir, 'raw_output.json');
+  await fs.writeFile(rawOutputPath, JSON.stringify(evaluationFrames, null, 2));
+
+  const finalFrame = evaluationFrames[evaluationFrames.length - 1];
+  if (finalFrame) {
+    // eslint-disable-next-line no-console
+    console.log('Final summary snapshot:', JSON.stringify(finalFrame.payload, null, 2));
+  }
+}
+
+runSimulation().catch((error) => {
+  // eslint-disable-next-line no-console
+  console.error('Simulation failed:', error);
+  process.exitCode = 1;
+});

--- a/workspaces/Describing_Simulation_0/project/plugins/simulation/systems/BankCollapseSystem.ts
+++ b/workspaces/Describing_Simulation_0/project/plugins/simulation/systems/BankCollapseSystem.ts
@@ -1,0 +1,78 @@
+import { ComponentManager } from '../../../src/core/components/ComponentManager';
+import { System } from '../../../src/core/systems/System';
+
+import {
+  BANK_STATE_COMPONENT,
+  CREDIT_MARKET_COMPONENT,
+  MARKET_CONFIDENCE_COMPONENT,
+  type BankStateComponent,
+  type CreditMarketStateComponent,
+  type MarketConfidenceComponent,
+} from '../components/CreditMarketComponents';
+
+const BANK_ENTITY_ID = 'top-3-bank';
+const MARKET_ENTITY_ID = 'credit-market';
+const SENTIMENT_ENTITY_ID = 'market-confidence';
+
+/**
+ * Applies the initial failure shock to the environment when the simulation begins.
+ */
+export class BankCollapseSystem extends System {
+  private shockApplied = false;
+
+  constructor(private readonly components: ComponentManager) {
+    super();
+  }
+
+  protected override update(): void {
+    if (this.shockApplied) {
+      return;
+    }
+
+    const bank = this.components.getComponent(BANK_ENTITY_ID, BANK_STATE_COMPONENT);
+    const market = this.components.getComponent(MARKET_ENTITY_ID, CREDIT_MARKET_COMPONENT);
+    const sentiment = this.components.getComponent(
+      SENTIMENT_ENTITY_ID,
+      MARKET_CONFIDENCE_COMPONENT,
+    );
+
+    if (!bank || !market || !sentiment) {
+      return;
+    }
+
+    const shockedBank: BankStateComponent = {
+      ...bank,
+      solvencyRatio: Math.max(-0.04, bank.solvencyRatio - 0.18),
+      liquidityCoverage: Math.max(0.08, bank.liquidityCoverage - 0.6),
+      assetBase: bank.assetBase * 0.64,
+      liabilityBase: bank.liabilityBase,
+      defaulted: true,
+    };
+
+    const shockedMarket: CreditMarketStateComponent = {
+      ...market,
+      creditSpreadBps: Math.max(market.creditSpreadBps, 420),
+      liquidityIndex: Math.max(0.22, market.liquidityIndex - 0.38),
+      lendingVolume: Math.max(0.52, market.lendingVolume - 0.42),
+      stressLevel: Math.min(0.92, Math.max(market.stressLevel, 0.86)),
+      fundingCost: 1.5 + Math.max(market.creditSpreadBps, 420) / 100,
+    };
+
+    const shockedSentiment: MarketConfidenceComponent = {
+      ...sentiment,
+      riskAppetite: Math.max(0.22, sentiment.riskAppetite - 0.44),
+      depositOutflowRatio: Math.min(0.38, sentiment.depositOutflowRatio + 0.3),
+      interbankTrust: Math.max(0.26, sentiment.interbankTrust - 0.4),
+    };
+
+    this.components.setComponent(BANK_ENTITY_ID, BANK_STATE_COMPONENT, shockedBank);
+    this.components.setComponent(MARKET_ENTITY_ID, CREDIT_MARKET_COMPONENT, shockedMarket);
+    this.components.setComponent(
+      SENTIMENT_ENTITY_ID,
+      MARKET_CONFIDENCE_COMPONENT,
+      shockedSentiment,
+    );
+
+    this.shockApplied = true;
+  }
+}

--- a/workspaces/Describing_Simulation_0/project/plugins/simulation/systems/CreditMarketEvolutionSystem.ts
+++ b/workspaces/Describing_Simulation_0/project/plugins/simulation/systems/CreditMarketEvolutionSystem.ts
@@ -1,0 +1,209 @@
+import { ComponentManager } from '../../../src/core/components/ComponentManager';
+import { System } from '../../../src/core/systems/System';
+
+import {
+  BANK_STATE_COMPONENT,
+  CREDIT_MARKET_COMPONENT,
+  MARKET_CONFIDENCE_COMPONENT,
+  POLICY_RESPONSE_COMPONENT,
+  type BankStateComponent,
+  type CreditMarketStateComponent,
+  type MarketConfidenceComponent,
+  type PolicyResponseComponent,
+} from '../components/CreditMarketComponents';
+
+const BANK_ENTITY_ID = 'top-3-bank';
+const MARKET_ENTITY_ID = 'credit-market';
+const SENTIMENT_ENTITY_ID = 'market-confidence';
+const POLICY_ENTITY_ID = 'policy-response';
+
+const SECONDS_PER_DAY = 86_400;
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(max, Math.max(min, value));
+
+/**
+ * Propagates confidence shocks through credit pricing, liquidity, and lending dynamics.
+ */
+export class CreditMarketEvolutionSystem extends System {
+  constructor(private readonly components: ComponentManager) {
+    super();
+  }
+
+  protected override update(deltaTime: number): void {
+    const bank = this.components.getComponent(BANK_ENTITY_ID, BANK_STATE_COMPONENT);
+    const market = this.components.getComponent(MARKET_ENTITY_ID, CREDIT_MARKET_COMPONENT);
+    const sentiment = this.components.getComponent(
+      SENTIMENT_ENTITY_ID,
+      MARKET_CONFIDENCE_COMPONENT,
+    );
+    const policy = this.components.getComponent(POLICY_ENTITY_ID, POLICY_RESPONSE_COMPONENT);
+
+    if (!bank || !market || !sentiment || !policy) {
+      return;
+    }
+
+    const dtDays = Math.max(deltaTime / SECONDS_PER_DAY, 0.01);
+    const supportEffect =
+      policy.supportLevel * 0.7 + policy.liquidityBackstop * 0.5 + policy.capitalInjection * 0.35;
+    const rateRelief = policy.emergencyRateCutBps / 200;
+
+    const desiredStress = this.computeStressTarget(bank, sentiment, supportEffect, rateRelief);
+    const stress = this.easeTowards(market.stressLevel, desiredStress, dtDays, 0.38, 0.05, 0.95);
+
+    const nextSpread = this.computeSpread(market, sentiment, supportEffect, rateRelief, stress, dtDays);
+    const nextLiquidity = this.computeLiquidity(market, sentiment, supportEffect, rateRelief, stress, dtDays);
+    const nextVolume = this.computeLendingVolume(
+      market,
+      sentiment,
+      supportEffect,
+      rateRelief,
+      stress,
+      dtDays,
+    );
+
+    const nextRisk = this.computeRiskAppetite(sentiment, supportEffect, stress, dtDays);
+    const nextOutflow = this.computeDepositOutflow(bank, sentiment, supportEffect, stress, dtDays);
+    const nextTrust = this.computeInterbankTrust(sentiment, supportEffect, stress, dtDays);
+
+    const nextFundingCost = 1.5 + nextSpread / 100;
+
+    const nextMarket: CreditMarketStateComponent = {
+      creditSpreadBps: nextSpread,
+      liquidityIndex: nextLiquidity,
+      lendingVolume: nextVolume,
+      stressLevel: stress,
+      fundingCost: nextFundingCost,
+    };
+
+    const nextSentiment: MarketConfidenceComponent = {
+      riskAppetite: nextRisk,
+      depositOutflowRatio: nextOutflow,
+      interbankTrust: nextTrust,
+    };
+
+    this.components.setComponent(MARKET_ENTITY_ID, CREDIT_MARKET_COMPONENT, nextMarket);
+    this.components.setComponent(SENTIMENT_ENTITY_ID, MARKET_CONFIDENCE_COMPONENT, nextSentiment);
+  }
+
+  private computeStressTarget(
+    bank: BankStateComponent,
+    sentiment: MarketConfidenceComponent,
+    supportEffect: number,
+    rateRelief: number,
+  ): number {
+    const solvencyShock = bank.defaulted ? 0.55 : 0.15;
+    const trustDrag = clamp(0.6 - sentiment.interbankTrust, 0, 0.5);
+    const outflowDrag = clamp(sentiment.depositOutflowRatio * 0.7, 0, 0.6);
+    const supportRelief = supportEffect * 0.6 + rateRelief * 0.25;
+
+    return clamp(solvencyShock + trustDrag + outflowDrag - supportRelief, 0.08, 0.92);
+  }
+
+  private computeSpread(
+    market: CreditMarketStateComponent,
+    sentiment: MarketConfidenceComponent,
+    supportEffect: number,
+    rateRelief: number,
+    stress: number,
+    dtDays: number,
+  ): number {
+    const baseSpread = 150;
+    const stressPremium = stress * 260;
+    const fundingPressure = sentiment.depositOutflowRatio * 380;
+    const policyOffset = supportEffect * 220 + rateRelief * 140;
+
+    const target = Math.max(baseSpread, baseSpread + stressPremium + fundingPressure - policyOffset);
+    return this.easeTowards(market.creditSpreadBps, target, dtDays, 0.46, 120, 600);
+  }
+
+  private computeLiquidity(
+    market: CreditMarketStateComponent,
+    sentiment: MarketConfidenceComponent,
+    supportEffect: number,
+    rateRelief: number,
+    stress: number,
+    dtDays: number,
+  ): number {
+    const baseLiquidity = 0.72;
+    const stressDrag = stress * 0.45;
+    const outflowDrag = sentiment.depositOutflowRatio * 0.55;
+    const supportBoost = supportEffect * 0.55 + rateRelief * 0.2;
+
+    const target = clamp(baseLiquidity - stressDrag - outflowDrag + supportBoost, 0.08, 1);
+    return this.easeTowards(market.liquidityIndex, target, dtDays, 0.52, 0.08, 1);
+  }
+
+  private computeLendingVolume(
+    market: CreditMarketStateComponent,
+    sentiment: MarketConfidenceComponent,
+    supportEffect: number,
+    rateRelief: number,
+    stress: number,
+    dtDays: number,
+  ): number {
+    const baseVolume = 1;
+    const stressDrag = stress * 0.65;
+    const riskPenalty = clamp(0.6 - sentiment.riskAppetite, 0, 0.6);
+    const supportBoost = supportEffect * 0.62 + rateRelief * 0.25;
+
+    const target = clamp(baseVolume - stressDrag - riskPenalty + supportBoost, 0.25, 1.1);
+    return this.easeTowards(market.lendingVolume, target, dtDays, 0.4, 0.25, 1.1);
+  }
+
+  private computeRiskAppetite(
+    sentiment: MarketConfidenceComponent,
+    supportEffect: number,
+    stress: number,
+    dtDays: number,
+  ): number {
+    const baseline = 0.66;
+    const stressPenalty = stress * 0.5;
+    const policyRelief = supportEffect * 0.35;
+
+    const target = clamp(baseline - stressPenalty + policyRelief, 0.18, 0.74);
+    return this.easeTowards(sentiment.riskAppetite, target, dtDays, 0.44, 0.18, 0.74);
+  }
+
+  private computeDepositOutflow(
+    bank: BankStateComponent,
+    sentiment: MarketConfidenceComponent,
+    supportEffect: number,
+    stress: number,
+    dtDays: number,
+  ): number {
+    const baseline = 0.02;
+    const shockOutflow = bank.defaulted ? 0.32 : 0.05;
+    const stressBias = stress * 0.35;
+    const policyRelief = supportEffect * 0.26;
+
+    const target = clamp(baseline + (shockOutflow - baseline) * (0.6 + stressBias) - policyRelief, baseline, 0.45);
+    return this.easeTowards(sentiment.depositOutflowRatio, target, dtDays, 0.5, baseline, 0.45);
+  }
+
+  private computeInterbankTrust(
+    sentiment: MarketConfidenceComponent,
+    supportEffect: number,
+    stress: number,
+    dtDays: number,
+  ): number {
+    const baseline = 0.78;
+    const stressPenalty = stress * 0.45;
+    const supportBoost = supportEffect * 0.4;
+
+    const target = clamp(baseline - stressPenalty + supportBoost, 0.25, 0.88);
+    return this.easeTowards(sentiment.interbankTrust, target, dtDays, 0.42, 0.25, 0.88);
+  }
+
+  private easeTowards(
+    current: number,
+    target: number,
+    dtDays: number,
+    intensity: number,
+    min: number,
+    max: number,
+  ): number {
+    const rate = clamp(intensity * dtDays + 0.05, 0.05, 1);
+    return clamp(current + (target - current) * rate, min, max);
+  }
+}

--- a/workspaces/Describing_Simulation_0/project/plugins/simulation/systems/EnvironmentSetupSystem.ts
+++ b/workspaces/Describing_Simulation_0/project/plugins/simulation/systems/EnvironmentSetupSystem.ts
@@ -1,0 +1,140 @@
+import { ComponentManager } from '../../../src/core/components/ComponentManager';
+import { EntityManager } from '../../../src/core/entity/EntityManager';
+import { System } from '../../../src/core/systems/System';
+
+import {
+  BANK_STATE_COMPONENT,
+  CREDIT_MARKET_COMPONENT,
+  MARKET_CONFIDENCE_COMPONENT,
+  POLICY_RESPONSE_COMPONENT,
+  type BankStateComponent,
+  type CreditMarketStateComponent,
+  type MarketConfidenceComponent,
+  type PolicyResponseComponent,
+} from '../components/CreditMarketComponents';
+
+const BANK_ENTITY_ID = 'top-3-bank';
+const MARKET_ENTITY_ID = 'credit-market';
+const SENTIMENT_ENTITY_ID = 'market-confidence';
+const POLICY_ENTITY_ID = 'policy-response';
+
+/**
+ * Materialises the core entities and baseline state required for the simulation.
+ */
+export class EnvironmentSetupSystem extends System {
+  constructor(
+    private readonly entities: EntityManager,
+    private readonly components: ComponentManager,
+  ) {
+    super();
+  }
+
+  protected override onInit(): void {
+    this.ensureComponentRegistration();
+    this.createOrUpdateEntities();
+  }
+
+  protected override update(): void {
+    // The setup work is idempotent and complete during initialisation.
+  }
+
+  private ensureComponentRegistration(): void {
+    const types = [
+      BANK_STATE_COMPONENT,
+      CREDIT_MARKET_COMPONENT,
+      MARKET_CONFIDENCE_COMPONENT,
+      POLICY_RESPONSE_COMPONENT,
+    ];
+
+    for (const type of types) {
+      if (!this.components.isRegistered(type)) {
+        this.components.register(type);
+      }
+    }
+  }
+
+  private createOrUpdateEntities(): void {
+    this.ensureBankState();
+    this.ensureMarketState();
+    this.ensureSentimentState();
+    this.ensurePolicyState();
+  }
+
+  private ensureBankState(): void {
+    if (!this.entities.has(BANK_ENTITY_ID)) {
+      this.entities.create(BANK_ENTITY_ID);
+    }
+
+    const initialBankState: BankStateComponent = {
+      solvencyRatio: 0.115,
+      liquidityCoverage: 0.82,
+      assetBase: 1_250,
+      liabilityBase: 1_140,
+      defaulted: false,
+    };
+
+    this.components.setComponent(
+      BANK_ENTITY_ID,
+      BANK_STATE_COMPONENT,
+      initialBankState,
+    );
+  }
+
+  private ensureMarketState(): void {
+    if (!this.entities.has(MARKET_ENTITY_ID)) {
+      this.entities.create(MARKET_ENTITY_ID);
+    }
+
+    const initialMarket: CreditMarketStateComponent = {
+      creditSpreadBps: 150,
+      liquidityIndex: 0.72,
+      lendingVolume: 1.0,
+      stressLevel: 0.24,
+      fundingCost: 3.1,
+    };
+
+    this.components.setComponent(
+      MARKET_ENTITY_ID,
+      CREDIT_MARKET_COMPONENT,
+      initialMarket,
+    );
+  }
+
+  private ensureSentimentState(): void {
+    if (!this.entities.has(SENTIMENT_ENTITY_ID)) {
+      this.entities.create(SENTIMENT_ENTITY_ID);
+    }
+
+    const initialSentiment: MarketConfidenceComponent = {
+      riskAppetite: 0.66,
+      depositOutflowRatio: 0.02,
+      interbankTrust: 0.78,
+    };
+
+    this.components.setComponent(
+      SENTIMENT_ENTITY_ID,
+      MARKET_CONFIDENCE_COMPONENT,
+      initialSentiment,
+    );
+  }
+
+  private ensurePolicyState(): void {
+    if (!this.entities.has(POLICY_ENTITY_ID)) {
+      this.entities.create(POLICY_ENTITY_ID);
+    }
+
+    const initialPolicy: PolicyResponseComponent = {
+      supportLevel: 0,
+      liquidityBackstop: 0.05,
+      capitalInjection: 0,
+      emergencyRateCutBps: 0,
+      interventionActive: false,
+    };
+
+    this.components.setComponent(
+      POLICY_ENTITY_ID,
+      POLICY_RESPONSE_COMPONENT,
+      initialPolicy,
+    );
+  }
+}

--- a/workspaces/Describing_Simulation_0/project/plugins/simulation/systems/PolicyResponseSystem.ts
+++ b/workspaces/Describing_Simulation_0/project/plugins/simulation/systems/PolicyResponseSystem.ts
@@ -1,0 +1,106 @@
+import { ComponentManager } from '../../../src/core/components/ComponentManager';
+import { System } from '../../../src/core/systems/System';
+
+import {
+  BANK_STATE_COMPONENT,
+  MARKET_CONFIDENCE_COMPONENT,
+  POLICY_RESPONSE_COMPONENT,
+  type PolicyResponseComponent,
+} from '../components/CreditMarketComponents';
+
+const BANK_ENTITY_ID = 'top-3-bank';
+const SENTIMENT_ENTITY_ID = 'market-confidence';
+const POLICY_ENTITY_ID = 'policy-response';
+
+const SECONDS_PER_DAY = 86_400;
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(max, Math.max(min, value));
+
+/**
+ * Models the fiscal and monetary interventions that respond to market stress.
+ */
+export class PolicyResponseSystem extends System {
+  constructor(private readonly components: ComponentManager) {
+    super();
+  }
+
+  protected override update(deltaTime: number): void {
+    const policy = this.components.getComponent(POLICY_ENTITY_ID, POLICY_RESPONSE_COMPONENT);
+    const sentiment = this.components.getComponent(
+      SENTIMENT_ENTITY_ID,
+      MARKET_CONFIDENCE_COMPONENT,
+    );
+    const bank = this.components.getComponent(BANK_ENTITY_ID, BANK_STATE_COMPONENT);
+
+    if (!policy || !sentiment || !bank) {
+      return;
+    }
+
+    const dtDays = Math.max(deltaTime / SECONDS_PER_DAY, 0.01);
+    const stressSignal = clamp(sentiment.depositOutflowRatio * 0.9 + (1 - sentiment.interbankTrust), 0, 1.2);
+    const shockBias = bank.defaulted ? 0.35 : 0.05;
+
+    const desiredSupport = clamp(shockBias + stressSignal * 0.55, 0, 1);
+    const desiredLiquidityBackstop = clamp(shockBias * 0.8 + stressSignal * 0.7, 0, 1);
+    const desiredCapital = clamp(bank.defaulted ? 0.45 + stressSignal * 0.4 : stressSignal * 0.2, 0, 1);
+    const desiredRateCut = clamp(bank.defaulted ? 60 + stressSignal * 140 : stressSignal * 40, 0, 200);
+
+    const supportLevel = this.moveTowards(
+      policy.supportLevel,
+      desiredSupport,
+      dtDays,
+      0.42,
+      0,
+      1,
+    );
+    const liquidityBackstop = this.moveTowards(
+      policy.liquidityBackstop,
+      desiredLiquidityBackstop,
+      dtDays,
+      0.5,
+      0,
+      1,
+    );
+    const capitalInjection = this.moveTowards(
+      policy.capitalInjection,
+      desiredCapital,
+      dtDays,
+      0.38,
+      0,
+      1,
+    );
+    const emergencyRateCutBps = this.moveTowards(
+      policy.emergencyRateCutBps,
+      desiredRateCut,
+      dtDays,
+      0.6,
+      0,
+      200,
+    );
+
+    const interventionActive = bank.defaulted || supportLevel > 0.08;
+
+    const nextPolicy: PolicyResponseComponent = {
+      supportLevel,
+      liquidityBackstop,
+      capitalInjection,
+      emergencyRateCutBps,
+      interventionActive,
+    };
+
+    this.components.setComponent(POLICY_ENTITY_ID, POLICY_RESPONSE_COMPONENT, nextPolicy);
+  }
+
+  private moveTowards(
+    current: number,
+    target: number,
+    dtDays: number,
+    intensity: number,
+    min: number,
+    max: number,
+  ): number {
+    const rate = clamp(intensity * dtDays + 0.05, 0.05, 1);
+    return clamp(current + (target - current) * rate, min, max);
+  }
+}

--- a/workspaces/Describing_Simulation_0/project/plugins/tsconfig.json
+++ b/workspaces/Describing_Simulation_0/project/plugins/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "../",
+    "noEmit": true
+  },
+  "include": [
+    "../src/**/*.ts",
+    "./**/*.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- add domain-specific components and systems to model a top-3 bank collapse and credit market contagion dynamics
- create an evaluation summary system and runner that captures simulation frames and writes results to verifications/bank_collapses
- document the scenario setup, form D reasoning, and findings in a dedicated report alongside the raw output

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d63e41cb04832abf23078e7d5fb6c7