### PR TITLE
Add HTTP server scaffolding and tests

### DIFF
--- a/workspaces/Describing_Simulation_0/project/src/main.ts
+++ b/workspaces/Describing_Simulation_0/project/src/main.ts
@@ -1,0 +1,83 @@
+import { Bus } from './core/messaging/Bus';
+import { ComponentManager } from './core/components/ComponentManager';
+import { EntityManager } from './core/entity/EntityManager';
+import { SystemManager } from './core/systems/SystemManager';
+import { SimulationPlayer } from './core/simplayer/SimulationPlayer';
+import { EvaluationPlayer } from './core/evalplayer/EvaluationPlayer';
+import { createServer } from './server';
+
+async function main(): Promise<void> {
+  const simulationComponents = new ComponentManager();
+  const simulationEntities = new EntityManager(simulationComponents);
+  const simulationSystems = new SystemManager();
+  const simulationInbound = new Bus();
+  const simulationOutbound = new Bus();
+
+  const evaluationComponents = new ComponentManager();
+  const evaluationEntities = new EntityManager(evaluationComponents);
+  const evaluationSystems = new SystemManager();
+  const evaluationInbound = new Bus();
+  const evaluationOutbound = new Bus();
+
+  const simulationPlayer = new SimulationPlayer(
+    simulationEntities,
+    simulationComponents,
+    simulationSystems,
+    simulationInbound,
+    simulationOutbound,
+  );
+
+  const evaluationPlayer = new EvaluationPlayer(
+    evaluationEntities,
+    evaluationComponents,
+    evaluationSystems,
+    evaluationInbound,
+    evaluationOutbound,
+  );
+
+  const server = createServer({
+    simulation: {
+      player: simulationPlayer,
+      inbound: simulationInbound,
+      outbound: simulationOutbound,
+    },
+    evaluation: {
+      player: evaluationPlayer,
+      inbound: evaluationInbound,
+      outbound: evaluationOutbound,
+    },
+  });
+
+  const configuredPort = process.env.PORT;
+  const requestedPort = configuredPort ? Number.parseInt(configuredPort, 10) : 3000;
+
+  if (Number.isNaN(requestedPort)) {
+    throw new Error(`Invalid PORT value: ${configuredPort}`);
+  }
+
+  const port = await server.listen(requestedPort);
+
+  // eslint-disable-next-line no-console
+  console.log(`Simulation server listening on port ${port}`);
+
+  const shutdown = async () => {
+    await server.close();
+    process.exit(0);
+  };
+
+  process.on('SIGINT', () => {
+    void shutdown();
+  });
+
+  process.on('SIGTERM', () => {
+    void shutdown();
+  });
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    // eslint-disable-next-line no-console
+    console.error('Failed to start simulation server:', error);
+    process.exit(1);
+  });
+}

--- a/workspaces/Describing_Simulation_0/project/src/routes/evaluation.ts
+++ b/workspaces/Describing_Simulation_0/project/src/routes/evaluation.ts
@@ -1,0 +1,32 @@
+import type { Bus } from '../core/messaging/Bus';
+import { Router } from './router';
+
+export interface EvaluationRouteContext {
+  readonly outboundBus: Bus;
+}
+
+export function registerEvaluationRoutes(
+  router: Router,
+  context: EvaluationRouteContext,
+): void {
+  router.add('GET', '/evaluation/stream', (req, res) => {
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Connection', 'keep-alive');
+    res.write(': connected\n\n');
+
+    const unsubscribe = context.outboundBus.subscribe((frame) => {
+      res.write(`data: ${JSON.stringify(frame)}\n\n`);
+    });
+
+    const cleanup = () => {
+      unsubscribe();
+      if (!res.writableEnded) {
+        res.end();
+      }
+    };
+
+    req.on('close', cleanup);
+    req.on('error', cleanup);
+  });
+}

