### PR TITLE
Expand TypeScript root directory and install Node types

### DIFF
--- a/workspaces/Describing_Simulation_0/project/package-lock.json
+++ b/workspaces/Describing_Simulation_0/project/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "devDependencies": {
         "@types/jest": "^30.0.0",
+        "@types/node": "^24.5.2",
         "jest": "^30.1.3",
         "ts-jest": "^29.4.4",
         "typescript": "^5.9.2"

--- a/workspaces/Describing_Simulation_0/project/package.json
+++ b/workspaces/Describing_Simulation_0/project/package.json
@@ -10,6 +10,7 @@
   "type": "commonjs",
   "devDependencies": {
     "@types/jest": "^30.0.0",
+    "@types/node": "^24.5.2",
     "jest": "^30.1.3",
     "ts-jest": "^29.4.4",
     "typescript": "^5.9.2"

--- a/workspaces/Describing_Simulation_0/project/tsconfig.json
+++ b/workspaces/Describing_Simulation_0/project/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "src/*": ["src/*"]
     },
-    "rootDir": "src",
+    "rootDir": ".",
     "outDir": "dist",
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
- broaden the TypeScript rootDir so project sources and tests share a common root
- add the Node.js type definitions to satisfy the compiler configuration

## Testing
- npm run build --prefix workspaces/Describing_Simulation_0/project

------
https://chatgpt.com/codex/tasks/task_e_68d748985984832a96e47b6bae97fb99