### PR TITLE
Add oil blockade simulation outputs and report

### DIFF
--- a/verifications/oil_blockade/evaluation_frames.json
+++ b/verifications/oil_blockade/evaluation_frames.json
@@ -1,0 +1,8463 @@
+[
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 0,
+              "cumulativeDays": 0,
+              "cumulativePrice": 0,
+              "peakPrice": null,
+              "troughPrice": null,
+              "cumulativeSupplyDemandGap": 0,
+              "finalPrice": 0,
+              "finalEffectiveSupplyMbpd": 0,
+              "finalDemandMbpd": 0,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 1,
+      "timestamp": 86400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 1,
+              "cumulativeDays": 1,
+              "cumulativePrice": 131.61200000000002,
+              "peakPrice": 131.61200000000002,
+              "troughPrice": 131.61200000000002,
+              "cumulativeSupplyDemandGap": 9.330042000000006,
+              "finalPrice": 131.61200000000002,
+              "finalEffectiveSupplyMbpd": 88.73450799999999,
+              "finalDemandMbpd": 98.06455,
+              "finalSupplyLossMbpd": 17.73
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 2,
+      "timestamp": 172800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 2,
+              "cumulativeDays": 2,
+              "cumulativePrice": 332.1689791030001,
+              "peakPrice": 200.55697910300006,
+              "troughPrice": 131.61200000000002,
+              "cumulativeSupplyDemandGap": 13.635782471710513,
+              "finalPrice": 200.55697910300006,
+              "finalEffectiveSupplyMbpd": 89.625012811927,
+              "finalDemandMbpd": 93.9307532836375,
+              "finalSupplyLossMbpd": 17.46
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 3,
+      "timestamp": 259200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 3,
+              "cumulativeDays": 3,
+              "cumulativePrice": 552.1689791030001,
+              "peakPrice": 220,
+              "troughPrice": 131.61200000000002,
+              "cumulativeSupplyDemandGap": 13.460385098620506,
+              "finalPrice": 220,
+              "finalEffectiveSupplyMbpd": 90.07000000000001,
+              "finalDemandMbpd": 89.89460262691,
+              "finalSupplyLossMbpd": 17.19
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 4,
+      "timestamp": 345600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 4,
+              "cumulativeDays": 4,
+              "cumulativePrice": 772.1689791030001,
+              "peakPrice": 220,
+              "troughPrice": 131.61200000000002,
+              "cumulativeSupplyDemandGap": 9.786067200148509,
+              "finalPrice": 220,
+              "finalEffectiveSupplyMbpd": 90.34,
+              "finalDemandMbpd": 86.665682101528,
+              "finalSupplyLossMbpd": 16.92
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 5,
+      "timestamp": 432000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 5,
+              "cumulativeDays": 5,
+              "cumulativePrice": 992.1689791030001,
+              "peakPrice": 220,
+              "troughPrice": 131.61200000000002,
+              "cumulativeSupplyDemandGap": 5.9429307798428965,
+              "finalPrice": 220,
+              "finalEffectiveSupplyMbpd": 87.92568210152801,
+              "finalDemandMbpd": 84.0825456812224,
+              "finalSupplyLossMbpd": 16.65
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 6,
+      "timestamp": 518400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 6,
+              "cumulativeDays": 6,
+              "cumulativePrice": 1208.0857818457912,
+              "peakPrice": 220,
+              "troughPrice": 131.61200000000002,
+              "cumulativeSupplyDemandGap": 2.468835997281033,
+              "finalPrice": 215.91680274279102,
+              "finalEffectiveSupplyMbpd": 85.64325122468512,
+              "finalDemandMbpd": 82.16915644212325,
+              "finalSupplyLossMbpd": 16.38
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 7,
+      "timestamp": 604800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 7,
+              "cumulativeDays": 7,
+              "cumulativePrice": 1394.0664981208492,
+              "peakPrice": 220,
+              "troughPrice": 131.61200000000002,
+              "cumulativeSupplyDemandGap": -1.4139421558105596,
+              "finalPrice": 185.98071627505806,
+              "finalEffectiveSupplyMbpd": 85.64382644647552,
+              "finalDemandMbpd": 81.76104829338392,
+              "finalSupplyLossMbpd": 16.11
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 8,
+      "timestamp": 691200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 8,
+              "cumulativeDays": 8,
+              "cumulativePrice": 1547.3253312609895,
+              "peakPrice": 220,
+              "troughPrice": 131.61200000000002,
+              "cumulativeSupplyDemandGap": -4.371639262119942,
+              "finalPrice": 153.25883314014035,
+              "finalEffectiveSupplyMbpd": 85.61932949826125,
+              "finalDemandMbpd": 82.66163239195187,
+              "finalSupplyLossMbpd": 15.84
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 9,
+      "timestamp": 777600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 9,
+              "cumulativeDays": 9,
+              "cumulativePrice": 1678.9347881534884,
+              "peakPrice": 220,
+              "troughPrice": 131.60945689249886,
+              "cumulativeSupplyDemandGap": -5.872173094059647,
+              "finalPrice": 131.60945689249886,
+              "finalEffectiveSupplyMbpd": 85.6944851120325,
+              "finalDemandMbpd": 84.19395128009279,
+              "finalSupplyLossMbpd": 15.57
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 10,
+      "timestamp": 864000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 10,
+              "cumulativeDays": 10,
+              "cumulativePrice": 1801.09038509737,
+              "peakPrice": 220,
+              "troughPrice": 122.15559694388163,
+              "cumulativeSupplyDemandGap": -5.977247327875901,
+              "finalPrice": 122.15559694388163,
+              "finalEffectiveSupplyMbpd": 85.87940037249493,
+              "finalDemandMbpd": 85.77432613867867,
+              "finalSupplyLossMbpd": 15.3
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 11,
+      "timestamp": 950400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 11,
+              "cumulativeDays": 11,
+              "cumulativePrice": 1923.2459820412516,
+              "peakPrice": 220,
+              "troughPrice": 122.15559694388163,
+              "cumulativeSupplyDemandGap": -5.09234781350213,
+              "finalPrice": 122.15559694388163,
+              "finalEffectiveSupplyMbpd": 86.1537265111736,
+              "finalDemandMbpd": 87.03862602554737,
+              "finalSupplyLossMbpd": 15.03
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 12,
+      "timestamp": 1036800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 12,
+              "cumulativeDays": 12,
+              "cumulativePrice": 2045.4015789851333,
+              "peakPrice": 220,
+              "troughPrice": 122.15559694388163,
+              "cumulativeSupplyDemandGap": -4.46030827650209,
+              "finalPrice": 122.15559694388163,
+              "finalEffectiveSupplyMbpd": 87.4180263980423,
+              "finalDemandMbpd": 88.05006593504234,
+              "finalSupplyLossMbpd": 14.76
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 13,
+      "timestamp": 1123200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 13,
+              "cumulativeDays": 13,
+              "cumulativePrice": 2167.557175929015,
+              "peakPrice": 220,
+              "troughPrice": 122.15559694388163,
+              "cumulativeSupplyDemandGap": -4.030556721401041,
+              "finalPrice": 122.15559694388163,
+              "finalEffectiveSupplyMbpd": 88.42946630753727,
+              "finalDemandMbpd": 88.85921786263832,
+              "finalSupplyLossMbpd": 14.49
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 14,
+      "timestamp": 1209600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 14,
+              "cumulativeDays": 14,
+              "cumulativePrice": 2289.712772872897,
+              "peakPrice": 220,
+              "troughPrice": 122.15559694388163,
+              "cumulativeSupplyDemandGap": -3.762635551819187,
+              "finalPrice": 122.15559694388163,
+              "finalEffectiveSupplyMbpd": 89.23861823513325,
+              "finalDemandMbpd": 89.5065394047151,
+              "finalSupplyLossMbpd": 14.219999999999999
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 15,
+      "timestamp": 1296000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 15,
+              "cumulativeDays": 15,
+              "cumulativePrice": 2411.868369816779,
+              "peakPrice": 220,
+              "troughPrice": 122.15559694388163,
+              "cumulativeSupplyDemandGap": -3.6241786906526983,
+              "finalPrice": 122.15559694388163,
+              "finalEffectiveSupplyMbpd": 89.88593977721003,
+              "finalDemandMbpd": 90.02439663837652,
+              "finalSupplyLossMbpd": 13.95
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 16,
+      "timestamp": 1382400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 16,
+              "cumulativeDays": 16,
+              "cumulativePrice": 2534.0239667606606,
+              "peakPrice": 220,
+              "troughPrice": 122.15559694388163,
+              "cumulativeSupplyDemandGap": -3.589293276218484,
+              "finalPrice": 122.15559694388163,
+              "finalEffectiveSupplyMbpd": 90.40379701087144,
+              "finalDemandMbpd": 90.43868242530566,
+              "finalSupplyLossMbpd": 13.68
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 17,
+      "timestamp": 1468800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 17,
+              "cumulativeDays": 17,
+              "cumulativePrice": 2656.1795637045425,
+              "peakPrice": 220,
+              "troughPrice": 122.15559694388163,
+              "cumulativeSupplyDemandGap": -3.6372650191701013,
+              "finalPrice": 122.15559694388163,
+              "finalEffectiveSupplyMbpd": 90.81808279780059,
+              "finalDemandMbpd": 90.77011105484897,
+              "finalSupplyLossMbpd": 13.41
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 18,
+      "timestamp": 1555200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 18,
+              "cumulativeDays": 18,
+              "cumulativePrice": 2778.3351606484243,
+              "peakPrice": 220,
+              "troughPrice": 122.15559694388163,
+              "cumulativeSupplyDemandGap": -3.751522488030389,
+              "finalPrice": 122.15559694388163,
+              "finalEffectiveSupplyMbpd": 91.1495114273439,
+              "finalDemandMbpd": 91.03525395848361,
+              "finalSupplyLossMbpd": 13.14
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 19,
+      "timestamp": 1641600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 19,
+              "cumulativeDays": 19,
+              "cumulativePrice": 2900.490757592306,
+              "peakPrice": 220,
+              "troughPrice": 122.15559694388163,
+              "cumulativeSupplyDemandGap": -3.9188085376175934,
+              "finalPrice": 122.15559694388163,
+              "finalEffectiveSupplyMbpd": 91.41465433097854,
+              "finalDemandMbpd": 91.24736828139133,
+              "finalSupplyLossMbpd": 12.870000000000001
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 20,
+      "timestamp": 1728000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 20,
+              "cumulativeDays": 20,
+              "cumulativePrice": 3022.646354536188,
+              "peakPrice": 220,
+              "troughPrice": 122.15559694388163,
+              "cumulativeSupplyDemandGap": -4.128517451786351,
+              "finalPrice": 122.15559694388163,
+              "finalEffectiveSupplyMbpd": 91.62676865388626,
+              "finalDemandMbpd": 91.4170597397175,
+              "finalSupplyLossMbpd": 12.600000000000001
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 21,
+      "timestamp": 1814400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 21,
+              "cumulativeDays": 21,
+              "cumulativePrice": 3144.80195148007,
+              "peakPrice": 220,
+              "troughPrice": 122.15559694388163,
+              "cumulativeSupplyDemandGap": -4.3721646576203455,
+              "finalPrice": 122.15559694388163,
+              "finalEffectiveSupplyMbpd": 91.79646011221243,
+              "finalDemandMbpd": 91.55281290637843,
+              "finalSupplyLossMbpd": 12.330000000000002
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 22,
+      "timestamp": 1900800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 22,
+              "cumulativeDays": 22,
+              "cumulativePrice": 3266.9575484239517,
+              "peakPrice": 220,
+              "troughPrice": 122.15559694388163,
+              "cumulativeSupplyDemandGap": -4.642962496786524,
+              "finalPrice": 122.15559694388163,
+              "finalEffectiveSupplyMbpd": 91.93221327887336,
+              "finalDemandMbpd": 91.66141543970718,
+              "finalSupplyLossMbpd": 12.060000000000002
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 23,
+      "timestamp": 1987200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 23,
+              "cumulativeDays": 23,
+              "cumulativePrice": 3389.1131453678336,
+              "peakPrice": 220,
+              "troughPrice": 122.15559694388163,
+              "cumulativeSupplyDemandGap": -4.935480842618446,
+              "finalPrice": 122.15559694388163,
+              "finalEffectiveSupplyMbpd": 92.04081581220211,
+              "finalDemandMbpd": 91.74829746637019,
+              "finalSupplyLossMbpd": 11.790000000000003
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 24,
+      "timestamp": 2073600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 24,
+              "cumulativeDays": 24,
+              "cumulativePrice": 3511.2687423117154,
+              "peakPrice": 220,
+              "troughPrice": 122.15559694388163,
+              "cumulativeSupplyDemandGap": -5.245375593782967,
+              "finalPrice": 122.15559694388163,
+              "finalEffectiveSupplyMbpd": 92.12769783886512,
+              "finalDemandMbpd": 91.8178030877006,
+              "finalSupplyLossMbpd": 11.520000000000003
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 25,
+      "timestamp": 2160000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 25,
+              "cumulativeDays": 25,
+              "cumulativePrice": 3633.4243392555973,
+              "peakPrice": 220,
+              "troughPrice": 122.15559694388163,
+              "cumulativeSupplyDemandGap": -5.569171469213572,
+              "finalPrice": 122.15559694388163,
+              "finalEffectiveSupplyMbpd": 92.19720346019552,
+              "finalDemandMbpd": 91.87340758476492,
+              "finalSupplyLossMbpd": 11.250000000000004
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 26,
+      "timestamp": 2246400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 26,
+              "cumulativeDays": 26,
+              "cumulativePrice": 3755.579936199479,
+              "peakPrice": 220,
+              "troughPrice": 122.15559694388163,
+              "cumulativeSupplyDemandGap": -5.90408824405705,
+              "finalPrice": 122.15559694388163,
+              "finalEffectiveSupplyMbpd": 92.25280795725985,
+              "finalDemandMbpd": 91.91789118241637,
+              "finalSupplyLossMbpd": 10.980000000000004
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 27,
+      "timestamp": 2332800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 27,
+              "cumulativeDays": 27,
+              "cumulativePrice": 3877.735533143361,
+              "peakPrice": 220,
+              "troughPrice": 122.15559694388163,
+              "cumulativeSupplyDemandGap": -6.247901738430812,
+              "finalPrice": 122.15559694388163,
+              "finalEffectiveSupplyMbpd": 92.2972915549113,
+              "finalDemandMbpd": 91.95347806053753,
+              "finalSupplyLossMbpd": 10.710000000000004
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 28,
+      "timestamp": 2419200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 28,
+              "cumulativeDays": 28,
+              "cumulativePrice": 3999.891130087243,
+              "peakPrice": 220,
+              "troughPrice": 122.15559694388163,
+              "cumulativeSupplyDemandGap": -6.598832608428808,
+              "finalPrice": 122.15559694388163,
+              "finalEffectiveSupplyMbpd": 92.33287843303246,
+              "finalDemandMbpd": 91.98194756303447,
+              "finalSupplyLossMbpd": 10.440000000000005
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 29,
+      "timestamp": 2505600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 29,
+              "cumulativeDays": 29,
+              "cumulativePrice": 4122.046727031125,
+              "peakPrice": 220,
+              "troughPrice": 122.15559694388163,
+              "cumulativeSupplyDemandGap": -6.955457378926184,
+              "finalPrice": 122.15559694388163,
+              "finalEffectiveSupplyMbpd": 92.3613479355294,
+              "finalDemandMbpd": 92.00472316503202,
+              "finalSupplyLossMbpd": 10.170000000000005
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 30,
+      "timestamp": 2592000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 30,
+              "cumulativeDays": 30,
+              "cumulativePrice": 4244.202323975006,
+              "peakPrice": 220,
+              "troughPrice": 122.15559694388163,
+              "cumulativeSupplyDemandGap": -7.316637269823076,
+              "finalPrice": 122.15559694388163,
+              "finalEffectiveSupplyMbpd": 92.38412353752695,
+              "finalDemandMbpd": 92.02294364663005,
+              "finalSupplyLossMbpd": 9.900000000000006
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 31,
+      "timestamp": 2678400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 31,
+              "cumulativeDays": 31,
+              "cumulativePrice": 4366.357920918887,
+              "peakPrice": 220,
+              "troughPrice": 122.15559694388163,
+              "cumulativeSupplyDemandGap": -7.681461257039572,
+              "finalPrice": 122.15559694388163,
+              "finalEffectiveSupplyMbpd": 92.40234401912498,
+              "finalDemandMbpd": 92.03752003190849,
+              "finalSupplyLossMbpd": 9.630000000000006
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 32,
+      "timestamp": 2764800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 32,
+              "cumulativeDays": 32,
+              "cumulativePrice": 4488.513517862769,
+              "peakPrice": 220,
+              "troughPrice": 122.15559694388163,
+              "cumulativeSupplyDemandGap": -8.04920052131176,
+              "finalPrice": 122.15559694388163,
+              "finalEffectiveSupplyMbpd": 92.41692040440341,
+              "finalDemandMbpd": 92.04918114013122,
+              "finalSupplyLossMbpd": 9.360000000000007
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 33,
+      "timestamp": 2851200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 33,
+              "cumulativeDays": 33,
+              "cumulativePrice": 4610.66911480665,
+              "peakPrice": 220,
+              "troughPrice": 122.15559694388163,
+              "cumulativeSupplyDemandGap": -8.4192720072285,
+              "finalPrice": 122.15559694388163,
+              "finalEffectiveSupplyMbpd": 92.42858151262615,
+              "finalDemandMbpd": 92.05851002670941,
+              "finalSupplyLossMbpd": 9.090000000000007
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 34,
+      "timestamp": 2937600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 34,
+              "cumulativeDays": 34,
+              "cumulativePrice": 4732.824711750532,
+              "peakPrice": 220,
+              "troughPrice": 122.15559694388163,
+              "cumulativeSupplyDemandGap": -8.791209270460868,
+              "finalPrice": 122.15559694388163,
+              "finalEffectiveSupplyMbpd": 92.43791039920434,
+              "finalDemandMbpd": 92.06597313597197,
+              "finalSupplyLossMbpd": 8.820000000000007
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 35,
+      "timestamp": 3024000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 35,
+              "cumulativeDays": 35,
+              "cumulativePrice": 4854.980308694413,
+              "peakPrice": 220,
+              "troughPrice": 122.15559694388163,
+              "cumulativeSupplyDemandGap": -9.164639155545757,
+              "finalPrice": 122.15559694388163,
+              "finalEffectiveSupplyMbpd": 92.4453735084669,
+              "finalDemandMbpd": 92.07194362338201,
+              "finalSupplyLossMbpd": 8.550000000000008
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 36,
+      "timestamp": 3110400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 36,
+              "cumulativeDays": 36,
+              "cumulativePrice": 4977.135905638294,
+              "peakPrice": 220,
+              "troughPrice": 122.15559694388163,
+              "cumulativeSupplyDemandGap": -9.539263138112645,
+              "finalPrice": 122.15559694388163,
+              "finalEffectiveSupplyMbpd": 92.45134399587694,
+              "finalDemandMbpd": 92.07672001331005,
+              "finalSupplyLossMbpd": 8.280000000000008
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 37,
+      "timestamp": 3196800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 37,
+              "cumulativeDays": 37,
+              "cumulativePrice": 5099.291502582176,
+              "peakPrice": 220,
+              "troughPrice": 122.15559694388163,
+              "cumulativeSupplyDemandGap": -9.914842398665144,
+              "finalPrice": 122.15559694388163,
+              "finalEffectiveSupplyMbpd": 92.45612038580498,
+              "finalDemandMbpd": 92.08054112525248,
+              "finalSupplyLossMbpd": 8.010000000000009
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 38,
+      "timestamp": 3283200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 38,
+              "cumulativeDays": 38,
+              "cumulativePrice": 5221.447099526057,
+              "peakPrice": 220,
+              "troughPrice": 122.15559694388163,
+              "cumulativeSupplyDemandGap": -10.291185881606125,
+              "finalPrice": 122.15559694388163,
+              "finalEffectiveSupplyMbpd": 92.45994149774741,
+              "finalDemandMbpd": 92.08359801480643,
+              "finalSupplyLossMbpd": 7.740000000000009
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 39,
+      "timestamp": 3369600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 39,
+              "cumulativeDays": 39,
+              "cumulativePrice": 5343.602696469939,
+              "peakPrice": 220,
+              "troughPrice": 122.15559694388163,
+              "cumulativeSupplyDemandGap": -10.668140742457894,
+              "finalPrice": 122.15559694388163,
+              "finalEffectiveSupplyMbpd": 92.46299838730135,
+              "finalDemandMbpd": 92.08604352644959,
+              "finalSupplyLossMbpd": 7.4700000000000095
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 40,
+      "timestamp": 3456000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 40,
+              "cumulativeDays": 40,
+              "cumulativePrice": 5465.75829341382,
+              "peakPrice": 220,
+              "troughPrice": 122.15559694388163,
+              "cumulativeSupplyDemandGap": -11.045584705638305,
+              "finalPrice": 122.15559694388163,
+              "finalEffectiveSupplyMbpd": 92.46544389894451,
+              "finalDemandMbpd": 92.0879999357641,
+              "finalSupplyLossMbpd": 7.20000000000001
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 41,
+      "timestamp": 3542400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 41,
+              "cumulativeDays": 41,
+              "cumulativePrice": 5587.913890357701,
+              "peakPrice": 220,
+              "troughPrice": 122.15559694388163,
+              "cumulativeSupplyDemandGap": -11.42341995068162,
+              "finalPrice": 122.15559694388163,
+              "finalEffectiveSupplyMbpd": 92.46740030825903,
+              "finalDemandMbpd": 92.08956506321572,
+              "finalSupplyLossMbpd": 6.93000000000001
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 42,
+      "timestamp": 3628800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 42,
+              "cumulativeDays": 42,
+              "cumulativePrice": 5709.730637262049,
+              "peakPrice": 220,
+              "troughPrice": 121.81674690434761,
+              "cumulativeSupplyDemandGap": -11.836246631161188,
+              "finalPrice": 121.81674690434761,
+              "finalEffectiveSupplyMbpd": 92.51635072213911,
+              "finalDemandMbpd": 92.10352404165954,
+              "finalSupplyLossMbpd": 6.660000000000011
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 43,
+      "timestamp": 3715200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 43,
+              "cumulativeDays": 43,
+              "cumulativePrice": 5829.494019432678,
+              "peakPrice": 220,
+              "troughPrice": 119.76338217062923,
+              "cumulativeSupplyDemandGap": -12.412424668767798,
+              "finalPrice": 119.76338217062923,
+              "finalEffectiveSupplyMbpd": 92.76787043953564,
+              "finalDemandMbpd": 92.19169240192903,
+              "finalSupplyLossMbpd": 6.390000000000011
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 44,
+      "timestamp": 3801600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 44,
+              "cumulativeDays": 44,
+              "cumulativePrice": 5946.040926281655,
+              "peakPrice": 220,
+              "troughPrice": 116.54690684897653,
+              "cumulativeSupplyDemandGap": -13.038501915701971,
+              "finalPrice": 116.54690684897653,
+              "finalEffectiveSupplyMbpd": 93.00892216164078,
+              "finalDemandMbpd": 92.38284491470661,
+              "finalSupplyLossMbpd": 6.120000000000012
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 45,
+      "timestamp": 3888000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 45,
+              "cumulativeDays": 45,
+              "cumulativePrice": 6058.952323731428,
+              "peakPrice": 220,
+              "troughPrice": 112.91139744977293,
+              "cumulativeSupplyDemandGap": -13.612605965351108,
+              "finalPrice": 112.91139744977293,
+              "finalEffectiveSupplyMbpd": 93.24620257704794,
+              "finalDemandMbpd": 92.6720985273988,
+              "finalSupplyLossMbpd": 5.850000000000012
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 46,
+      "timestamp": 3974400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 46,
+              "cumulativeDays": 46,
+              "cumulativePrice": 6168.46118352971,
+              "peakPrice": 220,
+              "troughPrice": 109.50885979828259,
+              "cumulativeSupplyDemandGap": -14.067089124052188,
+              "finalPrice": 109.50885979828259,
+              "finalEffectiveSupplyMbpd": 93.48557973818453,
+              "finalDemandMbpd": 93.03109657948345,
+              "finalSupplyLossMbpd": 5.5800000000000125
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 47,
+      "timestamp": 4060800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 47,
+              "cumulativeDays": 47,
+              "cumulativePrice": 6275.206073859386,
+              "peakPrice": 220,
+              "troughPrice": 106.74489032967622,
+              "cumulativeSupplyDemandGap": -14.375849260795363,
+              "finalPrice": 106.74489032967622,
+              "finalEffectiveSupplyMbpd": 93.73070401296707,
+              "finalDemandMbpd": 93.42194387622389,
+              "finalSupplyLossMbpd": 5.310000000000013
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 48,
+      "timestamp": 4147200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 48,
+              "cumulativeDays": 48,
+              "cumulativePrice": 6379.966247176886,
+              "peakPrice": 220,
+              "troughPrice": 104.76017331749978,
+              "cumulativeSupplyDemandGap": -14.54964221907997,
+              "finalPrice": 104.76017331749978,
+              "finalEffectiveSupplyMbpd": 93.98284155985748,
+              "finalDemandMbpd": 93.80904860157287,
+              "finalSupplyLossMbpd": 5.040000000000013
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 49,
+      "timestamp": 4233600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 49,
+              "cumulativeDays": 49,
+              "cumulativePrice": 6483.453340620717,
+              "peakPrice": 220,
+              "troughPrice": 103.48709344383148,
+              "cumulativeSupplyDemandGap": -14.62455318295983,
+              "finalPrice": 103.48709344383148,
+              "finalEffectiveSupplyMbpd": 94.24138384099447,
+              "finalDemandMbpd": 94.16647287711461,
+              "finalSupplyLossMbpd": 4.770000000000014
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 50,
+      "timestamp": 4320000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 50,
+              "cumulativeDays": 50,
+              "cumulativePrice": 6586.180425703166,
+              "peakPrice": 220,
+              "troughPrice": 102.72708508244865,
+              "cumulativeSupplyDemandGap": -14.648184337601975,
+              "finalPrice": 102.72708508244865,
+              "finalEffectiveSupplyMbpd": 94.50454376574201,
+              "finalDemandMbpd": 94.48091261109987,
+              "finalSupplyLossMbpd": 4.500000000000014
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 51,
+      "timestamp": 4406400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 51,
+              "cumulativeDays": 51,
+              "cumulativePrice": 6688.404167957752,
+              "peakPrice": 220,
+              "troughPrice": 102.22374225458633,
+              "cumulativeSupplyDemandGap": -14.666858263560329,
+              "finalPrice": 102.22374225458633,
+              "finalEffectiveSupplyMbpd": 94.77001368029126,
+              "finalDemandMbpd": 94.7513397543329,
+              "finalSupplyLossMbpd": 4.230000000000015
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 52,
+      "timestamp": 4492800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 52,
+              "cumulativeDays": 52,
+              "cumulativePrice": 6790.129435196767,
+              "peakPrice": 220,
+              "troughPrice": 101.7252672390148,
+              "cumulativeSupplyDemandGap": -14.716011386708189,
+              "finalPrice": 101.7252672390148,
+              "finalEffectiveSupplyMbpd": 95.03552740515113,
+              "finalDemandMbpd": 94.98637428200327,
+              "finalSupplyLossMbpd": 3.960000000000015
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 53,
+      "timestamp": 4579200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 53,
+              "cumulativeDays": 53,
+              "cumulativePrice": 6891.163030179736,
+              "peakPrice": 220,
+              "troughPrice": 101.03359498296908,
+              "cumulativeSupplyDemandGap": -14.814974127813613,
+              "finalPrice": 101.03359498296908,
+              "finalEffectiveSupplyMbpd": 95.2993023548467,
+              "finalDemandMbpd": 95.20033961374128,
+              "finalSupplyLossMbpd": 3.6900000000000155
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 54,
+      "timestamp": 4665600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 54,
+              "cumulativeDays": 54,
+              "cumulativePrice": 6991.198279754219,
+              "peakPrice": 220,
+              "troughPrice": 100.03524957448307,
+              "cumulativeSupplyDemandGap": -14.96634154203403,
+              "finalPrice": 100.03524957448307,
+              "finalEffectiveSupplyMbpd": 95.56031724617033,
+              "finalDemandMbpd": 95.40894983194991,
+              "finalSupplyLossMbpd": 3.420000000000016
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 55,
+      "timestamp": 4752000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 55,
+              "cumulativeDays": 55,
+              "cumulativePrice": 7089.907286074054,
+              "peakPrice": 220,
+              "troughPrice": 98.70900631983581,
+              "cumulativeSupplyDemandGap": -15.159150470346432,
+              "finalPrice": 98.70900631983581,
+              "finalEffectiveSupplyMbpd": 95.8183810568785,
+              "finalDemandMbpd": 95.62557212856609,
+              "finalSupplyLossMbpd": 3.1500000000000163
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 56,
+      "timestamp": 4838400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 56,
+              "cumulativeDays": 56,
+              "cumulativePrice": 7187.0178448496745,
+              "peakPrice": 220,
+              "troughPrice": 97.11055877562015,
+              "cumulativeSupplyDemandGap": -15.374333750559856,
+              "finalPrice": 97.11055877562015,
+              "finalEffectiveSupplyMbpd": 96.07399502898055,
+              "finalDemandMbpd": 95.85881174876712,
+              "finalSupplyLossMbpd": 2.8800000000000168
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 57,
+      "timestamp": 4924800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 57,
+              "cumulativeDays": 57,
+              "cumulativePrice": 7282.359500437752,
+              "peakPrice": 220,
+              "troughPrice": 95.34165558807726,
+              "cumulativeSupplyDemandGap": -15.590671336391736,
+              "finalPrice": 95.34165558807726,
+              "finalEffectiveSupplyMbpd": 96.32807490029268,
+              "finalDemandMbpd": 96.1117373144608,
+              "finalSupplyLossMbpd": 2.610000000000017
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 58,
+      "timestamp": 5011200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 58,
+              "cumulativeDays": 58,
+              "cumulativePrice": 7375.874939269792,
+              "peakPrice": 220,
+              "troughPrice": 93.5154388320402,
+              "cumulativeSupplyDemandGap": -15.789749390512938,
+              "finalPrice": 93.5154388320402,
+              "finalEffectiveSupplyMbpd": 96.58163894948834,
+              "finalDemandMbpd": 96.38256089536713,
+              "finalSupplyLossMbpd": 2.3400000000000176
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 59,
+      "timestamp": 5097600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 59,
+              "cumulativeDays": 59,
+              "cumulativePrice": 7467.603377483289,
+              "peakPrice": 220,
+              "troughPrice": 91.72843821349689,
+              "cumulativeSupplyDemandGap": -15.959073051146817,
+              "finalPrice": 91.72843821349689,
+              "finalEffectiveSupplyMbpd": 96.83555594392145,
+              "finalDemandMbpd": 96.66623228328757,
+              "finalSupplyLossMbpd": 2.070000000000018
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 60,
+      "timestamp": 5184000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 60,
+              "cumulativeDays": 60,
+              "cumulativePrice": 7557.647936170879,
+              "peakPrice": 220,
+              "troughPrice": 90.04455868759058,
+              "cumulativeSupplyDemandGap": -16.093159203489705,
+              "finalPrice": 90.04455868759058,
+              "finalEffectiveSupplyMbpd": 97.0904010281883,
+              "finalDemandMbpd": 96.95631487584541,
+              "finalSupplyLossMbpd": 1.8000000000000185
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 61,
+      "timestamp": 5270400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 61,
+              "cumulativeDays": 61,
+              "cumulativePrice": 7646.138984737045,
+              "peakPrice": 220,
+              "troughPrice": 88.49104856616574,
+              "cumulativeSupplyDemandGap": -16.192941061140075,
+              "finalPrice": 88.49104856616574,
+              "finalEffectiveSupplyMbpd": 97.34641943709548,
+              "finalDemandMbpd": 97.2466375794451,
+              "finalSupplyLossMbpd": 1.530000000000019
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 62,
+      "timestamp": 5356800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 62,
+              "cumulativeDays": 62,
+              "cumulativePrice": 7733.202236151946,
+              "peakPrice": 220,
+              "troughPrice": 87.06325141490125,
+              "cumulativeSupplyDemandGap": -16.264072188376872,
+              "finalPrice": 87.06325141490125,
+              "finalEffectiveSupplyMbpd": 97.60356926273408,
+              "finalDemandMbpd": 97.53243813549729,
+              "finalSupplyLossMbpd": 1.2600000000000193
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 63,
+      "timestamp": 5443200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 63,
+              "cumulativeDays": 63,
+              "cumulativePrice": 7818.936388455266,
+              "peakPrice": 220,
+              "troughPrice": 85.73415230332,
+              "cumulativeSupplyDemandGap": -16.314759762083398,
+              "finalPrice": 85.73415230332,
+              "finalEffectiveSupplyMbpd": 97.86160737072986,
+              "finalDemandMbpd": 97.81091979702333,
+              "finalSupplyLossMbpd": 0.9900000000000198
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 64,
+      "timestamp": 5529600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 64,
+              "cumulativeDays": 64,
+              "cumulativePrice": 7903.401725787877,
+              "peakPrice": 220,
+              "troughPrice": 84.4653373326106,
+              "cumulativeSupplyDemandGap": -16.353662110431088,
+              "finalPrice": 84.4653373326106,
+              "finalEffectiveSupplyMbpd": 98.12018803599346,
+              "finalDemandMbpd": 98.08128568764577,
+              "finalSupplyLossMbpd": 0.7200000000000202
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 65,
+      "timestamp": 5616000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 65,
+              "cumulativeDays": 65,
+              "cumulativePrice": 7986.618725643337,
+              "peakPrice": 220,
+              "troughPrice": 83.21699985546019,
+              "cumulativeSupplyDemandGap": -16.388224053593348,
+              "finalPrice": 83.21699985546019,
+              "finalEffectiveSupplyMbpd": 98.37895299869912,
+              "finalDemandMbpd": 98.34439105553686,
+              "finalSupplyLossMbpd": 0.4500000000000206
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 66,
+      "timestamp": 5702400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 66,
+              "cumulativeDays": 66,
+              "cumulativePrice": 8068.574281276762,
+              "peakPrice": 220,
+              "troughPrice": 81.95555563342491,
+              "cumulativeSupplyDemandGap": -16.423644546118098,
+              "finalPrice": 81.95555563342491,
+              "finalEffectiveSupplyMbpd": 98.6376000007008,
+              "finalDemandMbpd": 98.60217950817605,
+              "finalSupplyLossMbpd": 0.18000000000002103
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 67,
+      "timestamp": 5788800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 67,
+              "cumulativeDays": 67,
+              "cumulativePrice": 8149.638150052416,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -16.391370837645155,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 98.80957481898088,
+              "finalDemandMbpd": 98.84184852745382,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 68,
+      "timestamp": 5875200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 68,
+              "cumulativeDays": 68,
+              "cumulativePrice": 8230.70201882807,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -16.209210441203822,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 98.8514233464347,
+              "finalDemandMbpd": 99.03358374287603,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 69,
+      "timestamp": 5961600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 69,
+              "cumulativeDays": 69,
+              "cumulativePrice": 8311.765887603724,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -16.065397087846932,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.04315856185691,
+              "finalDemandMbpd": 99.1869719152138,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 70,
+      "timestamp": 6048000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 70,
+              "cumulativeDays": 70,
+              "cumulativePrice": 8392.829756379379,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.952261368957593,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.19654673419468,
+              "finalDemandMbpd": 99.30968245308402,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 71,
+      "timestamp": 6134400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 71,
+              "cumulativeDays": 71,
+              "cumulativePrice": 8473.893625155033,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.863667757642304,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.3192572720649,
+              "finalDemandMbpd": 99.40785088338019,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 72,
+      "timestamp": 6220800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 72,
+              "cumulativeDays": 72,
+              "cumulativePrice": 8554.957493930688,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.794707832386251,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.41742570236107,
+              "finalDemandMbpd": 99.48638562761712,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 73,
+      "timestamp": 6307200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 73,
+              "cumulativeDays": 73,
+              "cumulativePrice": 8636.021362706342,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.74145485597758,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.495960446598,
+              "finalDemandMbpd": 99.54921342300668,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 74,
+      "timestamp": 6393600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 74,
+              "cumulativeDays": 74,
+              "cumulativePrice": 8717.085231481997,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.700767438646821,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.55878824198756,
+              "finalDemandMbpd": 99.59947565931832,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 75,
+      "timestamp": 6480000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 75,
+              "cumulativeDays": 75,
+              "cumulativePrice": 8798.149100257651,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.670132468578387,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.6090504782992,
+              "finalDemandMbpd": 99.63968544836763,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 76,
+      "timestamp": 6566400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 76,
+              "cumulativeDays": 76,
+              "cumulativePrice": 8879.212969033306,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.64753945631982,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.64926026734851,
+              "finalDemandMbpd": 99.67185327960708,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 77,
+      "timestamp": 6652800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 77,
+              "cumulativeDays": 77,
+              "cumulativePrice": 8960.27683780896,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.631380010309144,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.68142809858796,
+              "finalDemandMbpd": 99.69758754459863,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 78,
+      "timestamp": 6739200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 78,
+              "cumulativeDays": 78,
+              "cumulativePrice": 9041.340706584615,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.620367417296777,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.70716236357951,
+              "finalDemandMbpd": 99.71817495659188,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 79,
+      "timestamp": 6825600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 79,
+              "cumulativeDays": 79,
+              "cumulativePrice": 9122.40457536027,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.61347230668305,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.72774977557276,
+              "finalDemandMbpd": 99.73464488618649,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 80,
+      "timestamp": 6912000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 80,
+              "cumulativeDays": 80,
+              "cumulativePrice": 9203.468444135924,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.609871181988254,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.74421970516737,
+              "finalDemandMbpd": 99.74782082986216,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 81,
+      "timestamp": 6998400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 81,
+              "cumulativeDays": 81,
+              "cumulativePrice": 9284.532312911579,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.608905246028584,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.75739564884304,
+              "finalDemandMbpd": 99.75836158480271,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 82,
+      "timestamp": 7084800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 82,
+              "cumulativeDays": 82,
+              "cumulativePrice": 9365.596181687233,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.610047461057036,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.7679364037836,
+              "finalDemandMbpd": 99.76679418875514,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 83,
+      "timestamp": 7171200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 83,
+              "cumulativeDays": 83,
+              "cumulativePrice": 9446.660050462888,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.612876196875973,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.77636900773602,
+              "finalDemandMbpd": 99.77354027191708,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 84,
+      "timestamp": 7257600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 84,
+              "cumulativeDays": 84,
+              "cumulativePrice": 9527.723919238542,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.617054149327288,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.78311509089797,
+              "finalDemandMbpd": 99.77893713844665,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 85,
+      "timestamp": 7344000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 85,
+              "cumulativeDays": 85,
+              "cumulativePrice": 9608.787788014197,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.622311475084516,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.78851195742753,
+              "finalDemandMbpd": 99.7832546316703,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 86,
+      "timestamp": 7430400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 86,
+              "cumulativeDays": 86,
+              "cumulativePrice": 9689.851656789851,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.628432299486477,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.79282945065118,
+              "finalDemandMbpd": 99.78670862624922,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 87,
+      "timestamp": 7516800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 87,
+              "cumulativeDays": 87,
+              "cumulativePrice": 9770.915525565506,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.635243922804221,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.7962834452301,
+              "finalDemandMbpd": 99.78947182191236,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 88,
+      "timestamp": 7603200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 88,
+              "cumulativeDays": 88,
+              "cumulativePrice": 9851.97939434116,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.642608185254602,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.79904664089324,
+              "finalDemandMbpd": 99.79168237844286,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 89,
+      "timestamp": 7689600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 89,
+              "cumulativeDays": 89,
+              "cumulativePrice": 9933.043263116815,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.650414559011082,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.80125719742374,
+              "finalDemandMbpd": 99.79345082366726,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 90,
+      "timestamp": 7776000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 90,
+              "cumulativeDays": 90,
+              "cumulativePrice": 10014.10713189247,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.658574621812434,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.80302564264814,
+              "finalDemandMbpd": 99.79486557984679,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 91,
+      "timestamp": 7862400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 91,
+              "cumulativeDays": 91,
+              "cumulativePrice": 10095.171000668124,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.667017635849689,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.80444039882767,
+              "finalDemandMbpd": 99.79599738479041,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 92,
+      "timestamp": 7948800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 92,
+              "cumulativeDays": 92,
+              "cumulativePrice": 10176.234869443779,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.675687010875677,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.80557220377129,
+              "finalDemandMbpd": 99.7969028287453,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 93,
+      "timestamp": 8035200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 93,
+              "cumulativeDays": 93,
+              "cumulativePrice": 10257.298738219433,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.684537474692647,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.80647764772618,
+              "finalDemandMbpd": 99.79762718390921,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 94,
+      "timestamp": 8121600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 94,
+              "cumulativeDays": 94,
+              "cumulativePrice": 10338.362606995088,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.69353280954239,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.8072020028901,
+              "finalDemandMbpd": 99.79820666804035,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 95,
+      "timestamp": 8208000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 95,
+              "cumulativeDays": 95,
+              "cumulativePrice": 10419.426475770742,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.702644041218363,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.80778148702123,
+              "finalDemandMbpd": 99.79867025534526,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 96,
+      "timestamp": 8294400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 96,
+              "cumulativeDays": 96,
+              "cumulativePrice": 10500.490344546397,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.711847990355324,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.80824507432614,
+              "finalDemandMbpd": 99.79904112518918,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 97,
+      "timestamp": 8380800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 97,
+              "cumulativeDays": 97,
+              "cumulativePrice": 10581.554213322052,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.721126113461068,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.80861594417006,
+              "finalDemandMbpd": 99.79933782106431,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 98,
+      "timestamp": 8467200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 98,
+              "cumulativeDays": 98,
+              "cumulativePrice": 10662.618082097706,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.730463575741837,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.8089126400452,
+              "finalDemandMbpd": 99.79957517776442,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 99,
+      "timestamp": 8553600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 99,
+              "cumulativeDays": 99,
+              "cumulativePrice": 10743.68195087336,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.73984850936263,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.8091499967453,
+              "finalDemandMbpd": 99.79976506312451,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 100,
+      "timestamp": 8640000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 100,
+              "cumulativeDays": 100,
+              "cumulativePrice": 10824.745819649015,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.749271420055436,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.80933988210539,
+              "finalDemandMbpd": 99.79991697141259,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 101,
+      "timestamp": 8726400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 101,
+              "cumulativeDays": 101,
+              "cumulativePrice": 10905.80968842467,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.75872471240585,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.80949179039347,
+              "finalDemandMbpd": 99.80003849804305,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 102,
+      "timestamp": 8812800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 102,
+              "cumulativeDays": 102,
+              "cumulativePrice": 10986.873557200324,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.768202310082359,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.80961331702393,
+              "finalDemandMbpd": 99.80013571934742,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 103,
+      "timestamp": 8899200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 103,
+              "cumulativeDays": 103,
+              "cumulativePrice": 11067.937425975979,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.777699352019752,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.8097105383283,
+              "finalDemandMbpd": 99.80021349639091,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 104,
+      "timestamp": 8985600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 104,
+              "cumulativeDays": 104,
+              "cumulativePrice": 11149.001294751633,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.78721194936584,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.80978831537179,
+              "finalDemandMbpd": 99.8002757180257,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 105,
+      "timestamp": 9072000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 105,
+              "cumulativeDays": 105,
+              "cumulativePrice": 11230.065163527288,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.796736991038884,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.80985053700658,
+              "finalDemandMbpd": 99.80032549533354,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 106,
+      "timestamp": 9158400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 106,
+              "cumulativeDays": 106,
+              "cumulativePrice": 11311.129032302943,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.806271988173492,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.80990031431442,
+              "finalDemandMbpd": 99.80036531717981,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 107,
+      "timestamp": 9244800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 107,
+              "cumulativeDays": 107,
+              "cumulativePrice": 11392.192901078597,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.81581494967736,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.80994013616069,
+              "finalDemandMbpd": 99.80039717465682,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 108,
+      "timestamp": 9331200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 108,
+              "cumulativeDays": 108,
+              "cumulativePrice": 11473.256769854252,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.825364282676631,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.8099719936377,
+              "finalDemandMbpd": 99.80042266063843,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 109,
+      "timestamp": 9417600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 109,
+              "cumulativeDays": 109,
+              "cumulativePrice": 11554.320638629906,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.834918712872224,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.80999747961931,
+              "finalDemandMbpd": 99.80044304942372,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 110,
+      "timestamp": 9504000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 110,
+              "cumulativeDays": 110,
+              "cumulativePrice": 11635.38450740556,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.84447722082487,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.8100178684046,
+              "finalDemandMbpd": 99.80045936045195,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 111,
+      "timestamp": 9590400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 111,
+              "cumulativeDays": 111,
+              "cumulativePrice": 11716.448376181215,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.85403899098317,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.81003417943283,
+              "finalDemandMbpd": 99.80047240927453,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 112,
+      "timestamp": 9676800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 112,
+              "cumulativeDays": 112,
+              "cumulativePrice": 11797.51224495687,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.863603370905977,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.81004722825541,
+              "finalDemandMbpd": 99.8004828483326,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 113,
+      "timestamp": 9763200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 113,
+              "cumulativeDays": 113,
+              "cumulativePrice": 11878.576113732524,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.873169838640408,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.81005766731349,
+              "finalDemandMbpd": 99.80049119957906,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 114,
+      "timestamp": 9849600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 114,
+              "cumulativeDays": 114,
+              "cumulativePrice": 11959.639982508179,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.882737976624128,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.81006601855994,
+              "finalDemandMbpd": 99.80049788057622,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 115,
+      "timestamp": 9936000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 115,
+              "cumulativeDays": 115,
+              "cumulativePrice": 12040.703851283834,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.89230745080728,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.8100726995571,
+              "finalDemandMbpd": 99.80050322537394,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 116,
+      "timestamp": 10022400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 116,
+              "cumulativeDays": 116,
+              "cumulativePrice": 12121.767720059488,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.901877993949967,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.81007804435482,
+              "finalDemandMbpd": 99.80050750121214,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 117,
+      "timestamp": 10108800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 117,
+              "cumulativeDays": 117,
+              "cumulativePrice": 12202.831588835143,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.911449392260295,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.81008232019302,
+              "finalDemandMbpd": 99.80051092188269,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 118,
+      "timestamp": 10195200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 118,
+              "cumulativeDays": 118,
+              "cumulativePrice": 12283.895457610797,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.92102147470473,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.81008574086357,
+              "finalDemandMbpd": 99.80051365841913,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 119,
+      "timestamp": 10281600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 119,
+              "cumulativeDays": 119,
+              "cumulativePrice": 12364.959326386452,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.93059410445646,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.81008847740001,
+              "finalDemandMbpd": 99.80051584764828,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 120,
+      "timestamp": 10368000000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 120,
+              "cumulativeDays": 120,
+              "cumulativePrice": 12446.023195162106,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.940167172054018,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.81009066662916,
+              "finalDemandMbpd": 99.80051759903161,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 121,
+      "timestamp": 10454400000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 121,
+              "cumulativeDays": 121,
+              "cumulativePrice": 12527.08706393776,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.949740239651575,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.81009066662916,
+              "finalDemandMbpd": 99.80051759903161,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 122,
+      "timestamp": 10540800000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 122,
+              "cumulativeDays": 122,
+              "cumulativePrice": 12608.150932713415,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.959313307249133,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.81009066662916,
+              "finalDemandMbpd": 99.80051759903161,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 123,
+      "timestamp": 10627200000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 123,
+              "cumulativeDays": 123,
+              "cumulativePrice": 12689.21480148907,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.96888637484669,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.81009066662916,
+              "finalDemandMbpd": 99.80051759903161,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 124,
+      "timestamp": 10713600000,
+      "deltaSeconds": 86400
+    }
+  },
+  {
+    "type": "evaluation/frame",
+    "payload": {
+      "entities": [
+        {
+          "id": "global-oil-market",
+          "components": {
+            "oil.blockade.state": {
+              "active": true,
+              "chokepointCapacityShare": 0.2,
+              "severity": 0.9,
+              "rerouteRatePerDay": 0.015,
+              "reserveReleaseMbpd": 2,
+              "reserveVolumeMb": 60,
+              "reservesRemainingMb": 0,
+              "adaptedCapacityMbpd": 18,
+              "availableSupplyMbpd": 100,
+              "supplyLossMbpd": 0,
+              "reserveUtilizationMbpd": 0
+            },
+            "oil.market.state": {
+              "baselineSupplyMbpd": 100,
+              "baselineDemandMbpd": 100,
+              "baselinePricePerBarrel": 80,
+              "pricePerBarrel": 81.06386877565392,
+              "priceFloorPerBarrel": 40,
+              "priceCeilingPerBarrel": 220,
+              "priceSensitivity": 5.5,
+              "demandElasticity": 0.15,
+              "supplyElasticity": 0.06,
+              "demandAdjustmentRate": 0.2,
+              "supplyAdjustmentRate": 0.12,
+              "physicalSupplyMbpd": 100.00957481898088,
+              "effectiveSupplyMbpd": 99.81009066662916,
+              "currentDemandMbpd": 99.80051759903161,
+              "inventoryMb": 1211.47546107342,
+              "inventoryDrawCapacityMbpd": 4,
+              "inventoryReplenishMbpd": 1.2,
+              "lastInventoryDrawMbpd": 0,
+              "lastInventoryReplenishMbpd": 0.19948415235171524
+            }
+          }
+        },
+        {
+          "id": "market-analytics",
+          "components": {
+            "oil.market.summary": {
+              "tickCount": 124,
+              "cumulativeDays": 124,
+              "cumulativePrice": 12770.278670264724,
+              "peakPrice": 220,
+              "troughPrice": 81.06386877565392,
+              "cumulativeSupplyDemandGap": -15.978459442444247,
+              "finalPrice": 81.06386877565392,
+              "finalEffectiveSupplyMbpd": 99.81009066662916,
+              "finalDemandMbpd": 99.80051759903161,
+              "finalSupplyLossMbpd": 0
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "tick": 125,
+      "timestamp": 10800000000,
+      "deltaSeconds": 86400
+    }
+  }
+]

--- a/verifications/oil_blockade/report.md
+++ b/verifications/oil_blockade/report.md
@@ -1,0 +1,26 @@
+# Maritime Blockade Oil Market Simulation
+
+## Form D Hypothetical Reasoning
+- **Environment (E):** A discrete-time global oil market ECS world with one market entity (`global-oil-market`) carrying oil supply/demand state and blockade status, plus an analytics entity aggregating market signals.
+- **Phenomenon (X):** A severe maritime chokepoint blockade that initially removes 18 mbpd from transit (90% disruption of a 20% chokepoint share) while emergency reserves can release up to 2 mbpd and rerouting gradually restores capacity.
+- **Condition (C):** The blockade remains active for the 120-day horizon; rerouting and reserve deployment continue until either capacity is restored or reserves are exhausted, exposing price and supply responses.
+- **Observation Targets (D):** Daily oil price, effective supply, demand, supply losses, and inventory levels extracted from the evaluation frames to assess transient shocks, adaptation pace, and steady-state outcomes.
+
+## Simulation Setup
+- **Temporal Resolution:** 120 daily ticks (86,400 second increments) coordinated by paired simulation and evaluation players.
+- **Key Systems:**
+  - `BlockadeShockSystem` applies chokepoint losses, reserve drawdowns, and rerouting recovery to the maritime blockade component.
+  - `OilMarketDynamicsSystem` updates market supply, demand, price, and inventory responses.
+  - `OilMarketSummarySystem` integrates evaluation frames for analytics and reporting.
+- **Initial State:** Baseline supply and demand at 100 mbpd with $80/bbl price, 1,200 Mb inventory, blockade active with 60 Mb reserves and zero adapted capacity.
+- **Outputs:** Full evaluation frames captured at `verifications/oil_blockade/evaluation_frames.json`.
+
+## Findings from Evaluation Output
+- **Shock Magnitude:** The analytics component records an immediate 17.7 mbpd supply loss on day 2 (tick 2), driving prices to $131.61/bbl while effective supply falls to 88.7 mbpd against 98.1 mbpd demand.【F:verifications/oil_blockade/evaluation_frames.json†L70-L96】
+- **Peak Stress:** By day 3 the price spikes to $200.56/bbl, and day 4 reaches the $220/bbl ceiling as residual supply losses stay above 17 mbpd despite reserve support.【F:verifications/oil_blockade/evaluation_frames.json†L138-L156】【F:verifications/oil_blockade/evaluation_frames.json†L214-L223】
+- **Adaptation Trajectory:** Continued rerouting narrows the gap—by day 7 prices ease to $215.92/bbl with supply loss down to 16.38 mbpd, and by day 30 prices retreat to $122.16/bbl as the loss shrinks near 10.2 mbpd.【F:verifications/oil_blockade/evaluation_frames.json†L418-L427】【F:verifications/oil_blockade/evaluation_frames.json†L1980-L1999】
+- **Normalization:** By days 60 and 90, effective supply nearly matches demand, prices fall back to ~$91.73/bbl and then baseline $81.06/bbl as the blockade’s net supply loss hits zero.【F:verifications/oil_blockade/evaluation_frames.json†L4020-L4039】【F:verifications/oil_blockade/evaluation_frames.json†L6060-L6079】
+- **Aggregate View:** Over 124 evaluated days the market averages $102.99/bbl (above baseline), peaking at $220/bbl, with the cumulative supply-demand gap slightly favoring supply as adaptation overshoots after recovery.【F:verifications/oil_blockade/evaluation_frames.json†L8442-L8451】
+
+## Interpretation
+The blockade triggers an acute, short-term price shock due to immediate transit losses. Emergency reserves and rerouting dampen the disruption within a week, yet prices remain elevated for roughly a month because effective supply lags demand. Once rerouting restores the lost 18 mbpd, inventories and demand rebalance, bringing prices back to baseline. The moderate negative cumulative supply-demand gap suggests post-recovery oversupply, implying policymakers must calibrate reserve drawdowns and rerouting pace to avoid secondary gluts.

--- a/workspaces/Describing_Simulation_0/project/plugins/simulation/systems/BlockadeShockSystem.ts
+++ b/workspaces/Describing_Simulation_0/project/plugins/simulation/systems/BlockadeShockSystem.ts
@@ -1,0 +1,129 @@
+import { ComponentManager } from 'src/core/components/ComponentManager';
+import { EntityManager } from 'src/core/entity/EntityManager';
+import { System } from 'src/core/systems/System';
+
+import {
+  MaritimeBlockadeStateComponent,
+  OilMarketStateComponent,
+} from '../components/OilMarket';
+
+const SECONDS_PER_DAY = 86_400;
+
+function clamp01(value: number): number {
+  if (value <= 0) {
+    return 0;
+  }
+
+  if (value >= 1) {
+    return 1;
+  }
+
+  return value;
+}
+
+/**
+ * Computes the physical supply available after accounting for chokepoint
+ * disruptions, rerouting progress, and reserve deployments.
+ */
+export class BlockadeShockSystem extends System {
+  constructor(
+    private readonly entityId: string,
+    private readonly entities: EntityManager,
+    private readonly components: ComponentManager,
+  ) {
+    super();
+  }
+
+  protected override onInit(): void {
+    if (!this.entities.has(this.entityId)) {
+      this.entities.create(this.entityId);
+    }
+
+    const blockade = this.components.getComponent(
+      this.entityId,
+      MaritimeBlockadeStateComponent,
+    );
+
+    if (blockade) {
+      blockade.reservesRemainingMb = blockade.reservesRemainingMb ?? blockade.reserveVolumeMb;
+      blockade.adaptedCapacityMbpd = blockade.adaptedCapacityMbpd ?? 0;
+      blockade.availableSupplyMbpd = blockade.availableSupplyMbpd ?? 0;
+      blockade.supplyLossMbpd = blockade.supplyLossMbpd ?? 0;
+      blockade.reserveUtilizationMbpd = blockade.reserveUtilizationMbpd ?? 0;
+    }
+  }
+
+  protected override update(deltaSeconds: number): void {
+    const market = this.components.getComponent(
+      this.entityId,
+      OilMarketStateComponent,
+    );
+    const blockade = this.components.getComponent(
+      this.entityId,
+      MaritimeBlockadeStateComponent,
+    );
+
+    if (!market || !blockade) {
+      return;
+    }
+
+    const baselineSupply = Math.max(0, market.baselineSupplyMbpd);
+    const chokepointShare = clamp01(blockade.chokepointCapacityShare);
+    const severity = clamp01(blockade.severity);
+    const disruptedFlowMbpd = baselineSupply * chokepointShare * severity;
+    const currentAdapted = Number.isFinite(blockade.adaptedCapacityMbpd)
+      ? Math.max(0, blockade.adaptedCapacityMbpd)
+      : 0;
+    const currentReserves = Number.isFinite(blockade.reservesRemainingMb)
+      ? Math.max(0, blockade.reservesRemainingMb)
+      : blockade.reserveVolumeMb;
+    const deltaDays = Math.max(deltaSeconds, 0) / SECONDS_PER_DAY;
+
+    if (!blockade.active) {
+      blockade.adaptedCapacityMbpd = disruptedFlowMbpd;
+    } else if (deltaDays > 0 && disruptedFlowMbpd > 0) {
+      const rerouteRate = Math.max(0, blockade.rerouteRatePerDay);
+      const adaptationGain = disruptedFlowMbpd * rerouteRate * deltaDays;
+      blockade.adaptedCapacityMbpd = Math.min(
+        disruptedFlowMbpd,
+        currentAdapted + adaptationGain,
+      );
+    }
+
+    const regainedCapacityMbpd = blockade.active
+      ? Math.max(
+          0,
+          Math.min(disruptedFlowMbpd, blockade.adaptedCapacityMbpd ?? currentAdapted),
+        )
+      : disruptedFlowMbpd;
+
+    const remainingLossMbpd = Math.max(0, disruptedFlowMbpd - regainedCapacityMbpd);
+
+    let availableSupply = Math.max(0, baselineSupply - remainingLossMbpd);
+    blockade.supplyLossMbpd = remainingLossMbpd;
+
+    let reserveUtilizationMbpd = 0;
+    if (
+      blockade.active &&
+      deltaDays > 0 &&
+      blockade.reserveReleaseMbpd > 0 &&
+      currentReserves > 0
+    ) {
+      const potentialReleaseVolume = blockade.reserveReleaseMbpd * deltaDays;
+      const actualReleaseVolume = Math.min(potentialReleaseVolume, currentReserves);
+
+      if (actualReleaseVolume > 0 && deltaDays > 0) {
+        reserveUtilizationMbpd = actualReleaseVolume / deltaDays;
+        blockade.reservesRemainingMb = Math.max(
+          0,
+          currentReserves - actualReleaseVolume,
+        );
+      }
+    }
+
+    availableSupply += reserveUtilizationMbpd;
+
+    blockade.reserveUtilizationMbpd = reserveUtilizationMbpd;
+    blockade.availableSupplyMbpd = availableSupply;
+  }
+}

--- a/workspaces/Describing_Simulation_0/project/src/scenarios/oilBlockade/index.ts
+++ b/workspaces/Describing_Simulation_0/project/src/scenarios/oilBlockade/index.ts
@@ -1,0 +1,309 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import { ComponentManager } from 'src/core/components/ComponentManager';
+import { EntityManager } from 'src/core/entity/EntityManager';
+import type { SnapshotFrame } from 'src/core/IOPlayer';
+import { EvaluationPlayer } from 'src/core/evalplayer/EvaluationPlayer';
+import { SimulationPlayer } from 'src/core/simplayer/SimulationPlayer';
+import { Bus } from 'src/core/messaging';
+import { SystemManager } from 'src/core/systems/SystemManager';
+
+import {
+  MaritimeBlockadeStateComponent,
+  OilMarketStateComponent,
+  type MaritimeBlockadeState,
+  type OilMarketState,
+} from '../../../plugins/simulation/components/OilMarket';
+import { BlockadeShockSystem } from '../../../plugins/simulation/systems/BlockadeShockSystem';
+import { OilMarketDynamicsSystem } from '../../../plugins/simulation/systems/OilMarketDynamicsSystem';
+import { OilMarketSummaryComponent } from '../../../plugins/evaluation/components/OilMarketSummary';
+import { OilMarketSummarySystem } from '../../../plugins/evaluation/systems/OilMarketSummarySystem';
+
+const WORLD_ENTITY_ID = 'global-oil-market';
+const SUMMARY_ENTITY_ID = 'market-analytics';
+const SIMULATION_DAYS = 120;
+const STEP_INTERVAL_MS = 86_400_000; // one day per tick
+
+class ManualClock {
+  private current = 0;
+
+  constructor(private readonly stepMs: number) {}
+
+  now(): number {
+    const value = this.current;
+    this.current += this.stepMs;
+    return value;
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+interface TimelinePoint {
+  day: number;
+  pricePerBarrel?: number;
+  effectiveSupplyMbpd?: number;
+  demandMbpd?: number;
+  supplyLossMbpd?: number;
+  inventoryMb?: number;
+}
+
+function extractWorldSnapshot(frame: SnapshotFrame): TimelinePoint | null {
+  const world = frame.payload.entities.find((entity) => entity.id === WORLD_ENTITY_ID);
+  if (!world) {
+    return null;
+  }
+
+  const market = world.components?.['oil.market.state'] as OilMarketState | undefined;
+  const blockade = world.components?.['oil.blockade.state'] as
+    | MaritimeBlockadeState
+    | undefined;
+
+  if (!market) {
+    return null;
+  }
+
+  return {
+    day: frame.metadata.tick,
+    pricePerBarrel: market.pricePerBarrel,
+    effectiveSupplyMbpd: market.effectiveSupplyMbpd,
+    demandMbpd: market.currentDemandMbpd,
+    supplyLossMbpd: blockade?.supplyLossMbpd,
+    inventoryMb: market.inventoryMb,
+  };
+}
+
+async function runSimulation(): Promise<void> {
+  const simulationComponents = new ComponentManager();
+  simulationComponents.register(OilMarketStateComponent);
+  simulationComponents.register(MaritimeBlockadeStateComponent);
+
+  const simulationEntities = new EntityManager(simulationComponents);
+  simulationEntities.create(WORLD_ENTITY_ID);
+
+  const baselineMarket: OilMarketState = {
+    baselineSupplyMbpd: 100,
+    baselineDemandMbpd: 100,
+    baselinePricePerBarrel: 80,
+    pricePerBarrel: 80,
+    priceFloorPerBarrel: 40,
+    priceCeilingPerBarrel: 220,
+    priceSensitivity: 5.5,
+    demandElasticity: 0.15,
+    supplyElasticity: 0.06,
+    demandAdjustmentRate: 0.2,
+    supplyAdjustmentRate: 0.12,
+    physicalSupplyMbpd: 100,
+    effectiveSupplyMbpd: 100,
+    currentDemandMbpd: 100,
+    inventoryMb: 1_200,
+    inventoryDrawCapacityMbpd: 4,
+    inventoryReplenishMbpd: 1.2,
+    lastInventoryDrawMbpd: 0,
+    lastInventoryReplenishMbpd: 0,
+  };
+
+  const blockadeState: MaritimeBlockadeState = {
+    active: true,
+    chokepointCapacityShare: 0.2,
+    severity: 0.9,
+    rerouteRatePerDay: 0.015,
+    reserveReleaseMbpd: 2,
+    reserveVolumeMb: 60,
+    reservesRemainingMb: 60,
+    adaptedCapacityMbpd: 0,
+    availableSupplyMbpd: baselineMarket.physicalSupplyMbpd,
+    supplyLossMbpd: 0,
+    reserveUtilizationMbpd: 0,
+  };
+
+  simulationComponents.setComponent(
+    WORLD_ENTITY_ID,
+    OilMarketStateComponent,
+    baselineMarket,
+  );
+  simulationComponents.setComponent(
+    WORLD_ENTITY_ID,
+    MaritimeBlockadeStateComponent,
+    blockadeState,
+  );
+
+  const simulationSystems = new SystemManager();
+  simulationSystems.register(
+    new BlockadeShockSystem(WORLD_ENTITY_ID, simulationEntities, simulationComponents),
+    0,
+  );
+  simulationSystems.register(
+    new OilMarketDynamicsSystem(WORLD_ENTITY_ID, simulationComponents),
+    1,
+  );
+
+  const evaluationComponents = new ComponentManager();
+  evaluationComponents.register(OilMarketStateComponent);
+  evaluationComponents.register(MaritimeBlockadeStateComponent);
+  evaluationComponents.register(OilMarketSummaryComponent);
+
+  const evaluationEntities = new EntityManager(evaluationComponents);
+  evaluationEntities.create(SUMMARY_ENTITY_ID);
+  const evaluationSystems = new SystemManager();
+  const summarySystem = new OilMarketSummarySystem(
+    WORLD_ENTITY_ID,
+    SUMMARY_ENTITY_ID,
+    evaluationEntities,
+    evaluationComponents,
+  );
+  evaluationSystems.register(summarySystem);
+
+  const simulationInboundBus = new Bus();
+  const simulationOutboundBus = new Bus();
+  const evaluationInboundBus = new Bus();
+  const evaluationOutboundBus = new Bus();
+
+  const simulationClock = new ManualClock(STEP_INTERVAL_MS);
+  const evaluationClock = new ManualClock(STEP_INTERVAL_MS);
+
+  const simulationPlayer = new SimulationPlayer(
+    simulationEntities,
+    simulationComponents,
+    simulationSystems,
+    simulationInboundBus,
+    simulationOutboundBus,
+    {
+      tickIntervalMs: 1,
+      timeProvider: simulationClock.now.bind(simulationClock),
+    },
+  );
+
+  const evaluationPlayer = new EvaluationPlayer(
+    evaluationEntities,
+    evaluationComponents,
+    evaluationSystems,
+    evaluationInboundBus,
+    evaluationOutboundBus,
+    {
+      tickIntervalMs: 1,
+      timeProvider: evaluationClock.now.bind(evaluationClock),
+    },
+  );
+
+  const evaluationFrames: SnapshotFrame[] = [];
+  evaluationOutboundBus.subscribe((frame) => {
+    evaluationFrames.push(frame as SnapshotFrame);
+  });
+
+  let simulationTicks = 0;
+  const completion = new Promise<void>((resolve) => {
+    simulationOutboundBus.subscribe((frame) => {
+      const snapshot = frame as SnapshotFrame;
+      evaluationInboundBus.send(snapshot);
+      simulationTicks += 1;
+
+      if (simulationTicks >= SIMULATION_DAYS) {
+        simulationInboundBus.send(simulationPlayer.commands.stop, undefined);
+        resolve();
+      }
+    });
+  });
+
+  evaluationPlayer.start();
+  simulationInboundBus.send(simulationPlayer.commands.start, undefined);
+
+  await completion;
+  await delay(5);
+
+  if (evaluationFrames.length === 0) {
+    throw new Error('Simulation results could not be resolved.');
+  }
+
+  const secondsPerDay = 86_400;
+  let cumulativePrice = 0;
+  let cumulativeGap = 0;
+  let totalDays = 0;
+  let peakPrice = Number.NEGATIVE_INFINITY;
+  let troughPrice = Number.POSITIVE_INFINITY;
+  let finalSnapshot: TimelinePoint | null = null;
+
+  for (const frame of evaluationFrames) {
+    const snapshot = extractWorldSnapshot(frame);
+    if (!snapshot || snapshot.pricePerBarrel === undefined) {
+      continue;
+    }
+
+    const deltaSeconds =
+      typeof frame.metadata?.deltaSeconds === 'number' ? frame.metadata.deltaSeconds : 0;
+    const deltaDays = deltaSeconds / secondsPerDay;
+
+    cumulativePrice += snapshot.pricePerBarrel * deltaDays;
+    if (
+      snapshot.demandMbpd !== undefined &&
+      snapshot.effectiveSupplyMbpd !== undefined
+    ) {
+      cumulativeGap +=
+        (snapshot.demandMbpd - snapshot.effectiveSupplyMbpd) * deltaDays;
+    }
+
+    totalDays += deltaDays;
+    peakPrice = Math.max(peakPrice, snapshot.pricePerBarrel);
+    troughPrice = Math.min(troughPrice, snapshot.pricePerBarrel);
+    finalSnapshot = snapshot;
+  }
+
+  if (!finalSnapshot) {
+    throw new Error('Simulation results could not be resolved.');
+  }
+
+  evaluationPlayer.stop();
+  simulationPlayer.stop();
+
+  const averagePrice =
+    totalDays > 0
+      ? cumulativePrice / totalDays
+      : finalSnapshot.pricePerBarrel ?? 0;
+  const averageSupplyGapMbpd =
+    totalDays > 0 ? cumulativeGap / totalDays : 0;
+
+  const keyDays = [1, 7, 30, 60, 90, 120];
+  const timeline = keyDays.map<TimelinePoint>((day) => {
+    const frame = evaluationFrames.find((entry) => entry.metadata.tick === day);
+    if (!frame) {
+      return { day };
+    }
+
+    const snapshot = extractWorldSnapshot(frame);
+    return snapshot ?? { day };
+  });
+
+  const outputDir = path.resolve(process.cwd(), '../../../verifications/oil_blockade');
+  await fs.mkdir(outputDir, { recursive: true });
+
+  const rawOutputPath = path.join(outputDir, 'evaluation_frames.json');
+  await fs.writeFile(rawOutputPath, JSON.stringify(evaluationFrames, null, 2));
+
+  const result = {
+    simulationDays: SIMULATION_DAYS,
+    rawOutputPath,
+    summary: {
+      finalPrice: finalSnapshot.pricePerBarrel ?? 0,
+      peakPrice,
+      troughPrice,
+      averagePrice,
+      finalDemandMbpd: finalSnapshot.demandMbpd ?? 0,
+      finalEffectiveSupplyMbpd: finalSnapshot.effectiveSupplyMbpd ?? 0,
+      finalSupplyLossMbpd: finalSnapshot.supplyLossMbpd ?? 0,
+      averageSupplyGapMbpd,
+      remainingInventoryMb: finalSnapshot.inventoryMb ?? 0,
+    },
+    timeline,
+  };
+
+  console.log(JSON.stringify(result, null, 2));
+}
+
+if (require.main === module) {
+  runSimulation().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary
- direct the oil blockade scenario runner to emit results under the repository-level `verifications/oil_blockade` folder and drop ad-hoc logging
- clean the `BlockadeShockSystem` implementation so the blockade supply calculations run without debug output
- capture the latest evaluation frames and document the scenario setup plus findings in `verifications/oil_blockade/report.md`

## Testing
- npm run simulate:oil-blockade

------
https://chatgpt.com/codex/tasks/task_e_68d63dc54860832ab0b437db4e561c65