### PR TITLE
Fix structure diagram Stop entry

### DIFF
--- a/Describing_Simulation_0.md
+++ b/Describing_Simulation_0.md
@@ -187,7 +187,7 @@ project/
 │   │   │   └── operations/
 │   │   │       ├── Start.ts
 │   │   │       ├── Pause.ts
-`│   │   │       ├── ``Stop.ts`
+│   │   │       ├── Stop.ts
 
 │   │   │       ├── EjectSystem.ts
 │   │   │       └── InjectSystem.ts


### PR DESCRIPTION
## Summary
- correct the Stop.ts entry in the structure diagram of Describing_Simulation_0.md to remove stray characters

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d73aa44104832a80899648f47887fd