--- a/workspaces/Describing_Simulation_0/project/src/routes/router.ts
+++ b/workspaces/Describing_Simulation_0/project/src/routes/router.ts
@@ -1,0 +1,110 @@
+import type { IncomingMessage, ServerResponse } from 'http';
+
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'OPTIONS';
+
+export type RouteHandler = (
+  req: IncomingMessage,
+  res: ServerResponse,
+) => void | Promise<void>;
+
+interface RouteDefinition {
+  readonly method: HttpMethod;
+  readonly path: string;
+  readonly handler: RouteHandler;
+}
+
+function extractPath(request: IncomingMessage): string | null {
+  if (!request.url) {
+    return null;
+  }
+
+  try {
+    const url = new URL(request.url, 'http://localhost');
+    return url.pathname;
+  } catch (error) {
+    return null;
+  }
+}
+
+export class Router {
+  private readonly routes: RouteDefinition[] = [];
+
+  add(method: HttpMethod, path: string, handler: RouteHandler): void {
+    this.routes.push({ method, path, handler });
+  }
+
+  async handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const method = (req.method ?? 'GET').toUpperCase() as HttpMethod;
+    const path = extractPath(req);
+
+    if (!path) {
+      sendJson(res, 400, { error: 'Invalid request URL.' });
+      return;
+    }
+
+    const route = this.routes.find(
+      (definition) => definition.method === method && definition.path === path,
+    );
+
+    if (!route) {
+      sendJson(res, 404, { error: 'Not found.' });
+      return;
+    }
+
+    try {
+      await route.handler(req, res);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Unhandled route error:', error);
+      if (!res.headersSent) {
+        sendJson(res, 500, { error: 'Internal server error.' });
+      } else {
+        res.end();
+      }
+    }
+  }
+}
+
+export function sendJson(
+  res: ServerResponse,
+  statusCode: number,
+  payload: unknown,
+): void {
+  const body = JSON.stringify(payload);
+  res.statusCode = statusCode;
+  res.setHeader('Content-Type', 'application/json');
+  res.setHeader('Content-Length', Buffer.byteLength(body));
+  res.end(body);
+}
+
+export async function readRequestBody(req: IncomingMessage): Promise<Buffer> {
+  return await new Promise<Buffer>((resolve, reject) => {
+    const chunks: Buffer[] = [];
+
+    req.on('data', (chunk: Buffer) => {
+      chunks.push(chunk);
+    });
+
+    req.on('end', () => {
+      resolve(Buffer.concat(chunks));
+    });
+
+    req.on('error', (error) => {
+      reject(error);
+    });
+  });
+}
+
+export async function readJsonBody<T>(req: IncomingMessage): Promise<T> {
+  const body = await readRequestBody(req);
+
+  if (body.length === 0) {
+    return {} as T;
+  }
+
+  try {
+    return JSON.parse(body.toString('utf8')) as T;
+  } catch (error) {
+    throw new Error('Invalid JSON payload.');
+  }
+}

