### PR TITLE
Add terminal-style simulation integration run

### DIFF
--- a/workspaces/Describing_Simulation_0/project/package-lock.json
+++ b/workspaces/Describing_Simulation_0/project/package-lock.json
@@ -11,6 +11,7 @@
         "@types/jest": "^30.0.0",
         "jest": "^30.1.3",
         "ts-jest": "^29.4.4",
+        "ts-node": "^10.9.2",
         "typescript": "^5.9.2"
       }
     },
@@ -509,6 +510,30 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.5.0",
@@ -1045,6 +1070,34 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1449,6 +1502,32 @@
         "win32"
       ]
     },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -1507,6 +1586,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -1944,6 +2030,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2010,6 +2103,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/eastasianwidth": {
@@ -4201,6 +4304,50 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -4332,6 +4479,13 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -4586,6 +4740,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/workspaces/Describing_Simulation_0/project/package.json
+++ b/workspaces/Describing_Simulation_0/project/package.json
@@ -5,13 +5,15 @@
   "description": "Core ECS primitives for the Describing Simulation 0 workspace.",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "test": "jest --runInBand"
+    "test": "jest --runInBand",
+    "integration": "ts-node tests/integration/server.integration.ts"
   },
   "type": "commonjs",
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "jest": "^30.1.3",
     "ts-jest": "^29.4.4",
+    "ts-node": "^10.9.2",
     "typescript": "^5.9.2"
   }
 }