--- a/workspaces/Describing_Simulation_0/project/src/routes/simulation.ts
+++ b/workspaces/Describing_Simulation_0/project/src/routes/simulation.ts
@@ -1,0 +1,188 @@
+import type { IncomingHttpHeaders } from 'http';
+import type { Bus } from '../core/messaging/Bus';
+import type { Acknowledgement } from '../core/messaging/outbound/Acknowledgement';
+import type { SimulationPlayerCommandTypes } from '../core/simplayer/SimulationPlayer';
+import type { System } from '../core/systems/System';
+import { readJsonBody, readRequestBody, Router, sendJson } from './router';
+
+export type SimulationPlaybackState = 'idle' | 'running' | 'paused';
+
+export interface SimulationSystemUploadRequest {
+  readonly rawBody: Buffer;
+  readonly json?: unknown;
+  readonly headers: IncomingHttpHeaders;
+}
+
+export interface SimulationSystemUploadResult {
+  readonly system: System;
+  readonly priority?: number;
+}
+
+export type SimulationSystemUploadHandler = (
+  request: SimulationSystemUploadRequest,
+) => Promise<SimulationSystemUploadResult>;
+
+export interface SimulationRouteContext {
+  readonly commandBus: Bus;
+  readonly outboundBus: Bus;
+  readonly commands: SimulationPlayerCommandTypes;
+  readonly onStateChange?: (state: SimulationPlaybackState) => void;
+  readonly systemUpload?: SimulationSystemUploadHandler;
+}
+
+interface PlaybackPayload {
+  readonly command?: string;
+}
+
+function publishState(
+  acknowledgement: Acknowledgement,
+  nextState: SimulationPlaybackState,
+  onStateChange?: (state: SimulationPlaybackState) => void,
+): void {
+  if (acknowledgement.acknowledged && onStateChange) {
+    onStateChange(nextState);
+  }
+}
+
+function mapCommand(
+  command: string,
+  commands: SimulationPlayerCommandTypes,
+): { type: string; nextState: SimulationPlaybackState } | null {
+  switch (command) {
+    case 'start':
+    case 'resume':
+      return { type: commands.start, nextState: 'running' };
+    case 'pause':
+      return { type: commands.pause, nextState: 'paused' };
+    case 'stop':
+      return { type: commands.stop, nextState: 'idle' };
+    default:
+      return null;
+  }
+}
+
+function establishStream(router: Router, path: string, bus: Bus): void {
+  router.add('GET', path, (req, res) => {
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Connection', 'keep-alive');
+    res.write(': connected\n\n');
+
+    const unsubscribe = bus.subscribe((frame) => {
+      res.write(`data: ${JSON.stringify(frame)}\n\n`);
+    });
+
+    const cleanup = () => {
+      unsubscribe();
+      if (!res.writableEnded) {
+        res.end();
+      }
+    };
+
+    req.on('close', cleanup);
+    req.on('error', cleanup);
+  });
+}
+
+async function handlePlayback(
+  router: Router,
+  context: SimulationRouteContext,
+): Promise<void> {
+  router.add('POST', '/simulation/playback', async (req, res) => {
+    let payload: PlaybackPayload;
+
+    try {
+      payload = await readJsonBody<PlaybackPayload>(req);
+    } catch (error) {
+      sendJson(res, 400, { error: 'Invalid JSON payload.' });
+      return;
+    }
+
+    const command = payload.command;
+    if (!command) {
+      sendJson(res, 400, { error: 'Missing playback command.' });
+      return;
+    }
+
+    const mapped = mapCommand(command, context.commands);
+    if (!mapped) {
+      sendJson(res, 400, { error: `Unsupported playback command: ${command}` });
+      return;
+    }
+
+    const acknowledgement = context.commandBus.send(mapped.type, undefined);
+    publishState(acknowledgement, mapped.nextState, context.onStateChange);
+
+    sendJson(res, acknowledgement.acknowledged ? 200 : 202, {
+      acknowledged: acknowledgement.acknowledged,
+      deliveries: acknowledgement.deliveries,
+      state: acknowledgement.acknowledged ? mapped.nextState : undefined,
+    });
+  });
+}
+
+function handleSystemUpload(router: Router, context: SimulationRouteContext): void {
+  router.add('POST', '/simulation/systems', async (req, res) => {
+    if (!context.systemUpload) {
+      sendJson(res, 501, { error: 'System uploads are not supported.' });
+      return;
+    }
+
+    const rawBody = await readRequestBody(req);
+    let json: unknown;
+    const contentType = req.headers['content-type'];
+
+    if (contentType && contentType.includes('application/json') && rawBody.length) {
+      try {
+        json = JSON.parse(rawBody.toString('utf8')) as unknown;
+      } catch (error) {
+        sendJson(res, 400, { error: 'Invalid JSON payload.' });
+        return;
+      }
+    }
+
+    let result: SimulationSystemUploadResult;
+    try {
+      result = await context.systemUpload({
+        rawBody,
+        json,
+        headers: req.headers,
+      });
+    } catch (error) {
+      sendJson(res, 400, {
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Failed to process system upload.',
+      });
+      return;
+    }
+
+    if (!result?.system) {
+      sendJson(res, 400, { error: 'System upload handler did not return a system.' });
+      return;
+    }
+
+    const acknowledgement = context.commandBus.send(
+      context.commands.injectSystem,
+      {
+        system: result.system,
+        priority: result.priority,
+      },
+    );
+
+    sendJson(res, acknowledgement.acknowledged ? 201 : 202, {
+      acknowledged: acknowledgement.acknowledged,
+      deliveries: acknowledgement.deliveries,
+    });
+  });
+}
+
+export function registerSimulationRoutes(
+  router: Router,
+  context: SimulationRouteContext,
+): void {
+  establishStream(router, '/simulation/stream', context.outboundBus);
+  handleSystemUpload(router, context);
+  void handlePlayback(router, context);
+}