--- a/workspaces/Describing_Simulation_0/project/tests/integration/server.integration.ts
+++ b/workspaces/Describing_Simulation_0/project/tests/integration/server.integration.ts
@@ -1,0 +1,492 @@
+import http from 'http';
+import { ComponentManager } from '../../src/core/components/ComponentManager';
+import { ComponentType } from '../../src/core/components/ComponentType';
+import { EntityManager } from '../../src/core/entity/EntityManager';
+import { Bus } from '../../src/core/messaging/Bus';
+import type { Frame } from '../../src/core/messaging/outbound/Frame';
+import { System } from '../../src/core/systems/System';
+import { SystemManager } from '../../src/core/systems/SystemManager';
+import { EvaluationPlayer } from '../../src/core/evalplayer/EvaluationPlayer';
+import { SimulationPlayer } from '../../src/core/simplayer/SimulationPlayer';
+import {
+  createServer,
+  type SimulationServer,
+  type SimulationSystemUploadHandler,
+} from '../../src/server';
+
+type JsonRecord = Record<string, unknown>;
+
+interface HarnessEnvironment {
+  readonly simulation: {
+    readonly components: ComponentManager;
+    readonly entities: EntityManager;
+    readonly registry: Map<string, ComponentType<unknown>>;
+  };
+  readonly evaluation: {
+    readonly components: ComponentManager;
+    readonly entities: EntityManager;
+    readonly registry: Map<string, ComponentType<unknown>>;
+  };
+}
+
+interface Harness extends HarnessEnvironment {
+  readonly server: SimulationServer;
+}
+
+interface UploadPayload extends JsonRecord {
+  readonly entityId?: string;
+  readonly components?: JsonRecord;
+  readonly priority?: number;
+  readonly systemSource?: string;
+}
+
+interface SseConnection {
+  readonly close: () => void;
+  readonly next: () => Promise<string>;
+}
+
+interface CompiledSystemFactory {
+  (context: {
+    System: typeof System;
+    ComponentType: typeof ComponentType;
+    simulation: {
+      components: ComponentManager;
+      entities: EntityManager;
+      ensureEntity(id: string): void;
+      ensureComponentType(name: string): ComponentType<unknown>;
+    };
+  }): System;
+}
+
+function ensureEntity(entities: EntityManager, id: string): void {
+  if (!entities.has(id)) {
+    entities.create(id);
+  }
+}
+
+function ensureComponentType<TComponent>(
+  manager: ComponentManager,
+  registry: Map<string, ComponentType<unknown>>,
+  name: string,
+): ComponentType<TComponent> {
+  const existing = registry.get(name) as ComponentType<TComponent> | undefined;
+  if (existing) {
+    if (!manager.isRegistered(existing)) {
+      manager.register(existing);
+    }
+    return existing;
+  }
+
+  const type = new ComponentType<TComponent>(name);
+  manager.register(type);
+  registry.set(name, type as ComponentType<unknown>);
+  return type;
+}
+
+function compileSystemFactory(source: string): CompiledSystemFactory {
+  const trimmed = source.trim();
+  if (!trimmed) {
+    throw new Error('System source is empty.');
+  }
+
+  const module = { exports: {} as unknown };
+  const sandboxRequire = (specifier: string): unknown => {
+    if (specifier === 'src/core/systems/System' || specifier === './core/systems/System') {
+      return { System };
+    }
+
+    if (specifier === 'src/core/components/ComponentType' || specifier === './core/components/ComponentType') {
+      return { ComponentType };
+    }
+
+    throw new Error(`Unsupported import: ${specifier}`);
+  };
+
+  const evaluator = new Function('require', 'module', 'exports', trimmed);
+  evaluator(sandboxRequire, module, module.exports);
+
+  const exported = module.exports as unknown;
+
+  if (typeof exported === 'function') {
+    return exported as CompiledSystemFactory;
+  }
+
+  if (
+    exported &&
+    typeof exported === 'object' &&
+    typeof (exported as { default?: unknown }).default === 'function'
+  ) {
+    return (exported as { default: CompiledSystemFactory }).default;
+  }
+
+  if (
+    exported &&
+    typeof exported === 'object' &&
+    typeof (exported as { createSystem?: unknown }).createSystem === 'function'
+  ) {
+    return (exported as { createSystem: CompiledSystemFactory }).createSystem;
+  }
+
+  throw new Error('System source must export a factory function.');
+}
+
+function createUploadHandler(environment: HarnessEnvironment): SimulationSystemUploadHandler {
+  return async (request) => {
+    const payload = request.json as UploadPayload | undefined;
+
+    if (!payload || Array.isArray(payload)) {
+      throw new Error('System upload payload must be a JSON object.');
+    }
+
+    const entityId = typeof payload.entityId === 'string' && payload.entityId.trim()
+      ? payload.entityId.trim()
+      : 'integration-runner';
+
+    const components =
+      payload.components && typeof payload.components === 'object'
+        ? (payload.components as JsonRecord)
+        : {};
+
+    ensureEntity(environment.simulation.entities, entityId);
+    ensureEntity(environment.evaluation.entities, entityId);
+
+    for (const [name, value] of Object.entries(components)) {
+      const simulationType = ensureComponentType(
+        environment.simulation.components,
+        environment.simulation.registry,
+        name,
+      );
+      environment.simulation.components.setComponent(entityId, simulationType, value);
+
+      const evaluationType = ensureComponentType(
+        environment.evaluation.components,
+        environment.evaluation.registry,
+        name,
+      );
+      environment.evaluation.components.setComponent(entityId, evaluationType, value);
+    }
+
+    const source = typeof payload.systemSource === 'string' ? payload.systemSource : '';
+    const factory = compileSystemFactory(source);
+
+    const system = factory({
+      System,
+      ComponentType,
+      simulation: {
+        components: environment.simulation.components,
+        entities: environment.simulation.entities,
+        ensureEntity: (id: string) => ensureEntity(environment.simulation.entities, id),
+        ensureComponentType: (name: string) =>
+          ensureComponentType(environment.simulation.components, environment.simulation.registry, name),
+      },
+    });
+
+    if (!(system instanceof System)) {
+      throw new Error('Uploaded system did not produce a System instance.');
+    }
+
+    return {
+      system,
+      priority: typeof payload.priority === 'number' ? payload.priority : undefined,
+    };
+  };
+}
+
+function createHarness(): Harness {
+  const simulationComponents = new ComponentManager();
+  const simulationEntities = new EntityManager(simulationComponents);
+  const simulationSystems = new SystemManager();
+  const simulationInbound = new Bus();
+  const simulationOutbound = new Bus();
+
+  const evaluationComponents = new ComponentManager();
+  const evaluationEntities = new EntityManager(evaluationComponents);
+  const evaluationSystems = new SystemManager();
+  const evaluationInbound = new Bus();
+  const evaluationOutbound = new Bus();
+
+  const environment: HarnessEnvironment = {
+    simulation: {
+      components: simulationComponents,
+      entities: simulationEntities,
+      registry: new Map(),
+    },
+    evaluation: {
+      components: evaluationComponents,
+      entities: evaluationEntities,
+      registry: new Map(),
+    },
+  };
+
+  const uploadHandler = createUploadHandler(environment);
+
+  const server = createServer({
+    simulation: {
+      player: new SimulationPlayer(
+        simulationEntities,
+        simulationComponents,
+        simulationSystems,
+        simulationInbound,
+        simulationOutbound,
+        { tickIntervalMs: 5 },
+      ),
+      inbound: simulationInbound,
+      outbound: simulationOutbound,
+    },
+    evaluation: {
+      player: new EvaluationPlayer(
+        evaluationEntities,
+        evaluationComponents,
+        evaluationSystems,
+        evaluationInbound,
+        evaluationOutbound,
+        { tickIntervalMs: 5 },
+      ),
+      inbound: evaluationInbound,
+      outbound: evaluationOutbound,
+    },
+    systemUpload: uploadHandler,
+  });
+
+  return {
+    ...environment,
+    server,
+  };
+}
+
+function requestJson(
+  port: number,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<{ status: number; payload: unknown }> {
+  const payload = body ? JSON.stringify(body) : undefined;
+
+  return new Promise<{ status: number; payload: unknown }>((resolve, reject) => {
+    const request = http.request(
+      {
+        method,
+        port,
+        path,
+        headers: payload
+          ? {
+              'Content-Type': 'application/json',
+              'Content-Length': Buffer.byteLength(payload),
+            }
+          : undefined,
+      },
+      (response) => {
+        const chunks: Buffer[] = [];
+
+        response.on('data', (chunk: Buffer) => chunks.push(chunk));
+        response.on('end', () => {
+          const buffer = Buffer.concat(chunks);
+          const text = buffer.toString('utf8') || 'null';
+
+          try {
+            resolve({
+              status: response.statusCode ?? 0,
+              payload: JSON.parse(text),
+            });
+          } catch (error) {
+            reject(error);
+          }
+        });
+      },
+    );
+
+    request.on('error', reject);
+
+    if (payload) {
+      request.write(payload);
+    }
+
+    request.end();
+  });
+}
+
+function connectSse(port: number, path: string): Promise<SseConnection> {
+  return new Promise((resolve, reject) => {
+    const request = http.request({
+      method: 'GET',
+      port,
+      path,
+      headers: { Accept: 'text/event-stream' },
+    });
+
+    request.on('response', (response) => {
+      response.setEncoding('utf8');
+
+      let resolver: ((value: string) => void) | null = null;
+      const buffer: string[] = [];
+
+      const flush = (chunk: string) => {
+        const segments = chunk.split('\n\n');
+        for (const segment of segments) {
+          const trimmed = segment.trim();
+          if (!trimmed.startsWith('data:')) {
+            continue;
+          }
+
+          const data = trimmed.slice('data:'.length).trim();
+          if (resolver) {
+            resolver(data);
+            resolver = null;
+          } else {
+            buffer.push(data);
+          }
+        }
+      };
+
+      response.on('data', (chunk: string) => flush(chunk));
+
+      resolve({
+        close: () => {
+          request.destroy();
+        },
+        next: () =>
+          new Promise<string>((nextResolve) => {
+            const existing = buffer.shift();
+            if (existing) {
+              nextResolve(existing);
+              return;
+            }
+
+            resolver = nextResolve;
+          }),
+      });
+    });
+
+    request.on('error', reject);
+    request.end();
+  });
+}
+
+async function waitForFrame(
+  connection: SseConnection,
+  predicate: (frame: Frame) => boolean,
+  attempts = 20,
+): Promise<Frame> {
+  for (let i = 0; i < attempts; i += 1) {
+    const raw = await connection.next();
+    const frame = JSON.parse(raw) as Frame;
+    if (predicate(frame)) {
+      return frame;
+    }
+  }
+
+  throw new Error('Timed out waiting for a matching frame.');
+}
+
+function extractCounter(frame: Frame, entityId: string): number | null {
+  if (!frame || typeof frame !== 'object' || typeof frame.payload !== 'object') {
+    return null;
+  }
+
+  const payload = frame.payload as JsonRecord;
+  const entities = payload.entities;
+  if (!Array.isArray(entities)) {
+    return null;
+  }
+
+  for (const entity of entities) {
+    if (!entity || typeof entity !== 'object') {
+      continue;
+    }
+
+    if ((entity as JsonRecord).id !== entityId) {
+      continue;
+    }
+
+    const components = (entity as JsonRecord).components as JsonRecord | undefined;
+    const counter = components?.counter as JsonRecord | undefined;
+    const value = counter?.value;
+    if (typeof value === 'number') {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+async function run(): Promise<void> {
+  console.log('Creating simulation harness...');
+  const harness = createHarness();
+
+  const port = await harness.server.listen(0);
+  console.log(`Simulation server listening on port ${port}`);
+
+  const simulationStream = await connectSse(port, '/simulation/stream');
+  console.log('Connected to simulation event stream.');
+
+  const evaluationStream = await connectSse(port, '/evaluation/stream');
+  console.log('Connected to evaluation event stream.');
+
+  const systemSource = `
+module.exports = ({ System, simulation }) => {
+  const counterType = simulation.ensureComponentType('counter');
+  simulation.ensureEntity('runner-1');
+
+  return new (class IncrementCounterSystem extends System {
+    update() {
+      const current = simulation.components.getComponent('runner-1', counterType) || { value: 0 };
+      simulation.components.setComponent('runner-1', counterType, { value: current.value + 1 });
+    }
+  })();
+};
+`;
+
+  console.log('Uploading system source code...');
+  const upload = await requestJson(port, 'POST', '/simulation/systems', {
+    entityId: 'runner-1',
+    components: {
+      counter: { value: 0 },
+      label: { text: 'integration-script' },
+    },
+    systemSource,
+  });
+
+  console.log('Upload response:', upload);
+  if (upload.status !== 201) {
+    throw new Error(`Unexpected upload status: ${upload.status}`);
+  }
+
+  console.log('Starting simulation playback...');
+  const start = await requestJson(port, 'POST', '/simulation/playback', {
+    command: 'start',
+  });
+
+  console.log('Playback response:', start);
+  if (start.status !== 200) {
+    throw new Error(`Unexpected playback status: ${start.status}`);
+  }
+
+  console.log('Waiting for simulation frame...');
+  const simulationFrame = await waitForFrame(
+    simulationStream,
+    (frame) => frame.type === 'simulation/frame' && (extractCounter(frame, 'runner-1') ?? 0) >= 1,
+  );
+  console.log('Simulation frame received:', JSON.stringify(simulationFrame, null, 2));
+
+  console.log('Waiting for evaluation frame...');
+  const evaluationFrame = await waitForFrame(
+    evaluationStream,
+    (frame) => frame.type === 'evaluation/frame' && (extractCounter(frame, 'runner-1') ?? 0) >= 1,
+  );
+  console.log('Evaluation frame received:', JSON.stringify(evaluationFrame, null, 2));
+
+  simulationStream.close();
+  evaluationStream.close();
+  await harness.server.close();
+  console.log('Simulation harness shut down successfully.');
+}
+
+if (require.main === module) {
+  run().catch((error) => {
+    // eslint-disable-next-line no-console
+    console.error('Integration run failed:', error);
+    process.exitCode = 1;
+  });
+}
+
+export { run };


### PR DESCRIPTION
## Summary
- replace the previous Jest integration spec with a terminal-style runner that boots the server, uploads a JS system, and watches both SSE streams
- add an `npm run integration` script (via ts-node) for manually executing the flow end to end

## Testing
- npm test
- npm run integration

------
https://chatgpt.com/codex/tasks/task_e_68d741d5e428832abfa2b180c676950a