--- a/workspaces/Describing_Simulation_0/project/src/server.ts
+++ b/workspaces/Describing_Simulation_0/project/src/server.ts
@@ -1,0 +1,163 @@
+import http, { type Server } from 'http';
+import type { Bus } from './core/messaging/Bus';
+import type { SimulationPlayer } from './core/simplayer/SimulationPlayer';
+import type { EvaluationPlayer } from './core/evalplayer/EvaluationPlayer';
+import { Router, sendJson } from './routes/router';
+import {
+  registerSimulationRoutes,
+  type SimulationPlaybackState,
+  type SimulationRouteContext,
+  type SimulationSystemUploadHandler,
+  type SimulationSystemUploadRequest,
+  type SimulationSystemUploadResult,
+} from './routes/simulation';
+import { registerEvaluationRoutes } from './routes/evaluation';
+
+interface SimulationConfig {
+  readonly player: Pick<
+    SimulationPlayer,
+    'start' | 'resume' | 'pause' | 'stop' | 'commands'
+  >;
+  readonly inbound: Bus;
+  readonly outbound: Bus;
+}
+
+interface EvaluationConfig {
+  readonly player: Pick<EvaluationPlayer, 'start' | 'stop'>;
+  readonly inbound: Bus;
+  readonly outbound: Bus;
+}
+
+export interface ServerConfig {
+  readonly simulation: SimulationConfig;
+  readonly evaluation: EvaluationConfig;
+  readonly systemUpload?: SimulationSystemUploadHandler;
+}
+
+class PlaybackStateTracker {
+  private state: SimulationPlaybackState;
+
+  constructor(initial: SimulationPlaybackState = 'idle') {
+    this.state = initial;
+  }
+
+  set(state: SimulationPlaybackState): void {
+    this.state = state;
+  }
+
+  get(): SimulationPlaybackState {
+    return this.state;
+  }
+}
+
+export interface SimulationServer {
+  readonly node: Server;
+  listen(port?: number): Promise<number>;
+  close(): Promise<void>;
+  getStates(): { simulation: SimulationPlaybackState; evaluation: SimulationPlaybackState };
+}
+
+export function createServer(config: ServerConfig): SimulationServer {
+  const router = new Router();
+  const simulationState = new PlaybackStateTracker();
+  const evaluationState = new PlaybackStateTracker();
+
+  const simulationContext: SimulationRouteContext = {
+    commandBus: config.simulation.inbound,
+    outboundBus: config.simulation.outbound,
+    commands: config.simulation.player.commands,
+    onStateChange: (state) => simulationState.set(state),
+    systemUpload: config.systemUpload,
+  };
+
+  registerSimulationRoutes(router, simulationContext);
+  registerEvaluationRoutes(router, { outboundBus: config.evaluation.outbound });
+
+  router.add('GET', '/info', (req, res) => {
+    sendJson(res, 200, {
+      simulation: { state: simulationState.get() },
+      evaluation: { state: evaluationState.get() },
+    });
+  });
+
+  const server = http.createServer((req, res) => router.handle(req, res));
+  let started = false;
+  const forwardUnsubscribe = config.simulation.outbound.subscribe((frame) => {
+    config.evaluation.inbound.send(frame);
+  });
+
+  return {
+    node: server,
+    async listen(port = 0) {
+      if (started) {
+        throw new Error('Server already started.');
+      }
+
+      await new Promise<void>((resolve, reject) => {
+        const handleError = (error: Error) => {
+          server.off('listening', handleListening);
+          reject(error);
+        };
+
+        const handleListening = () => {
+          server.off('error', handleError);
+          resolve();
+        };
+
+        server.once('error', handleError);
+        server.once('listening', handleListening);
+        server.listen(port);
+      });
+
+      started = true;
+      config.simulation.player.start();
+      simulationState.set('running');
+      config.evaluation.player.start();
+      evaluationState.set('running');
+
+      const address = server.address();
+      if (address && typeof address === 'object') {
+        return address.port;
+      }
+
+      return port;
+    },
+    async close() {
+      if (!started) {
+        forwardUnsubscribe();
+        return;
+      }
+
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+
+          resolve();
+        });
+      });
+
+      config.simulation.player.stop();
+      simulationState.set('idle');
+      config.evaluation.player.stop();
+      evaluationState.set('idle');
+      forwardUnsubscribe();
+      started = false;
+    },
+    getStates() {
+      return {
+        simulation: simulationState.get(),
+        evaluation: evaluationState.get(),
+      };
+    },
+  };
+}
+
+export type {
+  SimulationPlaybackState,
+  SimulationSystemUploadHandler,
+  SimulationSystemUploadRequest,
+  SimulationSystemUploadResult,
+};

--- a/workspaces/Describing_Simulation_0/project/tests/server/server.spec.ts
+++ b/workspaces/Describing_Simulation_0/project/tests/server/server.spec.ts
@@ -1,0 +1,326 @@
+import http from 'http';
+import { Bus, acknowledge } from 'src/core/messaging';
+import type { SimulationPlayerCommandTypes } from 'src/core/simplayer/SimulationPlayer';
+import { System } from 'src/core/systems/System';
+import { createServer, type SimulationServer } from 'src/server';
+import type { SimulationSystemUploadHandler } from 'src/server';
+
+interface TestServerOptions {
+  readonly systemUpload?: SimulationSystemUploadHandler;
+}
+
+interface TestServerContext {
+  readonly server: SimulationServer;
+  readonly simulationInbound: Bus;
+  readonly simulationOutbound: Bus;
+  readonly evaluationInbound: Bus;
+  readonly evaluationOutbound: Bus;
+  readonly simulationCommands: SimulationPlayerCommandTypes;
+  readonly simulationPlayer: {
+    start: jest.Mock;
+    resume: jest.Mock;
+    pause: jest.Mock;
+    stop: jest.Mock;
+  };
+  readonly evaluationPlayer: {
+    start: jest.Mock;
+    stop: jest.Mock;
+  };
+}
+
+function createTestServer(options: TestServerOptions = {}): TestServerContext {
+  const simulationInbound = new Bus();
+  const simulationOutbound = new Bus();
+  const evaluationInbound = new Bus();
+  const evaluationOutbound = new Bus();
+
+  const simulationCommands: SimulationPlayerCommandTypes = {
+    start: 'simulation/start',
+    pause: 'simulation/pause',
+    stop: 'simulation/stop',
+    injectSystem: 'simulation/system.inject',
+    ejectSystem: 'simulation/system.eject',
+  };
+
+  const simulationPlayer = {
+    start: jest.fn(),
+    resume: jest.fn(),
+    pause: jest.fn(),
+    stop: jest.fn(),
+    commands: simulationCommands,
+  };
+
+  const evaluationPlayer = {
+    start: jest.fn(),
+    stop: jest.fn(),
+  };
+
+  simulationInbound.subscribe(simulationCommands.start, () => {
+    simulationPlayer.start();
+    simulationPlayer.resume();
+    return acknowledge();
+  });
+
+  simulationInbound.subscribe(simulationCommands.pause, () => {
+    simulationPlayer.pause();
+    return acknowledge();
+  });
+
+  simulationInbound.subscribe(simulationCommands.stop, () => {
+    simulationPlayer.stop();
+    return acknowledge();
+  });
+
+  simulationInbound.subscribe(simulationCommands.injectSystem, () => acknowledge());
+
+  const server = createServer({
+    simulation: {
+      player: simulationPlayer,
+      inbound: simulationInbound,
+      outbound: simulationOutbound,
+    },
+    evaluation: {
+      player: evaluationPlayer,
+      inbound: evaluationInbound,
+      outbound: evaluationOutbound,
+    },
+    systemUpload: options.systemUpload,
+  });
+
+  return {
+    server,
+    simulationInbound,
+    simulationOutbound,
+    evaluationInbound,
+    evaluationOutbound,
+    simulationCommands,
+    simulationPlayer,
+    evaluationPlayer,
+  };
+}
+
+async function requestJson(
+  port: number,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<{ status: number; payload: unknown }> {
+  const payload = body ? JSON.stringify(body) : undefined;
+
+  return await new Promise<{ status: number; payload: unknown }>((resolve, reject) => {
+    const request = http.request(
+      {
+        method,
+        port,
+        path,
+        headers: payload
+          ? {
+              'Content-Type': 'application/json',
+              'Content-Length': Buffer.byteLength(payload),
+            }
+          : undefined,
+      },
+      (response) => {
+        const chunks: Buffer[] = [];
+
+        response.on('data', (chunk: Buffer) => chunks.push(chunk));
+        response.on('end', () => {
+          const buffer = Buffer.concat(chunks);
+          const text = buffer.toString('utf8') || 'null';
+
+          try {
+            resolve({
+              status: response.statusCode ?? 0,
+              payload: JSON.parse(text),
+            });
+          } catch (error) {
+            reject(error);
+          }
+        });
+      },
+    );
+
+    request.on('error', reject);
+
+    if (payload) {
+      request.write(payload);
+    }
+
+    request.end();
+  });
+}
+
+function connectSse(port: number, path: string): Promise<{ close: () => void; next: () => Promise<string> }> {
+  return new Promise((resolve, reject) => {
+    const request = http.request({ method: 'GET', port, path });
+
+    request.on('response', (response) => {
+      response.setEncoding('utf8');
+
+      let resolver: ((value: string) => void) | null = null;
+      const buffer: string[] = [];
+
+      const flush = (chunk: string) => {
+        const lines = chunk.split('\n\n');
+        for (const line of lines) {
+          if (!line.includes('data:')) {
+            continue;
+          }
+
+          const data = line.slice(line.indexOf('data:') + 5).trim();
+          if (resolver) {
+            resolver(data);
+            resolver = null;
+          } else {
+            buffer.push(data);
+          }
+        }
+      };
+
+      response.on('data', (chunk: string) => {
+        flush(chunk);
+      });
+
+      resolve({
+        close: () => {
+          request.destroy();
+        },
+        next: () =>
+          new Promise<string>((nextResolve) => {
+            const existing = buffer.shift();
+            if (existing) {
+              nextResolve(existing);
+              return;
+            }
+
+            resolver = nextResolve;
+          }),
+      });
+    });
+
+    request.on('error', reject);
+    request.end();
+  });
+}
+
+describe('server', () => {
+  jest.setTimeout(15000);
+
+  it('starts players and exposes lifecycle info', async () => {
+    const context = createTestServer();
+    const port = await context.server.listen(0);
+
+    expect(context.simulationPlayer.start).toHaveBeenCalled();
+    expect(context.evaluationPlayer.start).toHaveBeenCalled();
+
+    const info = await requestJson(port, 'GET', '/info');
+
+    expect(info.status).toBe(200);
+    expect(info.payload).toEqual({
+      simulation: { state: 'running' },
+      evaluation: { state: 'running' },
+    });
+
+    await context.server.close();
+  });
+
+  it('handles playback commands via HTTP', async () => {
+    const context = createTestServer();
+    const port = await context.server.listen(0);
+
+    const pause = await requestJson(port, 'POST', '/simulation/playback', {
+      command: 'pause',
+    });
+
+    expect(pause.status).toBe(200);
+    expect(context.simulationPlayer.pause).toHaveBeenCalled();
+    expect(pause.payload).toEqual({
+      acknowledged: true,
+      deliveries: 1,
+      state: 'paused',
+    });
+
+    const info = await requestJson(port, 'GET', '/info');
+    expect(info.payload).toEqual({
+      simulation: { state: 'paused' },
+      evaluation: { state: 'running' },
+    });
+
+    const start = await requestJson(port, 'POST', '/simulation/playback', {
+      command: 'start',
+    });
+
+    expect(start.status).toBe(200);
+    expect(context.simulationPlayer.resume).toHaveBeenCalled();
+    expect(start.payload).toEqual({
+      acknowledged: true,
+      deliveries: 1,
+      state: 'running',
+    });
+
+    await context.server.close();
+  });
+
+  it('streams simulation frames via server-sent events', async () => {
+    const context = createTestServer();
+    const port = await context.server.listen(0);
+
+    const sse = await connectSse(port, '/simulation/stream');
+
+    context.simulationOutbound.send('simulation/frame', { foo: 'bar' });
+
+    const data = await sse.next();
+    expect(JSON.parse(data)).toEqual({
+      type: 'simulation/frame',
+      payload: { foo: 'bar' },
+      metadata: {},
+    });
+
+    sse.close();
+    await context.server.close();
+  });
+
+  it('forwards simulation frames to the evaluation inbound bus', async () => {
+    const context = createTestServer();
+    const port = await context.server.listen(0);
+
+    const received = new Promise((resolve) => {
+      context.evaluationInbound.subscribe((frame) => {
+        resolve(frame);
+      });
+    });
+
+    context.simulationOutbound.send('simulation/frame', { tick: 1 });
+
+    await expect(received).resolves.toMatchObject({
+      type: 'simulation/frame',
+      payload: { tick: 1 },
+    });
+
+    await context.server.close();
+  });
+
+  it('processes system uploads through the configured handler', async () => {
+    class UploadedSystem extends System {
+      // eslint-disable-next-line class-methods-use-this
+      protected update(): void {}
+    }
+    const uploadedSystem = new UploadedSystem();
+    const uploadHandler: SimulationSystemUploadHandler = jest
+      .fn()
+      .mockResolvedValue({ system: uploadedSystem, priority: 5 });
+    const context = createTestServer({ systemUpload: uploadHandler });
+
+    const port = await context.server.listen(0);
+
+    const response = await requestJson(port, 'POST', '/simulation/systems', {
+      module: 'test-module',
+    });
+
+    expect(response.status).toBe(201);
+    expect(response.payload).toEqual({ acknowledged: true, deliveries: 1 });
+    expect(uploadHandler).toHaveBeenCalled();
+
+    await context.server.close();
+  });
+});


### PR DESCRIPTION
## Summary
- add an HTTP server wrapper that boots the simulation and evaluation players, bridges their buses, and exposes an info endpoint
- implement simulation and evaluation routing helpers with playback, system upload, and SSE streaming support
- provide a main entry point and Jest coverage for lifecycle, routing behavior, bus forwarding, and SSE streaming

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d73c94ba04832a938bd13efe270fe4